### PR TITLE
Add some common file extensions for frontend code

### DIFF
--- a/src/main/java/com/devoxx/genie/ui/settings/DevoxxGenieStateService.java
+++ b/src/main/java/com/devoxx/genie/ui/settings/DevoxxGenieStateService.java
@@ -117,7 +117,7 @@ public final class DevoxxGenieStateService implements PersistentStateComponent<D
     ));
 
     private List<String> includedFileExtensions = new ArrayList<>(Arrays.asList(
-            "java", "kt", "groovy", "scala", "xml", "json", "yaml", "yml", "properties", "txt", "md"
+            "java", "kt", "groovy", "scala", "xml", "json", "yaml", "yml", "properties", "txt", "md", "js", "ts", "css", "scss", "html"
     ));
 
     private Map<String, Double> modelInputCosts = new HashMap<>();


### PR DESCRIPTION
Fixes #308 
It makes sense to add frontend file extensions to the default. This might onboard new users more easily ('works out-of-the-box')