### PR TITLE
Add initial support for AWS Bedrock

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -47,6 +47,7 @@ dependencies {
     implementation("dev.langchain4j:langchain4j-local-ai:$lg4j_version")
     implementation("dev.langchain4j:langchain4j-open-ai:$lg4j_version")
     implementation("dev.langchain4j:langchain4j-anthropic:$lg4j_version")
+    implementation("dev.langchain4j:langchain4j-bedrock:$lg4j_version")
     implementation("dev.langchain4j:langchain4j-mistral-ai:$lg4j_version")
     implementation("dev.langchain4j:langchain4j-google-ai-gemini:$lg4j_version")
     implementation("dev.langchain4j:langchain4j-web-search-engine-google-custom:$lg4j_version")

--- a/core/src/main/java/com/devoxx/genie/model/enumarations/ModelProvider.java
+++ b/core/src/main/java/com/devoxx/genie/model/enumarations/ModelProvider.java
@@ -24,7 +24,8 @@ public enum ModelProvider {
     OpenRouter("OpenRouter", Type.CLOUD),
     DeepSeek("DeepSeek", Type.CLOUD),
 
-    AzureOpenAI("AzureOpenAI", Type.OPTIONAL);
+    AzureOpenAI("AzureOpenAI", Type.OPTIONAL),
+    Bedrock("Bedrock", Type.OPTIONAL);
 
     public enum Type {
         LOCAL, // Local Providers

--- a/core/src/main/java/com/devoxx/genie/service/DevoxxGenieSettingsService.java
+++ b/core/src/main/java/com/devoxx/genie/service/DevoxxGenieSettingsService.java
@@ -28,6 +28,12 @@ public interface DevoxxGenieSettingsService {
 
     String getAzureOpenAIKey();
 
+    String getAwsAccessKey();
+
+    String getAwsAccessKeyId();
+
+    String getAwsRegion();
+
     String getMistralKey();
 
     String getAnthropicKey();
@@ -109,6 +115,12 @@ public interface DevoxxGenieSettingsService {
     void setAzureOpenAIDeployment(String deployment);
 
     void setAzureOpenAIKey(String key);
+
+    void setAwsAccessKey(String key);
+
+    void setAwsAccessKeyId(String accessKeyId);
+
+    void setAwsRegion(String region);
 
     void setMistralKey(String key);
 

--- a/src/main/java/com/devoxx/genie/chatmodel/ChatModelFactoryProvider.java
+++ b/src/main/java/com/devoxx/genie/chatmodel/ChatModelFactoryProvider.java
@@ -2,6 +2,7 @@ package com.devoxx.genie.chatmodel;
 
 import com.devoxx.genie.chatmodel.cloud.anthropic.AnthropicChatModelFactory;
 import com.devoxx.genie.chatmodel.cloud.azureopenai.AzureOpenAIChatModelFactory;
+import com.devoxx.genie.chatmodel.cloud.bedrock.BedrockModelFactory;
 import com.devoxx.genie.chatmodel.cloud.deepinfra.DeepInfraChatModelFactory;
 import com.devoxx.genie.chatmodel.cloud.deepseek.DeepSeekChatModelFactory;
 import com.devoxx.genie.chatmodel.cloud.google.GoogleChatModelFactory;
@@ -44,6 +45,7 @@ public class ChatModelFactoryProvider {
         return switch (modelProvider) {
             case "Anthropic" -> new AnthropicChatModelFactory();
             case "AzureOpenAI" -> new AzureOpenAIChatModelFactory();
+            case "Bedrock" -> new BedrockModelFactory();
             case "CustomOpenAI" -> new CustomOpenAIChatModelFactory();
             case "DeepInfra" -> new DeepInfraChatModelFactory();
             case "DeepSeek" -> new DeepSeekChatModelFactory();

--- a/src/main/java/com/devoxx/genie/chatmodel/cloud/bedrock/BedrockModelFactory.java
+++ b/src/main/java/com/devoxx/genie/chatmodel/cloud/bedrock/BedrockModelFactory.java
@@ -1,0 +1,96 @@
+package com.devoxx.genie.chatmodel.cloud.bedrock;
+
+import com.devoxx.genie.chatmodel.ChatModelFactory;
+import com.devoxx.genie.model.ChatModel;
+import com.devoxx.genie.model.LanguageModel;
+import com.devoxx.genie.model.enumarations.ModelProvider;
+import com.devoxx.genie.ui.settings.DevoxxGenieStateService;
+import dev.langchain4j.model.bedrock.BedrockAnthropicMessageChatModel;
+import dev.langchain4j.model.chat.ChatLanguageModel;
+import org.apache.commons.lang3.NotImplementedException;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+
+import java.util.List;
+
+/**
+ * This factory supports creating models from different providers available on AWS Bedrock.
+ */
+public class BedrockModelFactory implements ChatModelFactory {
+    private static final String MODEL_PREFIX_ANTHROPIC = "anthropic.";
+
+    private final ModelProvider MODEL_PROVIDER = ModelProvider.Bedrock;
+
+    /**
+     * Creates a {@link ChatLanguageModel} based on the provided {@link ChatModel}.
+     *
+     * @param chatModel The configuration for the chat model.
+     * @return An instance of {@link ChatLanguageModel} configured with the provided settings.
+     * @throws NotImplementedException if the requested model is not supported.
+     */
+    @Override
+    public ChatLanguageModel createChatModel(ChatModel chatModel) {
+        final String modelName = chatModel.getModelName();
+
+        if (modelName.startsWith(MODEL_PREFIX_ANTHROPIC)) {
+            return createAnthropicChatModel(chatModel);
+        } else {
+            throw new NotImplementedException("Support for model %s isn't implemented yet", modelName);
+        }
+    }
+
+    /**
+     * Creates a {@link ChatLanguageModel} for Anthropic models on AWS Bedrock.
+     *
+     * @param chatModel The configuration for the chat model.
+     * @return An instance of {@link ChatLanguageModel} configured for Anthropic models.
+     */
+    private ChatLanguageModel createAnthropicChatModel(ChatModel chatModel) {
+        return BedrockAnthropicMessageChatModel.builder()
+                .model(chatModel.getModelName())
+                .temperature(chatModel.getTemperature())
+                .maxTokens(chatModel.getMaxTokens())
+                .credentialsProvider(getCredentialsProvider())
+                .region(getRegion())
+                .build();
+    }
+
+    /**
+     * Returns a list of supported language models for the Bedrock provider.
+     * <p>
+     * Full list of models
+     * <a href="https://docs.aws.amazon.com/bedrock/latest/userguide/models-supported.html">can be found at</a>
+     *
+     * @return A list of {@link LanguageModel} for Bedrock.
+     */
+    @Override
+    public List<LanguageModel> getModels() {
+        return getModels(MODEL_PROVIDER);
+    }
+
+    /**
+     * Creates an {@link AwsCredentialsProvider} using the configured AWS access key and secret key
+     * from the {@link DevoxxGenieStateService}.
+     *
+     * @return An {@link AwsCredentialsProvider} for authenticating with AWS.
+     */
+    AwsCredentialsProvider getCredentialsProvider() {
+        return StaticCredentialsProvider.create(AwsBasicCredentials.create(
+                DevoxxGenieStateService.getInstance().getAwsAccessKeyId(),
+                DevoxxGenieStateService.getInstance().getAwsAccessKey()
+        ));
+    }
+
+    /**
+     * Retrieves the AWS region from the {@link DevoxxGenieStateService}.
+     *
+     * @return The AWS {@link Region}.
+     */
+    Region getRegion() {
+        return Region.of(
+                DevoxxGenieStateService.getInstance().getAwsRegion()
+        );
+    }
+}

--- a/src/main/java/com/devoxx/genie/controller/ProjectContextController.java
+++ b/src/main/java/com/devoxx/genie/controller/ProjectContextController.java
@@ -106,6 +106,7 @@ public class ProjectContextController {
                 modelProvider.equals(DeepInfra) ||
                 modelProvider.equals(Ollama) ||
                 modelProvider.equals(Jan) ||
+                modelProvider.equals(Bedrock) ||
                 modelProvider.equals(LMStudio);
                 // Note : NOT GPT4All because the selected context window is not provided in JSON model response
     }

--- a/src/main/java/com/devoxx/genie/service/LLMModelRegistryService.java
+++ b/src/main/java/com/devoxx/genie/service/LLMModelRegistryService.java
@@ -37,6 +37,7 @@ public final class LLMModelRegistryService {
         addGeminiModels();
         addMistralModels();
         addDeepSeekModels();
+        addBedrockModels();
     }
 
     private void addAnthropicModels() {
@@ -698,6 +699,19 @@ public final class LLMModelRegistryService {
                         .outputCost(0.28)
                         .inputMaxTokens(128_000)
                         .apiKeyUsed(true)
+                        .build());
+    }
+
+    private void addBedrockModels() {
+        String claude3dot5 = "anthropic.claude-3-5-sonnet-20240620-v1:0";
+        models.put(ModelProvider.Bedrock.getName() + ":" + claude3dot5,
+                LanguageModel.builder()
+                        .provider(ModelProvider.Bedrock)
+                        .modelName(claude3dot5)
+                        .displayName("Claude 3.5 Sonnet")
+                        .inputCost(3)
+                        .outputCost(15)
+                        .inputMaxTokens(200_000)
                         .build());
     }
 

--- a/src/main/java/com/devoxx/genie/service/LLMProviderService.java
+++ b/src/main/java/com/devoxx/genie/service/LLMProviderService.java
@@ -29,6 +29,7 @@ public class LLMProviderService {
         providerKeyMap.put(DeepSeek, stateService::getDeepSeekKey);
         providerKeyMap.put(OpenRouter, stateService::getOpenRouterKey);
         providerKeyMap.put(AzureOpenAI, stateService::getAzureOpenAIKey);
+        providerKeyMap.put(Bedrock, stateService::getAwsAccessKey);
     }
 
     @NotNull
@@ -73,6 +74,11 @@ public class LLMProviderService {
         if (Boolean.TRUE.equals(DevoxxGenieStateService.getInstance().getShowAzureOpenAIFields())) {
             optionalModelProviders.add(AzureOpenAI);
         }
+
+        if (Boolean.TRUE.equals(DevoxxGenieStateService.getInstance().getShowAwsFields())) {
+            optionalModelProviders.add(Bedrock);
+        }
+
 
         return optionalModelProviders;
     }

--- a/src/main/java/com/devoxx/genie/ui/panel/LlmProviderPanel.java
+++ b/src/main/java/com/devoxx/genie/ui/panel/LlmProviderPanel.java
@@ -132,6 +132,7 @@ public class LlmProviderPanel extends JBPanel<LlmProviderPanel> implements LLMSe
                     case DeepSeek -> stateService.isDeepSeekEnabled();
                     case OpenRouter -> stateService.isOpenRouterEnabled();
                     case AzureOpenAI -> stateService.isAzureOpenAIEnabled();
+                    case Bedrock -> stateService.isAwsEnabled();
                 })
                 .distinct()
                 .sorted(Comparator.comparing(ModelProvider::getName))

--- a/src/main/java/com/devoxx/genie/ui/settings/DevoxxGenieStateService.java
+++ b/src/main/java/com/devoxx/genie/ui/settings/DevoxxGenieStateService.java
@@ -101,6 +101,7 @@ public final class DevoxxGenieStateService implements PersistentStateComponent<D
     private boolean isGoogleEnabled = false;
     private boolean isDeepSeekEnabled = false;
     private boolean isOpenRouterEnabled = false;
+    private boolean isAWSEnabled = false;
 
     // LLM API Keys
     private String openAIKey = "";
@@ -114,6 +115,9 @@ public final class DevoxxGenieStateService implements PersistentStateComponent<D
     private String azureOpenAIEndpoint = "";
     private String azureOpenAIDeployment = "";
     private String azureOpenAIKey = "";
+    private String awsAccessKeyId = "";
+    private String awsAccessKey = "";
+    private String awsRegion = "";
 
     // Search API Keys
     private Boolean isWebSearchEnabled = ENABLE_WEB_SEARCH;
@@ -150,6 +154,7 @@ public final class DevoxxGenieStateService implements PersistentStateComponent<D
     private Boolean excludeJavaDoc = false;
 
     private Boolean showAzureOpenAIFields = false;
+    private Boolean showAwsFields = false;
 
     @Setter
     private Boolean useGitIgnore = true;
@@ -265,6 +270,13 @@ public final class DevoxxGenieStateService implements PersistentStateComponent<D
                 !azureOpenAIKey.isEmpty() &&
                 !azureOpenAIEndpoint.isEmpty() &&
                 !azureOpenAIDeployment.isEmpty();
+    }
+
+    public boolean isAwsEnabled() {
+        return showAwsFields &&
+                !awsAccessKey.isEmpty() &&
+                !awsAccessKeyId.isEmpty() &&
+                !awsRegion.isEmpty();
     }
 
     public @Nullable String getConfigValue(@NotNull String key) {

--- a/src/main/java/com/devoxx/genie/ui/settings/llm/LLMProvidersComponent.java
+++ b/src/main/java/com/devoxx/genie/ui/settings/llm/LLMProvidersComponent.java
@@ -59,6 +59,12 @@ public class LLMProvidersComponent extends AbstractSettingsComponent {
     @Getter
     private final JPasswordField openRouterApiKeyField = new JPasswordField(stateService.getOpenRouterKey());
     @Getter
+    private final JPasswordField awsAccessKeyField = new JPasswordField(stateService.getAwsAccessKey());
+    @Getter
+    private final JPasswordField awsAccessKeyIdField = new JPasswordField(stateService.getAwsAccessKeyId());
+    @Getter
+    private final JTextField awsRegion = new JTextField(stateService.getAwsRegion());
+    @Getter
     private final JCheckBox streamModeCheckBox = new JCheckBox("", stateService.getStreamMode());
 
     @Getter
@@ -93,8 +99,12 @@ public class LLMProvidersComponent extends AbstractSettingsComponent {
     private final JCheckBox openRouterEnabledCheckBox = new JCheckBox("", stateService.isOpenRouterEnabled());
     @Getter
     private final JCheckBox enableAzureOpenAICheckBox = new JCheckBox("", stateService.getShowAzureOpenAIFields());
+    @Getter
+    private final JCheckBox enableAWSCheckBox = new JCheckBox("", stateService.getShowAwsFields());
 
     private final List<JComponent> azureComponents = new ArrayList<>();
+
+    private final List<JComponent> awsComponents = new ArrayList<>();
 
     public LLMProvidersComponent() {
         addListeners();
@@ -149,6 +159,7 @@ public class LLMProvidersComponent extends AbstractSettingsComponent {
                 createTextWithPasswordButton(openRouterApiKeyField, "https://openrouter.ai/settings/keys"));
 
         addAzureOpenAIPanel(panel, gbc);
+        addAWSPanel(panel, gbc);
 
         addSection(panel, gbc, "Plugin version");
         addSettingRow(panel, gbc, "v" + projectVersion.getText(), createTextWithLinkButton(new JLabel("View on GitHub"), "https://github.com/devoxx/DevoxxGenieIDEAPlugin"));
@@ -166,6 +177,9 @@ public class LLMProvidersComponent extends AbstractSettingsComponent {
         // Keep existing listeners
         enableAzureOpenAICheckBox.addItemListener(event -> {
             setNestedComponentsVisibility(azureComponents, event.getStateChange() == ItemEvent.SELECTED, true);
+        });
+        enableAWSCheckBox.addItemListener(event -> {
+            setNestedComponentsVisibility(awsComponents, event.getStateChange() == ItemEvent.SELECTED, true);
         });
 
         // Add new listeners for enable/disable checkboxes
@@ -209,6 +223,21 @@ public class LLMProvidersComponent extends AbstractSettingsComponent {
 
         // Set initial visibility
         setNestedComponentsVisibility(azureComponents, enableAzureOpenAICheckBox.isSelected(), false);
+    }
+
+    private void addAWSPanel(JPanel panel, GridBagConstraints gbc) {
+        final String bedrockURL = "https://docs.aws.amazon.com/bedrock/latest/userguide/getting-started-api.html";
+        addSettingRow(panel, gbc, "Enable AWS Bedrock", enableAWSCheckBox);
+
+        addNestedSettingsRow(panel, gbc, "AWS Access Key ID",
+                createTextWithLinkButton(awsAccessKeyIdField, bedrockURL), awsComponents);
+        addNestedSettingsRow(panel, gbc, "AWS Secret Access Key",
+                createTextWithLinkButton(awsAccessKeyField, bedrockURL), awsComponents);
+        addNestedSettingsRow(panel, gbc, "AWS region",
+                createTextWithPasswordButton(awsRegion, bedrockURL), awsComponents);
+
+        // Set initial visibility
+        setNestedComponentsVisibility(awsComponents, enableAWSCheckBox.isSelected(), false);
     }
 
     /**

--- a/src/main/java/com/devoxx/genie/ui/settings/llm/LLMProvidersComponent.java
+++ b/src/main/java/com/devoxx/genie/ui/settings/llm/LLMProvidersComponent.java
@@ -6,10 +6,17 @@ import com.intellij.util.ui.JBUI;
 import lombok.Getter;
 import org.jetbrains.annotations.NotNull;
 
-import javax.swing.*;
-import java.awt.*;
+import javax.swing.JCheckBox;
+import javax.swing.JComponent;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.JPasswordField;
+import javax.swing.JTextField;
+import java.awt.GridBagConstraints;
+import java.awt.GridBagLayout;
 import java.awt.event.ItemEvent;
 import java.util.ArrayList;
+import java.util.List;
 
 public class LLMProvidersComponent extends AbstractSettingsComponent {
 
@@ -87,7 +94,7 @@ public class LLMProvidersComponent extends AbstractSettingsComponent {
     @Getter
     private final JCheckBox enableAzureOpenAICheckBox = new JCheckBox("", stateService.getShowAzureOpenAIFields());
 
-    private final java.util.List<JComponent> azureComponents = new ArrayList<>();
+    private final List<JComponent> azureComponents = new ArrayList<>();
 
     public LLMProvidersComponent() {
         addListeners();
@@ -158,9 +165,7 @@ public class LLMProvidersComponent extends AbstractSettingsComponent {
     public void addListeners() {
         // Keep existing listeners
         enableAzureOpenAICheckBox.addItemListener(event -> {
-            azureComponents.forEach(comp -> comp.setVisible(event.getStateChange() == ItemEvent.SELECTED));
-            panel.revalidate();
-            panel.repaint();
+            setNestedComponentsVisibility(azureComponents, event.getStateChange() == ItemEvent.SELECTED, true);
         });
 
         // Add new listeners for enable/disable checkboxes
@@ -192,35 +197,69 @@ public class LLMProvidersComponent extends AbstractSettingsComponent {
 //    }
 
     private void addAzureOpenAIPanel(JPanel panel, GridBagConstraints gbc) {
+        final String azureOpenAIUrl = "https://learn.microsoft.com/en-us/azure/ai-services/openai/overview";
         addSettingRow(panel, gbc, "Enable Azure OpenAI Provider", enableAzureOpenAICheckBox);
 
-        addAzureComponentsSettingRow(panel, gbc, "Azure OpenAI Endpoint",
-                createTextWithLinkButton(azureOpenAIEndpointField, "https://learn.microsoft.com/en-us/azure/ai-services/openai/overview"));
-        addAzureComponentsSettingRow(panel, gbc, "Azure OpenAI Deployment",
-                createTextWithLinkButton(azureOpenAIDeploymentField, "https://learn.microsoft.com/en-us/azure/ai-services/openai/overview"));
-        addAzureComponentsSettingRow(panel, gbc, "Azure OpenAI API Key",
-                createTextWithPasswordButton(azureOpenAIKeyField, "https://learn.microsoft.com/en-us/azure/ai-services/openai/overview"));
+        addNestedSettingsRow(panel, gbc, "Azure OpenAI Endpoint",
+                createTextWithLinkButton(azureOpenAIEndpointField, azureOpenAIUrl), azureComponents);
+        addNestedSettingsRow(panel, gbc, "Azure OpenAI Deployment",
+                createTextWithLinkButton(azureOpenAIDeploymentField, azureOpenAIUrl), azureComponents);
+        addNestedSettingsRow(panel, gbc, "Azure OpenAI API Key",
+                createTextWithPasswordButton(azureOpenAIKeyField, azureOpenAIUrl), azureComponents);
 
         // Set initial visibility
-        boolean azureEnabled = enableAzureOpenAICheckBox.isSelected();
-        for (JComponent comp : azureComponents) {
-            comp.setVisible(azureEnabled);
-        }
+        setNestedComponentsVisibility(azureComponents, enableAzureOpenAICheckBox.isSelected(), false);
     }
 
-    private void addAzureComponentsSettingRow(@NotNull JPanel panel, @NotNull GridBagConstraints gbc, String label, JComponent component) {
+    /**
+     * Adds a row of settings to the panel with nested components.
+     * The nested components are added to a list for visibility management.
+     *
+     * @param panel           The panel to add the settings row to.
+     * @param gbc             The GridBagConstraints for layout.
+     * @param label           The label for the setting.
+     * @param component       The component associated with the setting.
+     * @param componentsGroup The list to add the label and component to for visibility management.
+     */
+    private void addNestedSettingsRow(
+            @NotNull JPanel panel,
+            @NotNull GridBagConstraints gbc,
+            String label,
+            JComponent component,
+            @NotNull final List<JComponent> componentsGroup
+    ) {
         gbc.gridwidth = 1;
         gbc.gridx = 0;
         gbc.insets = JBUI.insets(5, 20, 5, 5); // Indent by 20 pixels on the left
         JLabel jLabel = new JLabel(label);
         panel.add(jLabel, gbc);
-        azureComponents.add(jLabel);
+        componentsGroup.add(jLabel);
 
         gbc.gridx = 1;
         panel.add(component, gbc);
-        azureComponents.add(component);
+        componentsGroup.add(component);
         gbc.gridy++;
 
         gbc.insets = JBUI.insets(5);
+    }
+
+    /**
+     * Sets the visibility of a group of components.
+     *
+     * @param componentsGroup The list of components to modify.
+     * @param isVisible       Whether the components should be visible.
+     * @param rePaintPanel    Whether to force repaint panel after changing visibility.
+     */
+    private void setNestedComponentsVisibility(
+            @NotNull final List<JComponent> componentsGroup,
+            boolean isVisible,
+            boolean rePaintPanel
+    ) {
+        componentsGroup.forEach(comp -> comp.setVisible(isVisible));
+
+        if (rePaintPanel) {
+            panel.revalidate();
+            panel.repaint();
+        }
     }
 }

--- a/src/main/java/com/devoxx/genie/ui/settings/llm/LLMProvidersConfigurable.java
+++ b/src/main/java/com/devoxx/genie/ui/settings/llm/LLMProvidersConfigurable.java
@@ -9,6 +9,8 @@ import org.jetbrains.annotations.Nullable;
 
 import javax.swing.*;
 
+import java.util.Arrays;
+
 import static com.intellij.openapi.options.Configurable.isFieldModified;
 
 public class LLMProvidersConfigurable implements Configurable {
@@ -79,6 +81,11 @@ public class LLMProvidersConfigurable implements Configurable {
         isModified |= isFieldModified(llmSettingsComponent.getAzureOpenAIDeploymentField(), stateService.getAzureOpenAIDeployment());
         isModified |= isFieldModified(llmSettingsComponent.getAzureOpenAIKeyField(), stateService.getAzureOpenAIKey());
 
+        isModified |= !stateService.getShowAwsFields().equals(llmSettingsComponent.getEnableAWSCheckBox().isSelected());
+        isModified |= isFieldModified(llmSettingsComponent.getAwsAccessKeyField(), stateService.getAwsAccessKey());
+        isModified |= isFieldModified(llmSettingsComponent.getAwsAccessKeyIdField(), stateService.getAwsAccessKeyId());
+        isModified |= isFieldModified(llmSettingsComponent.getAwsRegion(), stateService.getAwsRegion());
+
         isModified |= stateService.isOllamaEnabled() != llmSettingsComponent.getOllamaEnabledCheckBox().isSelected();
         isModified |= stateService.isLmStudioEnabled() != llmSettingsComponent.getLmStudioEnabledCheckBox().isSelected();
         isModified |= stateService.isGpt4AllEnabled() != llmSettingsComponent.getGpt4AllEnabledCheckBox().isSelected();
@@ -135,6 +142,11 @@ public class LLMProvidersConfigurable implements Configurable {
         settings.setAzureOpenAIDeployment(llmSettingsComponent.getAzureOpenAIDeploymentField().getText());
         settings.setAzureOpenAIKey(new String(llmSettingsComponent.getAzureOpenAIKeyField().getPassword()));
 
+        settings.setShowAwsFields(llmSettingsComponent.getEnableAWSCheckBox().isSelected());
+        settings.setAwsAccessKey(new String(llmSettingsComponent.getAwsAccessKeyField().getPassword()));
+        settings.setAwsAccessKeyId(new String(llmSettingsComponent.getAwsAccessKeyIdField().getPassword()));
+        settings.setAwsRegion(llmSettingsComponent.getAwsRegion().getText());
+
         settings.setOllamaEnabled(llmSettingsComponent.getOllamaEnabledCheckBox().isSelected());
         settings.setLmStudioEnabled(llmSettingsComponent.getLmStudioEnabledCheckBox().isSelected());
         settings.setGpt4AllEnabled(llmSettingsComponent.getGpt4AllEnabledCheckBox().isSelected());
@@ -164,6 +176,9 @@ public class LLMProvidersConfigurable implements Configurable {
                     (!settings.getGeminiKey().isBlank() && settings.isGoogleEnabled()) ||
                     (!settings.getGroqKey().isBlank() && settings.isGroqEnabled()) ||
                     (!settings.getMistralKey().isBlank() && settings.isMistralEnabled()) ||
+                    (!settings.getAwsAccessKey().isBlank() && settings.getShowAwsFields()) ||
+                    (!settings.getAwsAccessKeyId().isBlank() && settings.getShowAwsFields()) ||
+                    (!settings.getAwsRegion().isBlank() && settings.getShowAwsFields()) ||
                     (!settings.getAzureOpenAIKey().isBlank() && settings.getShowAzureOpenAIFields());
 
             project.getMessageBus()

--- a/src/test/java/com/devoxx/genie/chatmodel/cloud/bedrock/BedrockModelFactoryTest.java
+++ b/src/test/java/com/devoxx/genie/chatmodel/cloud/bedrock/BedrockModelFactoryTest.java
@@ -1,0 +1,65 @@
+package com.devoxx.genie.chatmodel.cloud.bedrock;
+
+import com.devoxx.genie.chatmodel.AbstractLightPlatformTestCase;
+import com.devoxx.genie.model.LanguageModel;
+import com.devoxx.genie.ui.settings.DevoxxGenieStateService;
+import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.testFramework.ServiceContainerUtil;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class BedrockModelFactoryTest extends AbstractLightPlatformTestCase {
+    private static final String DUMMY_AWS_API_KEY = "dummy-aws-api-key";
+    private static final String DUMMY_AWS_API_KEY_ID = "dummy-aws-api-key-id";
+    private static final String US_EAST_1 = "us-east-1";
+    private static final String US_WEST_2 = "us-west-2";
+
+    private DevoxxGenieStateService settingsStateMock;
+
+    @BeforeEach
+    public void setUp() throws Exception {
+        super.setUp();
+        // Mock SettingsState
+        settingsStateMock = mock(DevoxxGenieStateService.class);
+        when(settingsStateMock.getAwsAccessKeyId()).thenReturn(DUMMY_AWS_API_KEY_ID);
+        when(settingsStateMock.getAwsAccessKey()).thenReturn(DUMMY_AWS_API_KEY);
+        when(settingsStateMock.getAwsRegion()).thenReturn(US_EAST_1);
+
+        // Replace the service instance with the mock
+        ServiceContainerUtil.replaceService(ApplicationManager.getApplication(), DevoxxGenieStateService.class, settingsStateMock, getTestRootDisposable());
+    }
+
+    @Test
+    public void getModels() {
+        BedrockModelFactory factory = new BedrockModelFactory();
+        assertThat(factory.getModels()).isNotEmpty();
+
+        List<LanguageModel> models = factory.getModels();
+        assertThat(models).size().isEqualTo(1);
+    }
+
+    @Test
+    public void getRegion() {
+        BedrockModelFactory factory = new BedrockModelFactory();
+        assertThat(factory.getRegion().toString()).isEqualTo(US_EAST_1);
+
+        when(settingsStateMock.getAwsRegion()).thenReturn(US_WEST_2);
+        assertThat(factory.getRegion().toString()).isEqualTo(US_WEST_2);
+    }
+
+    @Test
+    public void getCredentialsProvider() {
+        BedrockModelFactory factory = new BedrockModelFactory();
+        AwsCredentialsProvider awsCredentialsProvider = factory.getCredentialsProvider();
+
+        assertThat(awsCredentialsProvider.resolveCredentials().secretAccessKey()).isEqualTo(DUMMY_AWS_API_KEY);
+        assertThat(awsCredentialsProvider.resolveCredentials().accessKeyId()).isEqualTo(DUMMY_AWS_API_KEY_ID);
+    }
+}


### PR DESCRIPTION
- Extract common logic for nested UI components
- Add UI for AWS authorization (similar to how Azure OpenAI provider is supported now)
- Include `langchain4j-bedrock` library into the build 
- Add support for Anthropic models using `BedrockAnthropicMessageChatModel`

Additional models can be added later easily as they should really on the same authorization method.

Might help with https://github.com/devoxx/DevoxxGenieIDEAPlugin/issues/250   