### PR TITLE
Fix connection to docker daemon on Windows

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -55,6 +55,7 @@ dependencies {
     implementation("dev.langchain4j:langchain4j-chroma:$lg4j_version")
 
     implementation("com.github.docker-java:docker-java:3.4.0")
+    implementation("com.github.docker-java:docker-java-transport-httpclient5:3.4.0")
 
     implementation("com.knuddels:jtokkit:1.0.0")
     implementation("org.commonmark:commonmark:0.22.0")

--- a/src/main/java/com/devoxx/genie/service/chromadb/ChromaDockerService.java
+++ b/src/main/java/com/devoxx/genie/service/chromadb/ChromaDockerService.java
@@ -3,11 +3,11 @@ package com.devoxx.genie.service.chromadb;
 import com.devoxx.genie.service.chromadb.exception.ChromaDBException;
 import com.devoxx.genie.service.chromadb.exception.DockerException;
 import com.devoxx.genie.ui.settings.DevoxxGenieStateService;
+import com.devoxx.genie.util.DockerUtil;
 import com.github.dockerjava.api.DockerClient;
 import com.github.dockerjava.api.command.CreateContainerResponse;
 import com.github.dockerjava.api.exception.NotModifiedException;
 import com.github.dockerjava.api.model.*;
-import com.github.dockerjava.core.DockerClientBuilder;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.application.PathManager;
 import com.intellij.openapi.components.Service;
@@ -94,7 +94,7 @@ public final class ChromaDockerService {
      * @throws DockerException if an error occurs while pulling the image
      */
     public void pullChromaDockerImage(ChromaDBStatusCallback callback) throws DockerException {
-        try (DockerClient dockerClient = DockerClientBuilder.getInstance().build()) {
+        try (DockerClient dockerClient = DockerUtil.getDockerClient()) {
             dockerClient.pullImageCmd(CHROMA_IMAGE).start().awaitCompletion();
         } catch (IOException e) {
             callback.onError(FAILED_TO_PULL_CHROMA_DB_IMAGE + e.getMessage());
@@ -112,7 +112,7 @@ public final class ChromaDockerService {
      * @throws IOException if an I/O error occurs
      */
     private boolean isChromaDBRunning() throws IOException {
-        try (DockerClient dockerClient = DockerClientBuilder.getInstance().build()) {
+        try (DockerClient dockerClient = DockerUtil.getDockerClient()) {
 
             return dockerClient.listContainersCmd()
                     .withShowAll(true)
@@ -131,7 +131,7 @@ public final class ChromaDockerService {
      * @throws ChromaDBException if an error occurs while starting the container
      */
     private void startChromaContainer(String volumePath, ChromaDBStatusCallback callback) throws ChromaDBException {
-        try (DockerClient dockerClient = DockerClientBuilder.getInstance().build()) {
+        try (DockerClient dockerClient = DockerUtil.getDockerClient()) {
 
             // First, check if container exists
             List<Container> existingContainers = dockerClient.listContainersCmd()

--- a/src/main/java/com/devoxx/genie/service/rag/validator/ChromeDBValidator.java
+++ b/src/main/java/com/devoxx/genie/service/rag/validator/ChromeDBValidator.java
@@ -1,10 +1,10 @@
 package com.devoxx.genie.service.rag.validator;
 
 import com.devoxx.genie.ui.settings.DevoxxGenieStateService;
+import com.devoxx.genie.util.DockerUtil;
 import com.github.dockerjava.api.DockerClient;
 import com.github.dockerjava.api.model.Container;
 import com.github.dockerjava.api.model.Image;
-import com.github.dockerjava.core.DockerClientBuilder;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Arrays;
@@ -21,7 +21,7 @@ public class ChromeDBValidator implements Validator {
 
     @Override
     public boolean isValid() {
-        try (DockerClient dockerClient = DockerClientBuilder.getInstance().build()) {
+        try (DockerClient dockerClient = DockerUtil.getDockerClient()) {
             // First check if Docker is running and we can connect
             if (!isDockerRunning(dockerClient)) {
                 this.message = "Docker is not running. Please start Docker first.";

--- a/src/main/java/com/devoxx/genie/service/rag/validator/DockerValidator.java
+++ b/src/main/java/com/devoxx/genie/service/rag/validator/DockerValidator.java
@@ -1,7 +1,7 @@
 package com.devoxx.genie.service.rag.validator;
 
+import com.devoxx.genie.util.DockerUtil;
 import com.github.dockerjava.api.DockerClient;
-import com.github.dockerjava.core.DockerClientBuilder;
 
 public class DockerValidator implements Validator {
 
@@ -9,7 +9,7 @@ public class DockerValidator implements Validator {
 
     @Override
     public boolean isValid() {
-        try (DockerClient dockerClient = DockerClientBuilder.getInstance().build()) {
+        try (DockerClient dockerClient = DockerUtil.getDockerClient()) {
            return true;
         } catch (Exception e) {
             this.message = "Docker is not installed";

--- a/src/main/java/com/devoxx/genie/util/DockerUtil.java
+++ b/src/main/java/com/devoxx/genie/util/DockerUtil.java
@@ -1,0 +1,34 @@
+package com.devoxx.genie.util;
+
+import java.time.Duration;
+
+import com.github.dockerjava.api.DockerClient;
+import com.github.dockerjava.core.DefaultDockerClientConfig;
+import com.github.dockerjava.core.DockerClientBuilder;
+import com.github.dockerjava.core.DockerClientConfig;
+import com.github.dockerjava.httpclient5.ApacheDockerHttpClient;
+import com.github.dockerjava.transport.DockerHttpClient;
+
+public final class DockerUtil {
+
+	private DockerUtil() {}
+
+	/**
+	 * Instantiate a docker client with dockerjava
+	 *
+	 * @return a docker client
+	 */
+	public static DockerClient getDockerClient() {
+		DockerClientConfig config = DefaultDockerClientConfig.createDefaultConfigBuilder().build();
+		DockerHttpClient httpClient = new ApacheDockerHttpClient.Builder()
+				.dockerHost(config.getDockerHost())
+				.sslConfig(config.getSSLConfig())
+				.maxConnections(100)
+				.connectionTimeout(Duration.ofSeconds(30))
+				.responseTimeout(Duration.ofSeconds(45))
+				.build();
+		return DockerClientBuilder.getInstance(config)
+				.withDockerHttpClient(httpClient)
+				.build();
+	}
+}


### PR DESCRIPTION
## Context

I tried to use the **RAG** feature of DevoxxGenie on a Windows computer and even if docker was running, the plugin failed to detect it.
I don't have a custom setup of Docker. I use the defaults of Docker Desktop.

## Solution found

I followed the steps described in the [getting started of dockerjava](https://github.com/docker-java/docker-java/blob/main/docs/getting_started.md) and it led me to this solution.
At step 2, I chose Apache HttpClient 5 because "it has everything to become the default transport of docker-java in future releases" according to [this other file](https://github.com/docker-java/docker-java/blob/main/docs/transports.md).

## Safety measure

Could you tell me whether it still works on Mac as before?