### PR TITLE
fix (rag): change order to iterate over included files only after sca…

### DIFF
--- a/src/main/java/com/devoxx/genie/service/projectscanner/ProjectScannerService.java
+++ b/src/main/java/com/devoxx/genie/service/projectscanner/ProjectScannerService.java
@@ -50,9 +50,9 @@ public class ProjectScannerService {
         ReadAction.run(() -> {
             fileScanner.reset();
             fileScanner.initGitignoreParser(project, startDirectory);
-            fileScanner.getIncludedFiles().forEach(scanContentResult::addFile);
 
             String content = scanContent(project, startDirectory, windowContextMaxTokens, isTokenCalculation);
+            fileScanner.getIncludedFiles().forEach(scanContentResult::addFile);
 
             scanContentResult.setTokenCount(tokenCalculator.calculateTokens(content));
             scanContentResult.setContent(content);


### PR DESCRIPTION
I changed the order to what it is setup in the existing tests and tested it locally.

<img width="788" alt="indexed-segments" src="https://github.com/user-attachments/assets/45361c48-8864-4314-aa33-911b76438321" />
