### PR TITLE
FIX: Chat memory is not cleared when opening new project #413

### DIFF
--- a/src/main/java/com/devoxx/genie/action/AddDirectoryAction.java
+++ b/src/main/java/com/devoxx/genie/action/AddDirectoryAction.java
@@ -56,10 +56,10 @@ public class AddDirectoryAction extends DumbAwareAction {
         List<VirtualFile> filesToAdd = new ArrayList<>();
         DevoxxGenieSettingsService settings = DevoxxGenieStateService.getInstance();
 
-        addFilesRecursively(directory, fileListManager, filesToAdd, settings);
+        addFilesRecursively(project, directory, fileListManager, filesToAdd, settings);
 
         if (!filesToAdd.isEmpty()) {
-            fileListManager.addFiles(filesToAdd);
+            fileListManager.addFiles(project, filesToAdd);
 
             ModelProvider selectedProvider = ModelProvider.fromString(settings.getSelectedProvider(project.getLocationHash()));
             String selectedModel = settings.getSelectedLanguageModel(project.getLocationHash());
@@ -86,15 +86,15 @@ public class AddDirectoryAction extends DumbAwareAction {
         }
     }
 
-    private void addFilesRecursively(@NotNull VirtualFile directory, FileListManager fileListManager,
+    private void addFilesRecursively(Project project, @NotNull VirtualFile directory, FileListManager fileListManager,
                                      List<VirtualFile> filesToAdd, DevoxxGenieSettingsService settings) {
         VirtualFile[] children = directory.getChildren();
         for (VirtualFile child : children) {
             if (child.isDirectory()) {
                 if (!settings.getExcludedDirectories().contains(child.getName())) {
-                    addFilesRecursively(child, fileListManager, filesToAdd, settings);
+                    addFilesRecursively(project, child, fileListManager, filesToAdd, settings);
                 }
-            } else if (shouldIncludeFile(child, settings) && !fileListManager.contains(child)) {
+            } else if (shouldIncludeFile(child, settings) && !fileListManager.contains(project, child)) {
                 filesToAdd.add(child);
             }
         }

--- a/src/main/java/com/devoxx/genie/action/AddFileAction.java
+++ b/src/main/java/com/devoxx/genie/action/AddFileAction.java
@@ -32,13 +32,13 @@ public class AddFileAction extends DumbAwareAction {
         if (selectedFiles != null && selectedFiles.length > 0) {
             List<VirtualFile> filesToAdd = new ArrayList<>();
             for (VirtualFile file : selectedFiles) {
-                if (!file.isDirectory() && !fileListManager.contains(file)) {
+                if (!file.isDirectory() && !fileListManager.contains(project, file)) {
                     filesToAdd.add(file);
                 }
             }
 
             if (!filesToAdd.isEmpty()) {
-                fileListManager.addFiles(filesToAdd);
+                fileListManager.addFiles(project, filesToAdd);
                 NotificationUtil.sendNotification(project, "Added " + filesToAdd.size() + " file(s) to prompt context");
             } else {
                 NotificationUtil.sendNotification(project, "No new files to add or only directories selected");

--- a/src/main/java/com/devoxx/genie/action/AddSnippetAction.java
+++ b/src/main/java/com/devoxx/genie/action/AddSnippetAction.java
@@ -9,10 +9,12 @@ import com.intellij.openapi.editor.SelectionModel;
 import com.intellij.openapi.fileTypes.FileType;
 import com.intellij.openapi.fileTypes.FileTypeManager;
 import com.intellij.openapi.project.DumbAwareAction;
+import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.Key;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.testFramework.LightVirtualFile;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import static com.devoxx.genie.ui.util.WindowPluginUtil.ensureToolWindowVisible;
 
@@ -45,10 +47,10 @@ public class AddSnippetAction extends DumbAwareAction {
             SelectionModel selectionModel = editor.getSelectionModel();
             String selectedText = selectionModel.getSelectedText();
             if (selectedText != null) {
-                createAndAddVirtualFile(selectedFile, selectionModel, selectedText);
+                createAndAddVirtualFile(e.getProject(), selectedFile, selectionModel, selectedText);
             } else {
                 // No text selected, add complete file
-                addSelectedFile(selectedFile);
+                addSelectedFile(e.getProject(), selectedFile);
             }
         }
     }
@@ -58,22 +60,23 @@ public class AddSnippetAction extends DumbAwareAction {
      *
      * @param selectedFile the selected file
      */
-    private static void addSelectedFile(VirtualFile selectedFile) {
+    private static void addSelectedFile(Project project, VirtualFile selectedFile) {
         FileListManager fileListManager = FileListManager.getInstance();
-        if (fileListManager.contains(selectedFile)) {
+        if (fileListManager.contains(project, selectedFile)) {
             return;
         }
-        fileListManager.addFile(selectedFile);
+        fileListManager.addFile(project, selectedFile);
     }
 
     /**
      * Create a virtual file and add it to the file list manager.
      *
+     * @param project
      * @param originalFile   the original file
      * @param selectionModel the selection model
      * @param selectedText   the selected text
      */
-    private void createAndAddVirtualFile(@NotNull VirtualFile originalFile,
+    private void createAndAddVirtualFile(@Nullable Project project, @NotNull VirtualFile originalFile,
                                          @NotNull SelectionModel selectionModel,
                                          String selectedText) {
         LightVirtualFile virtualFile = new LightVirtualFile(originalFile.getName(), selectedText);
@@ -82,7 +85,7 @@ public class AddSnippetAction extends DumbAwareAction {
         virtualFile.putUserData(SELECTED_TEXT_KEY, selectedText);
         virtualFile.putUserData(SELECTION_START_KEY, selectionModel.getSelectionStart());
         virtualFile.putUserData(SELECTION_END_KEY, selectionModel.getSelectionEnd());
-        FileListManager.getInstance().addFile(virtualFile);
+        FileListManager.getInstance().addFile(project, virtualFile);
     }
 
 

--- a/src/main/java/com/devoxx/genie/service/streaming/StreamingResponseHandler.java
+++ b/src/main/java/com/devoxx/genie/service/streaming/StreamingResponseHandler.java
@@ -67,7 +67,7 @@ public class StreamingResponseHandler implements dev.langchain4j.model.Streaming
         if (chatMessageContext.hasFiles()) {
             ApplicationManager.getApplication().invokeLater(() -> {
                 ExpandablePanel fileListPanel =
-                    new ExpandablePanel(chatMessageContext, FileListManager.getInstance().getFiles());
+                    new ExpandablePanel(chatMessageContext, FileListManager.getInstance().getFiles(chatMessageContext.getProject()));
                 fileListPanel.setName(chatMessageContext.getId());
                 promptOutputPanel.addStreamFileReferencesResponse(fileListPanel);
             });

--- a/src/main/java/com/devoxx/genie/ui/panel/ChatStreamingResponsePanel.java
+++ b/src/main/java/com/devoxx/genie/ui/panel/ChatStreamingResponsePanel.java
@@ -40,7 +40,7 @@ public class ChatStreamingResponsePanel extends BackgroundPanel {
         setMaxWidth();
 
         if (chatMessageContext.hasFiles()) {
-            java.util.List<VirtualFile> files = FileListManager.getInstance().getFiles();
+            java.util.List<VirtualFile> files = FileListManager.getInstance().getFiles(chatMessageContext.getProject());
             ExpandablePanel fileListPanel = new ExpandablePanel(chatMessageContext, files);
             add(fileListPanel);
         }

--- a/src/main/java/com/devoxx/genie/ui/panel/ConversationPanel.java
+++ b/src/main/java/com/devoxx/genie/ui/panel/ConversationPanel.java
@@ -174,7 +174,7 @@ public class ConversationPanel extends JPanel implements ConversationSelectionLi
      */
     @Override
     public void startNewConversation() {
-        FileListManager.getInstance().clear();
+        FileListManager.getInstance().clear(project);
         ChatMemoryService.getInstance().clear(project);
 
         chatService.startNewConversation("");

--- a/src/main/java/com/devoxx/genie/ui/panel/FileSelectionPanelFactory.java
+++ b/src/main/java/com/devoxx/genie/ui/panel/FileSelectionPanelFactory.java
@@ -37,7 +37,7 @@ public class FileSelectionPanelFactory implements DumbAware {
 
     public static @NotNull JPanel createPanel(Project project, List<VirtualFile> openFiles) {
         DefaultListModel<VirtualFile> listModel = new DefaultListModel<>();
-        JBList<VirtualFile> resultList = createResultList(listModel);
+        JBList<VirtualFile> resultList = createResultList(project, listModel);
         JBTextField filterField = createFilterField(project, listModel, resultList, openFiles);
 
         JPanel mainPanel = new JPanel(new BorderLayout());
@@ -64,15 +64,16 @@ public class FileSelectionPanelFactory implements DumbAware {
     /**
      * Create the result list
      *
+     * @param project
      * @param listModel the list model
      * @return the list
      */
-    private static @NotNull JBList<VirtualFile> createResultList(DefaultListModel<VirtualFile> listModel) {
+    private static @NotNull JBList<VirtualFile> createResultList(Project project, DefaultListModel<VirtualFile> listModel) {
         JBList<VirtualFile> resultList = new JBList<>(listModel);
         resultList.setCellRenderer(new FileListCellRenderer());
         resultList.setVisibleRowCount(10); // Show 10 rows by default
 
-        addMouseListenerToResultList(resultList);
+        addMouseListenerToResultList(project, resultList);
         return resultList;
     }
 
@@ -201,14 +202,15 @@ public class FileSelectionPanelFactory implements DumbAware {
     /**
      * Add a mouse listener to the result list
      *
+     * @param project
      * @param resultList the result list
      */
-    private static void addMouseListenerToResultList(@NotNull JBList<VirtualFile> resultList) {
+    private static void addMouseListenerToResultList(Project project, @NotNull JBList<VirtualFile> resultList) {
         resultList.addMouseListener(new MouseInputAdapter() {
             @Override
             public void mouseClicked(MouseEvent e) {
                 if (e.getClickCount() == DOUBLE_CLICK) {
-                    addSelectedFile(resultList);
+                    addSelectedFile(project, resultList);
                 }
             }
         });
@@ -217,12 +219,13 @@ public class FileSelectionPanelFactory implements DumbAware {
     /**
      * Add the selected file to the file list
      *
+     * @param project
      * @param resultList the result list
      */
-    private static void addSelectedFile(@NotNull JBList<VirtualFile> resultList) {
+    private static void addSelectedFile(Project project, @NotNull JBList<VirtualFile> resultList) {
         VirtualFile selectedFile = resultList.getSelectedValue();
         if (selectedFile != null) {
-            FileListManager.getInstance().addFile(selectedFile);
+            FileListManager.getInstance().addFile(project, selectedFile);
         }
     }
 

--- a/src/main/java/com/devoxx/genie/ui/panel/PromptContextFileListPanel.java
+++ b/src/main/java/com/devoxx/genie/ui/panel/PromptContextFileListPanel.java
@@ -30,7 +30,7 @@ public class PromptContextFileListPanel extends JPanel
     public PromptContextFileListPanel(Project project) {
         this.project = project;
         fileListManager = FileListManager.getInstance();
-        fileListManager.addObserver(this);
+        fileListManager.addObserver(project,this);
 
         setLayout(new BoxLayout(this, BoxLayout.Y_AXIS));
 
@@ -75,13 +75,13 @@ public class PromptContextFileListPanel extends JPanel
     }
 
     private void updateFilesPanelVisibility() {
-        if (fileListManager.isEmpty()) {
+        if (fileListManager.isEmpty(project)) {
             filesScrollPane.setVisible(false);
             filesScrollPane.setPreferredSize(new Dimension(0, 0));
         } else {
             filesScrollPane.setVisible(true);
             int MAX_VISIBLE_FILES = 3;
-            int fileCount = Math.min(fileListManager.size(), MAX_VISIBLE_FILES);
+            int fileCount = Math.min(fileListManager.size(project), MAX_VISIBLE_FILES);
             int heightPerFile = 30;
             int prefHeight = fileCount * heightPerFile;
             filesScrollPane.setPreferredSize(new Dimension(getPreferredSize().width, prefHeight));
@@ -92,7 +92,7 @@ public class PromptContextFileListPanel extends JPanel
 
     @Override
     public void onFileRemoved(VirtualFile file) {
-        fileListManager.removeFile(file);
+        fileListManager.removeFile(project, file);
         removeFromFilesPanel(file);
         updateFilesPanelVisibility();
         updateUIState();

--- a/src/main/java/com/devoxx/genie/ui/panel/chatresponse/FileListPanel.java
+++ b/src/main/java/com/devoxx/genie/ui/panel/chatresponse/FileListPanel.java
@@ -7,6 +7,6 @@ import com.devoxx.genie.ui.component.ExpandablePanel;
 public class FileListPanel extends ExpandablePanel {
 
     public FileListPanel(ChatMessageContext chatMessageContext) {
-        super(chatMessageContext, FileListManager.getInstance().getFiles());
+        super(chatMessageContext, FileListManager.getInstance().getFiles(chatMessageContext.getProject()));
     }
 }

--- a/src/main/java/com/devoxx/genie/util/ChatMessageContextUtil.java
+++ b/src/main/java/com/devoxx/genie/util/ChatMessageContextUtil.java
@@ -44,7 +44,7 @@ public class ChatMessageContextUtil {
             .userPrompt(userPromptText)
             .languageModel(languageModel)
             .webSearchRequested(stateService.getWebSearchActivated() && (stateService.isGoogleSearchEnabled() || stateService.isTavilySearchEnabled()))
-            .totalFileCount(FileListManager.getInstance().size())
+            .totalFileCount(FileListManager.getInstance().size(project))
             .executionTimeMs(0)
             .cost(0)
             .build();
@@ -84,7 +84,7 @@ public class ChatMessageContextUtil {
             Editor selectedTextEditor = editorFileButtonManager.getSelectedTextEditor();
 
             // Add files to the context
-            List<VirtualFile> files = FileListManager.getInstance().getFiles();
+            List<VirtualFile> files = FileListManager.getInstance().getFiles(chatMessageContext.getProject());
             if (!files.isEmpty()) {
                 addSelectedFiles(chatMessageContext, userPrompt, files);
             }


### PR DESCRIPTION
related to : [Chat memory is not cleared when opening new project #413](https://github.com/devoxx/DevoxxGenieIDEAPlugin/issues/413)

Modification of FileListManager so each VirtualFiles and File observers are segregated by project in a Hashmap data structure with project.getLocationHash() as Map, consequently "project" become a argument for each calls

Previously ChatMessageContextUtil was calling a getFiles method on FileLIstManager at:

**`List<VirtualFile> files = FileListManager.getInstance().getFiles();`** grabbing indistinctively files belonging to the collection of files in FileListManager (Lists)

Now FileListManager is handling files and observers to these files in a hashmap.

In term of test (reproducing @mydeveloperplanet use case):

-  Add a file to the prompt context (errorHandler.java)
-  ask a question 'tell me something about this file' (running /explain)
- The response explains the file
 
![image](https://github.com/user-attachments/assets/9afb2f7f-c15a-462f-9727-2ae0d6752d3e)
 
Then 

- open a new project (in a new IntelliJ window)
- ask a question 'tell me something about this file' (give me opitmizations on ErrorHandler class)
- The response is about the file added in step 1 (from another project) --> **the response in the screenshot show the LLM has not be informed of any file named ErrorHandler in the chat context**

![image](https://github.com/user-attachments/assets/52c0d8cb-78dd-4994-b850-a2ea1c807c63)
