### PR TITLE
[poc] add a way to specify custom model name

### DIFF
--- a/src/main/java/com/devoxx/genie/chatmodel/openai/OpenAIChatModelFactory.java
+++ b/src/main/java/com/devoxx/genie/chatmodel/openai/OpenAIChatModelFactory.java
@@ -35,6 +35,10 @@ public class OpenAIChatModelFactory implements ChatModelFactory {
             builder.baseUrl(DevoxxGenieStateService.getInstance().getCustomOpenAIUrl());
         }
 
+        if (Strings.isNotBlank(DevoxxGenieStateService.getInstance().getCustomOpenAIModel())) {
+            builder.modelName(DevoxxGenieStateService.getInstance().getCustomOpenAIModel());
+        }
+
         return builder.build();
     }
 
@@ -51,6 +55,11 @@ public class OpenAIChatModelFactory implements ChatModelFactory {
         if (Strings.isNotBlank(DevoxxGenieStateService.getInstance().getCustomOpenAIUrl())) {
             builder.baseUrl(DevoxxGenieStateService.getInstance().getCustomOpenAIUrl());
         }
+
+        if (Strings.isNotBlank(DevoxxGenieStateService.getInstance().getCustomOpenAIModel())) {
+            builder.modelName(DevoxxGenieStateService.getInstance().getCustomOpenAIModel());
+        }
+
         return builder.build();
     }
 

--- a/src/main/java/com/devoxx/genie/service/LLMModelRegistryService.java
+++ b/src/main/java/com/devoxx/genie/service/LLMModelRegistryService.java
@@ -208,6 +208,18 @@ public final class LLMModelRegistryService {
                         .contextWindow(128_000)
                         .apiKeyUsed(true)
                         .build());
+
+        String custom = "custom";
+        models.put(ModelProvider.OpenAI.getName() + ":" + gpt4oMini,
+              LanguageModel.builder()
+                    .provider(ModelProvider.OpenAI)
+                    .modelName(custom)
+                    .displayName("Custom Model")
+                    .inputCost(0.15)
+                    .outputCost(0.6)
+                    .contextWindow(128_000)
+                    .apiKeyUsed(true)
+                    .build());
     }
 
     private void addDeepInfraModels() {

--- a/src/main/java/com/devoxx/genie/ui/settings/DevoxxGenieStateService.java
+++ b/src/main/java/com/devoxx/genie/ui/settings/DevoxxGenieStateService.java
@@ -68,6 +68,7 @@ public final class DevoxxGenieStateService implements PersistentStateComponent<D
     private String llamaCPPUrl = LLAMA_CPP_MODEL_URL;
     private String jlamaUrl = JLAMA_MODEL_URL;
     private String customOpenAIUrl = "";
+    private String customOpenAIModel = "";
 
     // Local LLM Providers
     private boolean isOllamaEnabled = true;
@@ -78,6 +79,7 @@ public final class DevoxxGenieStateService implements PersistentStateComponent<D
     private boolean isLlamaCPPEnabled = true;
     private boolean isJlamaEnabled = true;
     private boolean isCustomOpenAIEnabled = false;
+    private boolean isCustomOpenAIModelEnabled = false;
 
     // Remote LLM Providers
     private boolean isOpenAIEnabled = false;

--- a/src/main/java/com/devoxx/genie/ui/settings/llm/LLMProvidersComponent.java
+++ b/src/main/java/com/devoxx/genie/ui/settings/llm/LLMProvidersComponent.java
@@ -32,6 +32,8 @@ public class LLMProvidersComponent extends AbstractSettingsComponent {
     @Getter
     private final JTextField customOpenAIUrlField = new JTextField(stateService.getCustomOpenAIUrl());
     @Getter
+    private final JTextField customOpenAIModelField = new JTextField(stateService.getCustomOpenAIModel());
+    @Getter
     private final JPasswordField openAIKeyField = new JPasswordField(stateService.getOpenAIKey());
     @Getter
     private final JTextField azureOpenAIEndpointField = new JTextField(stateService.getAzureOpenAIEndpoint());
@@ -72,6 +74,8 @@ public class LLMProvidersComponent extends AbstractSettingsComponent {
     private final JCheckBox jlamaEnabledCheckBox = new JCheckBox("", stateService.isJlamaEnabled());
     @Getter
     private final JCheckBox customOpenAIEnabledCheckBox = new JCheckBox("", stateService.isCustomOpenAIEnabled());
+    @Getter
+    private final JCheckBox customOpenAIModelEnabledCheckBox = new JCheckBox("", stateService.isCustomOpenAIModelEnabled());
 
     @Getter
     private final JCheckBox openAIEnabledCheckBox = new JCheckBox("", stateService.isOpenAIEnabled());
@@ -129,6 +133,7 @@ public class LLMProvidersComponent extends AbstractSettingsComponent {
         addProviderSettingRow(panel, gbc, "JLama URL", jlamaEnabledCheckBox,
                 createTextWithLinkButton(jlamaModelUrlField, "https://github.com/tjake/Jlama"));
         addProviderSettingRow(panel, gbc, "Custom OpenAI URL", customOpenAIEnabledCheckBox, customOpenAIUrlField);
+        addProviderSettingRow(panel, gbc, "Custom OpenAI Model", customOpenAIModelEnabledCheckBox, customOpenAIModelField);
 
         // Cloud LLM Providers section
         addSection(panel, gbc, "Cloud LLM Providers");

--- a/src/main/java/com/devoxx/genie/ui/settings/llm/LLMProvidersConfigurable.java
+++ b/src/main/java/com/devoxx/genie/ui/settings/llm/LLMProvidersConfigurable.java
@@ -71,6 +71,7 @@ public class LLMProvidersConfigurable implements Configurable {
         isModified |= isFieldModified(llmSettingsComponent.getJanModelUrlField(), stateService.getJanModelUrl());
         isModified |= isFieldModified(llmSettingsComponent.getExoModelUrlField(), stateService.getExoModelUrl());
         isModified |= isFieldModified(llmSettingsComponent.getCustomOpenAIUrlField(), stateService.getCustomOpenAIUrl());
+        isModified |= isFieldModified(llmSettingsComponent.getCustomOpenAIModelField(), stateService.getCustomOpenAIModel());
 
         isModified |= !stateService.getShowAzureOpenAIFields().equals(llmSettingsComponent.getEnableAzureOpenAICheckBox().isSelected());
         isModified |= isFieldModified(llmSettingsComponent.getAzureOpenAIEndpointField(), stateService.getAzureOpenAIEndpoint());
@@ -118,6 +119,7 @@ public class LLMProvidersConfigurable implements Configurable {
         settings.setLlamaCPPUrl(llmSettingsComponent.getLlamaCPPModelUrlField().getText());
         settings.setJlamaUrl(llmSettingsComponent.getJlamaModelUrlField().getText());
         settings.setCustomOpenAIUrl(llmSettingsComponent.getCustomOpenAIUrlField().getText());
+        settings.setCustomOpenAIModel(llmSettingsComponent.getCustomOpenAIModelField().getText());
 
         settings.setOpenAIKey(new String(llmSettingsComponent.getOpenAIKeyField().getPassword()));
         settings.setMistralKey(new String(llmSettingsComponent.getMistralApiKeyField().getPassword()));
@@ -187,6 +189,7 @@ public class LLMProvidersConfigurable implements Configurable {
         llmSettingsComponent.getLlamaCPPModelUrlField().setText(settings.getLlamaCPPUrl());
         llmSettingsComponent.getJlamaModelUrlField().setText(settings.getJlamaUrl());
         llmSettingsComponent.getCustomOpenAIUrlField().setText(settings.getCustomOpenAIUrl());
+        llmSettingsComponent.getCustomOpenAIModelField().setText(settings.getCustomOpenAIModel());
 
         llmSettingsComponent.getOpenAIKeyField().setText(settings.getOpenAIKey());
         llmSettingsComponent.getMistralApiKeyField().setText(settings.getMistralKey());


### PR DESCRIPTION
Many people run local instances of custom OpenAI-API compatible LLMs with non standard model names. Though, DevoxxGenie allows to specify custom endpoint, the model names are not configurable.

issue: #156