### PR TITLE
Update until build to 251

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -96,7 +96,7 @@ tasks {
 
     patchPluginXml {
         sinceBuild.set("233")
-        untilBuild.set("243.*")
+        untilBuild.set("251.*")
     }
 
     shadowJar {


### PR DESCRIPTION
Executed the pluginVerifier task and it should still work ;-)

```
Plugin com.devoxx.genie:0.4.7 against IC-251.14649.49: Compatible. 4 usages of experimental API
Experimental API usages (4): 
    #Experimental API class com.intellij.lang.documentation.DocumentationSettings reference
        Experimental API class com.intellij.lang.documentation.DocumentationSettings is referenced in com.devoxx.genie.ui.renderer.CodeBlockNodeRenderer.determineHighlightingMode(boolean) : CodeBlockNodeRenderer.HighlightingMode. This class can be changed in a future release leading to incompatibilities
        Experimental API class com.intellij.lang.documentation.DocumentationSettings is referenced in com.devoxx.genie.ui.renderer.CodeBlockNodeRenderer.lambda$appendHighlightedByLexerAndEncodedAsHtmlCodeSnippet$0(CodeBlockNodeRenderer.HighlightingMode, StringBuilder, Project, Language, String) : void. This class can be changed in a future release leading to incompatibilities
    #Experimental API method com.intellij.lang.documentation.DocumentationSettings.getHighlightingSaturation(boolean) invocation
        Experimental API method com.intellij.lang.documentation.DocumentationSettings.getHighlightingSaturation(boolean isForRenderedDoc) : float is invoked in com.devoxx.genie.ui.renderer.CodeBlockNodeRenderer.lambda$appendHighlightedByLexerAndEncodedAsHtmlCodeSnippet$0(CodeBlockNodeRenderer.HighlightingMode, StringBuilder, Project, Language, String) : void. This method can be changed in a future release leading to incompatibilities
    #Experimental API method com.intellij.lang.documentation.DocumentationSettings.isHighlightingOfCodeBlocksEnabled() invocation
        Experimental API method com.intellij.lang.documentation.DocumentationSettings.isHighlightingOfCodeBlocksEnabled() : boolean is invoked in com.devoxx.genie.ui.renderer.CodeBlockNodeRenderer.determineHighlightingMode(boolean) : CodeBlockNodeRenderer.HighlightingMode. This method can be changed in a future release leading to incompatibilities
Dynamic Plugin Eligibility:
    Plugin can probably be enabled or disabled without IDE restart
```