### PR TITLE
Add “Custom OpenAI HTTP 1.1” toggle for custom OpenAI provider

### DIFF
--- a/src/main/java/com/devoxx/genie/chatmodel/local/customopenai/CustomOpenAIChatModelFactory.java
+++ b/src/main/java/com/devoxx/genie/chatmodel/local/customopenai/CustomOpenAIChatModelFactory.java
@@ -8,11 +8,14 @@ import dev.langchain4j.model.chat.ChatLanguageModel;
 import dev.langchain4j.model.chat.StreamingChatLanguageModel;
 import dev.langchain4j.model.openai.OpenAiChatModel;
 import dev.langchain4j.model.openai.OpenAiStreamingChatModel;
+import dev.langchain4j.http.client.jdk.JdkHttpClient;
+import dev.langchain4j.http.client.jdk.JdkHttpClientBuilder;
 import org.jetbrains.annotations.NotNull;
 
 import java.time.Duration;
 import java.util.Collections;
 import java.util.List;
+import java.net.http.HttpClient;
 
 public class CustomOpenAIChatModelFactory implements ChatModelFactory {
 
@@ -30,6 +33,7 @@ public class CustomOpenAIChatModelFactory implements ChatModelFactory {
                 .timeout(Duration.ofSeconds(chatModel.getTimeout()))
                 .topP(chatModel.getTopP())
                 .listeners(getListener())
+                .httpClientBuilder(getHttpClientBuilder())
                 .build();
     }
 
@@ -45,7 +49,16 @@ public class CustomOpenAIChatModelFactory implements ChatModelFactory {
                 .topP(chatModel.getTopP())
                 .timeout(Duration.ofSeconds(chatModel.getTimeout()))
                 .listeners(getListener())
+                .httpClientBuilder(getHttpClientBuilder())
                 .build();
+    }
+
+    private JdkHttpClientBuilder getHttpClientBuilder() {
+        boolean forceHttp11 = DevoxxGenieStateService.getInstance().isCustomOpenAIForceHttp11();
+        return forceHttp11
+                ? JdkHttpClient.builder()
+                        .httpClientBuilder(HttpClient.newBuilder().version(HttpClient.Version.HTTP_1_1))
+                : JdkHttpClient.builder();
     }
 
     /**

--- a/src/main/java/com/devoxx/genie/ui/settings/AbstractSettingsComponent.java
+++ b/src/main/java/com/devoxx/genie/ui/settings/AbstractSettingsComponent.java
@@ -55,6 +55,13 @@ public class AbstractSettingsComponent implements SettingsComponent {
         gbc.gridy++;
     }
 
+    protected void addProviderSettingRow(JPanel panel, GridBagConstraints gbc, String label, JCheckBox checkbox) {
+        JPanel providerPanel = new JPanel(new BorderLayout(5, 0));
+        providerPanel.add(checkbox, BorderLayout.WEST);
+
+        addSettingRow(panel, gbc, label, providerPanel);
+    }
+    
     protected void addProviderSettingRow(JPanel panel, GridBagConstraints gbc, String label, JCheckBox checkbox, JComponent urlComponent) {
         JPanel providerPanel = new JPanel(new BorderLayout(5, 0));
         providerPanel.add(checkbox, BorderLayout.WEST);

--- a/src/main/java/com/devoxx/genie/ui/settings/DevoxxGenieStateService.java
+++ b/src/main/java/com/devoxx/genie/ui/settings/DevoxxGenieStateService.java
@@ -101,6 +101,7 @@ public final class DevoxxGenieStateService implements PersistentStateComponent<D
 
     // Local custom OpenAI-compliant LLM fields
     private boolean isCustomOpenAIUrlEnabled = false;
+    private boolean isCustomOpenAIForceHttp11 = false;
     private boolean isCustomOpenAIModelNameEnabled = false;
     private boolean isCustomOpenAIApiKeyEnabled = false;
 

--- a/src/main/java/com/devoxx/genie/ui/settings/llm/LLMProvidersComponent.java
+++ b/src/main/java/com/devoxx/genie/ui/settings/llm/LLMProvidersComponent.java
@@ -75,6 +75,8 @@ public class LLMProvidersComponent extends AbstractSettingsComponent {
     @Getter
     private final JCheckBox customOpenAIUrlEnabledCheckBox = new JCheckBox("", stateService.isCustomOpenAIUrlEnabled());
     @Getter
+    private final JCheckBox customOpenAIForceHttp11CheckBox = new JCheckBox("", stateService.isCustomOpenAIForceHttp11());
+    @Getter
     private final JCheckBox customOpenAIModelNameEnabledCheckBox = new JCheckBox("", stateService.isCustomOpenAIModelNameEnabled());
     @Getter
     private final JCheckBox enableCustomOpenAIApiKeyCheckBox = new JCheckBox("", stateService.isCustomOpenAIApiKeyEnabled());
@@ -138,6 +140,7 @@ public class LLMProvidersComponent extends AbstractSettingsComponent {
         addProviderSettingRow(panel, gbc, "Custom OpenAI URL", customOpenAIUrlEnabledCheckBox, customOpenAIUrlField);
         addProviderSettingRow(panel, gbc, "Custom OpenAI Model", customOpenAIModelNameEnabledCheckBox, customOpenAIModelNameField);
         addProviderSettingRow(panel, gbc, "Custom OpenAI API Key", enableCustomOpenAIApiKeyCheckBox, customOpenAIApiKeyField);
+        addProviderSettingRow(panel, gbc, "Custom OpenAI HTTP 1.1", customOpenAIForceHttp11CheckBox);
 
         // Cloud LLM Providers section
         addSection(panel, gbc, "Cloud LLM Providers");

--- a/src/main/java/com/devoxx/genie/ui/settings/llm/LLMProvidersConfigurable.java
+++ b/src/main/java/com/devoxx/genie/ui/settings/llm/LLMProvidersConfigurable.java
@@ -94,6 +94,7 @@ public class LLMProvidersConfigurable implements Configurable {
 
         isModified |= stateService.isCustomOpenAIUrlEnabled() != llmSettingsComponent.getCustomOpenAIUrlEnabledCheckBox().isSelected();
         isModified |= stateService.isCustomOpenAIModelNameEnabled() != llmSettingsComponent.getCustomOpenAIModelNameEnabledCheckBox().isSelected();
+        isModified |= stateService.isCustomOpenAIForceHttp11() != llmSettingsComponent.getCustomOpenAIForceHttp11CheckBox().isSelected();
 
         isModified |= stateService.isOpenAIEnabled() != llmSettingsComponent.getOpenAIEnabledCheckBox().isSelected();
         isModified |= stateService.isMistralEnabled() != llmSettingsComponent.getMistralEnabledCheckBox().isSelected();
@@ -129,6 +130,7 @@ public class LLMProvidersConfigurable implements Configurable {
         settings.setCustomOpenAIModelName(llmSettingsComponent.getCustomOpenAIModelNameField().getText());
         settings.setCustomOpenAIApiKey(new String(llmSettingsComponent.getCustomOpenAIApiKeyField().getPassword()));
         settings.setCustomOpenAIApiKeyEnabled(llmSettingsComponent.getEnableCustomOpenAIApiKeyCheckBox().isSelected());
+        settings.setCustomOpenAIForceHttp11(llmSettingsComponent.getCustomOpenAIForceHttp11CheckBox().isSelected());
 
         settings.setOpenAIKey(new String(llmSettingsComponent.getOpenAIKeyField().getPassword()));
         settings.setMistralKey(new String(llmSettingsComponent.getMistralApiKeyField().getPassword()));
@@ -231,6 +233,8 @@ public class LLMProvidersConfigurable implements Configurable {
 
         llmSettingsComponent.getCustomOpenAIUrlEnabledCheckBox().setSelected(settings.isCustomOpenAIUrlEnabled());
         llmSettingsComponent.getCustomOpenAIModelNameEnabledCheckBox().setSelected(settings.isCustomOpenAIModelNameEnabled());
+        llmSettingsComponent.getCustomOpenAIForceHttp11CheckBox().setSelected(settings.isCustomOpenAIForceHttp11());
+
 
         llmSettingsComponent.getOpenAIEnabledCheckBox().setSelected(settings.isOpenAIEnabled());
         llmSettingsComponent.getMistralEnabledCheckBox().setSelected(settings.isMistralEnabled());


### PR DESCRIPTION
Added a “Custom OpenAI HTTP 1.1” toggle to the LLM Providers settings for custom OpenAI endpoints.
• When enabled, the plugin forces HttpClient.Version.HTTP_1_1 via JdkHttpClientBuilder, eliminating 400 / Upgrade errors with LM Studio, local proxies, Express back-ends, and other services that reject HTTP/2.
• When disabled (default), behavior remains unchanged.