### PR TITLE
Last selected provider is not set

### DIFF
--- a/src/main/java/com/devoxx/genie/ui/settings/DevoxxGenieStateService.java
+++ b/src/main/java/com/devoxx/genie/ui/settings/DevoxxGenieStateService.java
@@ -9,6 +9,8 @@ import com.intellij.openapi.components.PersistentStateComponent;
 import com.intellij.openapi.components.State;
 import com.intellij.openapi.components.Storage;
 import com.intellij.util.xmlb.XmlSerializerUtil;
+
+import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.Setter;
 import org.jetbrains.annotations.Contract;
@@ -58,8 +60,6 @@ public final class DevoxxGenieStateService implements PersistentStateComponent<D
     private Integer maxSearchResults = MAX_SEARCH_RESULTS;
 
     // Last selected language model
-    @Getter
-    @Setter
     private String selectedProvider;
     private String selectedLanguageModel;
 
@@ -102,6 +102,10 @@ public final class DevoxxGenieStateService implements PersistentStateComponent<D
     private Map<String, Integer> modelWindowContexts = new HashMap<>();
     private Integer defaultWindowContext = 8000;
 
+    @Getter(AccessLevel.NONE)
+    @Setter(AccessLevel.NONE)
+    private List<Runnable> loadListeners = new ArrayList<>();
+
     public DevoxxGenieStateService() {
         initializeDefaultPrompts();
     }
@@ -124,6 +128,15 @@ public final class DevoxxGenieStateService implements PersistentStateComponent<D
         XmlSerializerUtil.copyBean(state, this);
         initializeDefaultCostsIfEmpty();
         initializeDefaultPrompts();
+
+        // Notify all listeners that the state has been loaded
+        for (Runnable listener : loadListeners) {
+            listener.run();
+        }
+    }
+
+    public void addLoadListener(Runnable listener) {
+        loadListeners.add(listener);
     }
 
     public void setModelCost(ModelProvider provider,


### PR DESCRIPTION
Fixes #181 
I had to explicitely load the state in the constructor of `DevoxxGenieToolWindowContent`, otherwise another race condition occurred: the `addLoadListener` method was called after `loadState` was invoked. So now I explicitely call `loadState`. The listener is still useful, because it should ensure that the state is loaded again if changed on disk.

The field `loadListeners` should have been annotated with `@Transient` in order to prevent storing it to disk. However, this seems not to work. I solved this by removing the getter and setter.

Tested it thoroughly, and it now works on my machine also :-)