### PR TITLE
Feat/issue 196

### DIFF
--- a/src/main/java/com/devoxx/genie/model/Constant.java
+++ b/src/main/java/com/devoxx/genie/model/Constant.java
@@ -8,16 +8,6 @@ public class Constant {
     // The fixed command prompts
     public static final String SYSTEM_PROMPT = """
         You are a software developer IDEA plugin with expert knowledge in any programming language.
-
-        The Devoxx Genie plugin supports the following commands:
-        /test: write unit tests on selected code
-        /explain: explain the selected code
-        /review: review selected code
-        /help: show commands
-
-        The Devoxx Genie is open source and available at https://github.com/devoxx/DevoxxGenieIDEAPlugin.
-        You can follow us on Bluesky @ https://bsky.app/profile/devoxxgenie.bsky.social.
-        Do not include any more info which might be incorrect, like discord, documentation or other websites.
         Only provide info that is correct and relevant to the code or plugin.
         """;
 
@@ -34,6 +24,7 @@ public class Constant {
     public static final String REVIEW_COMMAND = "review";
     public static final String EXPLAIN_COMMAND = "explain";
     public static final String TDG_COMMAND = "tdg";
+    public static final String HELP_COMMAND = "help";
 
     // The Local LLM Model URLs, these can be overridden in the settings page
     public static final String OLLAMA_MODEL_URL = "http://localhost:11434/";

--- a/src/main/java/com/devoxx/genie/model/Constant.java
+++ b/src/main/java/com/devoxx/genie/model/Constant.java
@@ -8,6 +8,10 @@ public class Constant {
     // The fixed command prompts
     public static final String SYSTEM_PROMPT = """
         You are a software developer IDEA plugin with expert knowledge in any programming language.
+
+        The Devoxx Genie is open source and available at https://github.com/devoxx/DevoxxGenieIDEAPlugin.
+        You can follow us on Bluesky @ https://bsky.app/profile/devoxxgenie.bsky.social.
+        Do not include any more info which might be incorrect, like discord, documentation or other websites.
         Only provide info that is correct and relevant to the code or plugin.
         """;
 
@@ -17,7 +21,7 @@ public class Constant {
     public static final String REVIEW_PROMPT = "Review the selected code, can it be improved or are there any bugs?";
     public static final String EXPLAIN_PROMPT = "Break down the code in simple terms to help a junior developer grasp its functionality.";
     public static final String TDG_PROMPT = "You are a professional Java developer. Give me a SINGLE FILE COMPLETE java implementation that will pass this test. Do not respond with a test. Give me only complete code and no snippets. Include imports and use the right package.";
-    public static final String FIND_PROMPT = "Perform semantic search on the project files using RAG and show matching files. (NOTE: RAG feature should be enabled)";
+    public static final String FIND_PROMPT = "Perform semantic search on the project files using RAG and show matching files. (NOTE: The /find command requires RAG to be enabled in settings)";
     public static final String HELP_PROMPT = "Display help and available commands for the Genie Devoxx Plugin";
 
     public static final String TEST_COMMAND = "test";

--- a/src/main/java/com/devoxx/genie/model/Constant.java
+++ b/src/main/java/com/devoxx/genie/model/Constant.java
@@ -17,7 +17,8 @@ public class Constant {
     public static final String REVIEW_PROMPT = "Review the selected code, can it be improved or are there any bugs?";
     public static final String EXPLAIN_PROMPT = "Break down the code in simple terms to help a junior developer grasp its functionality.";
     public static final String TDG_PROMPT = "You are a professional Java developer. Give me a SINGLE FILE COMPLETE java implementation that will pass this test. Do not respond with a test. Give me only complete code and no snippets. Include imports and use the right package.";
-    public static final String FIND_PROMPT = "Perform semantic search on the project files using RAG and show matching files.";
+    public static final String FIND_PROMPT = "Perform semantic search on the project files using RAG and show matching files. (NOTE: RAG feature should be enabled)";
+    public static final String HELP_PROMPT = "Display help and available commands for the Genie Devoxx Plugin";
 
     public static final String TEST_COMMAND = "test";
     public static final String FIND_COMMAND = "find";

--- a/src/main/java/com/devoxx/genie/service/ChatPromptExecutor.java
+++ b/src/main/java/com/devoxx/genie/service/ChatPromptExecutor.java
@@ -197,13 +197,13 @@ public class ChatPromptExecutor {
         // if OK
         if (matchingPrompt.isPresent()) {
             // Check if the prompt is "/help" --> we display the help
-            if (matchingPrompt.get().getPrompt().equalsIgnoreCase(HELP_COMMAND)) {
+            if (matchingPrompt.get().getName().equalsIgnoreCase(HELP_COMMAND)) {
                 promptOutputPanel.showHelpText();
                 return Optional.empty(); // Return empty since we handled the help case
             }
 
             // Check for the /find command
-            if (matchingPrompt.get().getPrompt().equalsIgnoreCase(FIND_COMMAND)) {
+            if (matchingPrompt.get().getName().equalsIgnoreCase(FIND_COMMAND)) {
                 if (Boolean.FALSE.equals(DevoxxGenieStateService.getInstance().getRagEnabled())) {
                     NotificationUtil.sendNotification(chatMessageContext.getProject(),
                             "The /find command requires RAG to be enabled in settings");

--- a/src/main/java/com/devoxx/genie/service/ChatPromptExecutor.java
+++ b/src/main/java/com/devoxx/genie/service/ChatPromptExecutor.java
@@ -22,11 +22,13 @@ import com.intellij.openapi.vfs.VirtualFile;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Arrays;
+import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.ConcurrentHashMap;
 
 import static com.devoxx.genie.model.Constant.FIND_COMMAND;
+import static com.devoxx.genie.model.Constant.HELP_COMMAND;
 
 public class ChatPromptExecutor {
 
@@ -183,10 +185,25 @@ public class ChatPromptExecutor {
     private Optional<String> getCommandFromPrompt(@NotNull ChatMessageContext chatMessageContext,
                                                   PromptOutputPanel promptOutputPanel) {
         String prompt = chatMessageContext.getUserPrompt().trim();
-        if (prompt.startsWith("/")) {
-            DevoxxGenieSettingsService settings = DevoxxGenieStateService.getInstance();
+        DevoxxGenieSettingsService settings = DevoxxGenieStateService.getInstance();
+        List<CustomPrompt> customPrompts = settings.getCustomPrompts();
 
-            if (prompt.toLowerCase().startsWith("/" + FIND_COMMAND + " ")) {
+        Optional<CustomPrompt> matchingPrompt = customPrompts.stream()
+                .filter(customPrompt ->
+                        prompt.equalsIgnoreCase("/" + customPrompt.getName())
+                )
+                .findFirst();
+
+        // if OK
+        if (matchingPrompt.isPresent()) {
+            // Check if the prompt is "/help" --> we display the help
+            if (matchingPrompt.get().getPrompt().equalsIgnoreCase(HELP_COMMAND)) {
+                promptOutputPanel.showHelpText();
+                return Optional.empty(); // Return empty since we handled the help case
+            }
+
+            // Check for the /find command
+            if (matchingPrompt.get().getPrompt().equalsIgnoreCase(FIND_COMMAND)) {
                 if (Boolean.FALSE.equals(DevoxxGenieStateService.getInstance().getRagEnabled())) {
                     NotificationUtil.sendNotification(chatMessageContext.getProject(),
                             "The /find command requires RAG to be enabled in settings");
@@ -196,15 +213,9 @@ public class ChatPromptExecutor {
                 return Optional.of(prompt.substring(6).trim());
             }
 
-            // Check for custom prompts
-            for (CustomPrompt customPrompt : settings.getCustomPrompts()) {
-                if (prompt.equalsIgnoreCase("/" + customPrompt.getName())) {
-                    chatMessageContext.setCommandName(customPrompt.getName());
-                    return Optional.of(customPrompt.getPrompt());
-                }
-            }
-            promptOutputPanel.showHelpText();
-            return Optional.empty();
+            // Set the command name and return the prompt
+            chatMessageContext.setCommandName(matchingPrompt.get().getName());
+            return Optional.of(matchingPrompt.get().getPrompt());
         }
         return Optional.of(prompt);
     }

--- a/src/main/java/com/devoxx/genie/ui/component/input/CommandAutoCompleteTextField.java
+++ b/src/main/java/com/devoxx/genie/ui/component/input/CommandAutoCompleteTextField.java
@@ -20,6 +20,8 @@ import java.awt.event.KeyEvent;
 import java.util.ArrayList;
 import java.util.List;
 
+import static com.devoxx.genie.model.Constant.*;
+
 public class CommandAutoCompleteTextField extends JBTextArea implements CustomPromptChangeListener {
 
     private static final Logger LOG = Logger.getInstance(CommandAutoCompleteTextField.class);
@@ -46,11 +48,11 @@ public class CommandAutoCompleteTextField extends JBTextArea implements CustomPr
 
     private void initializeCommands() {
         commands.clear();
-        commands.add("/test");
-        commands.add("/explain");
-        commands.add("/review");
-        commands.add("/tdg");
-        commands.add("/help");
+        commands.add("/" + TEST_COMMAND);
+        commands.add("/" + EXPLAIN_COMMAND);
+        commands.add("/" + REVIEW_COMMAND);
+        commands.add("/" + TDG_COMMAND);
+        commands.add("/" + HELP_COMMAND);
 
         DevoxxGenieSettingsService stateService = DevoxxGenieStateService.getInstance();
         for (CustomPrompt customPrompt : stateService.getCustomPrompts()) {

--- a/src/main/java/com/devoxx/genie/ui/settings/DevoxxGenieStateService.java
+++ b/src/main/java/com/devoxx/genie/ui/settings/DevoxxGenieStateService.java
@@ -38,6 +38,15 @@ public final class DevoxxGenieStateService implements PersistentStateComponent<D
 
     private List<CustomPrompt> customPrompts = new ArrayList<>();
 
+    private final List<CustomPrompt> defaultPrompts = Arrays.asList(
+            new CustomPrompt(TEST_COMMAND, TEST_PROMPT),
+            new CustomPrompt(EXPLAIN_COMMAND, EXPLAIN_PROMPT),
+            new CustomPrompt(REVIEW_COMMAND, REVIEW_PROMPT),
+            new CustomPrompt(TDG_COMMAND, TDG_PROMPT),
+            new CustomPrompt(FIND_COMMAND, FIND_PROMPT),
+            new CustomPrompt(HELP_COMMAND, HELP_PROMPT)
+    );
+
     private List<LanguageModel> languageModels = new ArrayList<>();
 
     private Boolean showExecutionTime = true;
@@ -160,17 +169,13 @@ public final class DevoxxGenieStateService implements PersistentStateComponent<D
     private List<Runnable> loadListeners = new ArrayList<>();
 
     public DevoxxGenieStateService() {
-        initializeDefaultPrompts();
+        initializeUserPrompt();
     }
 
-    private void initializeDefaultPrompts() {
-        if (customPrompts.isEmpty()) {
-            customPrompts.add(new CustomPrompt(TEST_COMMAND, TEST_PROMPT));
-            customPrompts.add(new CustomPrompt(EXPLAIN_COMMAND, EXPLAIN_PROMPT));
-            customPrompts.add(new CustomPrompt(REVIEW_COMMAND, REVIEW_PROMPT));
-            customPrompts.add(new CustomPrompt(FIND_COMMAND, FIND_PROMPT));
-            customPrompts.add(new CustomPrompt(TDG_COMMAND, TDG_PROMPT));
-            customPrompts.add(new CustomPrompt(HELP_COMMAND, ""));
+    private void initializeUserPrompt() {
+        //If User prompt happens to be empty then we load the default list
+        if (customPrompts == null || customPrompts.isEmpty()) {
+            customPrompts = new ArrayList<>(defaultPrompts);
         }
     }
 
@@ -183,7 +188,7 @@ public final class DevoxxGenieStateService implements PersistentStateComponent<D
     public void loadState(@NotNull DevoxxGenieStateService state) {
         XmlSerializerUtil.copyBean(state, this);
         initializeDefaultCostsIfEmpty();
-        initializeDefaultPrompts();
+        initializeUserPrompt();
 
         // Notify all listeners that the state has been loaded
         for (Runnable listener : loadListeners) {

--- a/src/main/java/com/devoxx/genie/ui/settings/DevoxxGenieStateService.java
+++ b/src/main/java/com/devoxx/genie/ui/settings/DevoxxGenieStateService.java
@@ -170,6 +170,7 @@ public final class DevoxxGenieStateService implements PersistentStateComponent<D
             customPrompts.add(new CustomPrompt(REVIEW_COMMAND, REVIEW_PROMPT));
             customPrompts.add(new CustomPrompt(FIND_COMMAND, FIND_PROMPT));
             customPrompts.add(new CustomPrompt(TDG_COMMAND, TDG_PROMPT));
+            customPrompts.add(new CustomPrompt(HELP_COMMAND, ""));
         }
     }
 

--- a/src/main/java/com/devoxx/genie/ui/settings/prompt/PromptSettingsComponent.java
+++ b/src/main/java/com/devoxx/genie/ui/settings/prompt/PromptSettingsComponent.java
@@ -25,6 +25,8 @@ public class PromptSettingsComponent extends AbstractSettingsComponent {
     private static final int NAME_COLUMN = 0;
     private static final int PROMPT_COLUMN = 1;
 
+
+    private final DevoxxGenieStateService settings;
     @Getter
     private final JTextArea systemPromptField = new JTextArea(stateService.getSystemPrompt());
     @Getter
@@ -48,7 +50,7 @@ public class PromptSettingsComponent extends AbstractSettingsComponent {
     public PromptSettingsComponent(Project project) {
         this.project = project;
 
-        DevoxxGenieStateService settings = DevoxxGenieStateService.getInstance();
+        settings = DevoxxGenieStateService.getInstance();
 
         setupCustomPromptsTable();
         setCustomPrompts(settings.getCustomPrompts());
@@ -87,6 +89,10 @@ public class PromptSettingsComponent extends AbstractSettingsComponent {
         JButton removeCustomPromptBtn = new JButton("Remove Custom Prompt");
         removeCustomPromptBtn.addActionListener(e -> removeCustomPrompt());
         buttonPanel.add(removeCustomPromptBtn);
+
+        JButton restoreDefaultCustomPromptBtn = new JButton("Restore Default Prompt");
+        restoreDefaultCustomPromptBtn.addActionListener(e -> restoreDefaultPrompts());
+        buttonPanel.add(restoreDefaultCustomPromptBtn);
 
         gbc.gridy++;
         gbc.weighty = 0.0;
@@ -156,6 +162,10 @@ public class PromptSettingsComponent extends AbstractSettingsComponent {
                 .syncPublisher(AppTopics.CUSTOM_PROMPT_CHANGED_TOPIC)
                 .onCustomPromptsChanged();
         }
+    }
+
+    private void restoreDefaultPrompts() {
+        setCustomPrompts(settings.getDefaultPrompts());
     }
 
     public List<CustomPrompt> getCustomPrompts() {

--- a/src/main/java/com/devoxx/genie/ui/util/HelpUtil.java
+++ b/src/main/java/com/devoxx/genie/ui/util/HelpUtil.java
@@ -12,10 +12,14 @@ public class HelpUtil {
 
     public static @NotNull String getHelpMessage() {
         return "<html><body style='width: 300px; font-family: Arial, sans-serif; font-size: 12px;'>" +
-            "<h3>Available commands:</h3>" +
+            "<h3>The Devoxx Genie plugin supports the following commands:</h3>" +
             "<ul>" +
             getCustomPromptCommands() +
-            "</ul></body></html>";
+            "</ul>" +
+            "The Devoxx Genie is open source and available at https://github.com/devoxx/DevoxxGenieIDEAPlugin.<br>" +
+            "You can follow us on Bluesky @ https://bsky.app/profile/devoxxgenie.bsky.social.<br>" +
+            "Do not include any more info which might be incorrect, like discord, documentation or other websites.<br>" +
+            "</body></html>";
     }
 
     public static @NotNull String getCustomPromptCommands() {

--- a/src/main/java/com/devoxx/genie/ui/util/HelpUtil.java
+++ b/src/main/java/com/devoxx/genie/ui/util/HelpUtil.java
@@ -1,8 +1,8 @@
 package com.devoxx.genie.ui.util;
 
 import com.devoxx.genie.ui.settings.DevoxxGenieStateService;
+import com.intellij.ui.scale.JBUIScale;
 import org.jetbrains.annotations.NotNull;
-
 import java.util.stream.Collectors;
 
 public class HelpUtil {
@@ -11,15 +11,44 @@ public class HelpUtil {
     }
 
     public static @NotNull String getHelpMessage() {
-        return "<html><body style='width: 300px; font-family: Arial, sans-serif; font-size: 12px;'>" +
-            "<h3>The Devoxx Genie plugin supports the following commands:</h3>" +
-            "<ul>" +
-            getCustomPromptCommands() +
-            "</ul>" +
-            "The Devoxx Genie is open source and available at https://github.com/devoxx/DevoxxGenieIDEAPlugin.<br>" +
-            "You can follow us on Bluesky @ https://bsky.app/profile/devoxxgenie.bsky.social.<br>" +
-            "Do not include any more info which might be incorrect, like discord, documentation or other websites.<br>" +
-            "</body></html>";
+        float scaleFactor = JBUIScale.scale(1f);
+        return  """
+                <html>
+                    <head>
+                        <style type="text/css">
+                            body {
+                                font-family: 'Source Code Pro', monospace;
+                                zoom: %s;
+                            }
+                            h2 {
+                                margin-bottom: 5px;
+                            }
+                            p {
+                                margin: 0;
+                              }
+                            ul {
+                                margin-bottom: 5px;
+                            }
+                            li {
+                                margin-bottom: 5px;
+                            }
+                        </style>
+                    </head>
+                    <body>
+                        <h3>Available commands:</h3>
+                            <ul>
+                                %s
+                            </ul>
+                        <h3>
+                            The Devoxx Genie is open source and available at https://github.com/devoxx/DevoxxGenieIDEAPlugin.
+                            You can follow us on Bluesky @ https://bsky.app/profile/devoxxgenie.bsky.social.
+                            Do not include any more info which might be incorrect, like discord, documentation or other websites.
+                        </h3>
+                    </body>
+                </html>
+                """.formatted(scaleFactor == 1.0f ? "normal" : scaleFactor * 100 + "%",
+                getCustomPromptCommands()
+        );
     }
 
     public static @NotNull String getCustomPromptCommands() {


### PR DESCRIPTION
related to [Continue with prompt if / command is unknown Issue #196](https://github.com/devoxx/DevoxxGenieIDEAPlugin/issues/196)

Bringing some modifications requiring review from you @stephanj :

- cleaning in the SYSTEM_PROMPT that refers to the commands (the llm seems to feedback the commands by itself when a wrong "/" command is given)
- refactoring and optimizing getCommandFromPrompt in ChatPromptExecutor to match the exact available custom prompts list
- Creation of a default prompt list in DevoxxPersistentStateService
- Creation of a "Restore Default prompt button" in custom prompt settings UI
- Refactoring the Help Message HTML

Here are some results i had with some random docker and shell commands (starting with a /) given as test to Gemini 1206 and CodeGemma:2b (ollama)
![screenshot-genie-2](https://github.com/user-attachments/assets/9e3a892b-5b21-4d67-8a14-d67a69dcab7b)
![screenshot-genie](https://github.com/user-attachments/assets/fbe53dd0-4a00-44d5-b641-afdee7d09077)
![screenshot-genie-3](https://github.com/user-attachments/assets/58d1dab6-51e5-47ba-8467-b704c36ab0e3)

For some other cases (let's say i input a "/whatever" or "/tuttifrutti" word) it seems the llm is totally trying to interpret this and can bring to a wide range of answers (even sur interpretion if not hallucination)

Please let me know your feedback