### PR TITLE
Calculate token cost shows consistent results after switching projects

### DIFF
--- a/src/main/java/com/devoxx/genie/service/ProjectScannerService.java
+++ b/src/main/java/com/devoxx/genie/service/ProjectScannerService.java
@@ -28,7 +28,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 public class ProjectScannerService {
 
     private static final Encoding ENCODING = Encodings.newDefaultEncodingRegistry().getEncoding(EncodingType.CL100K_BASE);
-    private final UniqueDirectoryScannerService uniqueDirectoryScanner = new UniqueDirectoryScannerService();
 
     public static ProjectScannerService getInstance() {
         return ApplicationManager.getApplication().getService(ProjectScannerService.class);
@@ -86,6 +85,9 @@ public class ProjectScannerService {
                                                 int windowContextMaxTokens,
                                                 StringBuilder result,
                                                 ScanContentResult scanContentResult) {
+
+        UniqueDirectoryScannerService uniqueDirectoryScanner = new UniqueDirectoryScannerService();
+
         // Collect all content roots from modules
         VirtualFile[] contentRootsFromAllModules =
             ProjectRootManager.getInstance(project).getContentRootsFromAllModules();


### PR DESCRIPTION
It seemed that the uniqueDirectoryScanner continued to add directories but it got never reset. If project A was scanned, directories were added, if project B was scanned, the directories of project B were added, but the directories of project A were not removed.

Since the DirectoryScanner was only used in ProjectScannerService.getContentFromModules, I moved the initialisation to this method. There is no need for it to be a class level variable.

Tested it as follows:
* Open IntelliJ with DevoxxGenie repo: calculate token cost, it shows 105K tokens
* Switch to pet-clinic repo: calculate token cost, it shows 37K tokens
* Switch to DevoxxGenie repo: calculate token cost, it shows 105K tokens (before it showed 596 tokens)

