### PR TITLE
With Dark theme, light background was used

### DIFF
--- a/src/main/java/com/devoxx/genie/ui/settings/appearance/AppearanceRefreshHandler.java
+++ b/src/main/java/com/devoxx/genie/ui/settings/appearance/AppearanceRefreshHandler.java
@@ -93,7 +93,7 @@ public final class AppearanceRefreshHandler implements AppearanceSettingsEvents 
         String assistantMessageBackgroundColor;
         String assistantMessageTextColor;
 
-        if (state.getUseCustomColors()) {
+        if (Boolean.TRUE.equals(state.getUseCustomColors())) {
             log.debug("Use custom colors");
 
             // Use user-defined colors
@@ -151,13 +151,13 @@ public final class AppearanceRefreshHandler implements AppearanceSettingsEvents 
                 .append("el.style.borderColor = '").append(assistantMessageBorderColor).append("'; });\n");
 
         // Apply font sizes if custom sizes are enabled
-        if (state.getUseCustomFontSize()) {
+        if (Boolean.TRUE.equals(state.getUseCustomFontSize())) {
             cssStyleUpdates.append("document.body.style.fontSize = '").append(state.getCustomFontSize()).append("px';\n");
         } else {
             cssStyleUpdates.append("document.body.style.fontSize = '';\n");
         }
 
-        if (state.getUseCustomCodeFontSize()) {
+        if (Boolean.TRUE.equals(state.getUseCustomCodeFontSize())) {
             cssStyleUpdates.append("document.querySelectorAll('code').forEach(function(el) { el.style.fontSize = '")
                     .append(state.getCustomCodeFontSize()).append("px'; });\n");
         } else {
@@ -165,7 +165,7 @@ public final class AppearanceRefreshHandler implements AppearanceSettingsEvents 
         }
 
         // Apply rounded corners setting
-        String borderRadius = state.getUseRoundedCorners() ? state.getCornerRadius() + "px" : "0";
+        String borderRadius = Boolean.TRUE.equals(state.getUseRoundedCorners()) ? state.getCornerRadius() + "px" : "0";
         cssStyleUpdates.append("document.querySelectorAll('.user-message, .assistant-message').forEach(function(el) { ")
                 .append("el.style.borderRadius = '").append(borderRadius).append("'; });\n");
 

--- a/src/main/java/com/devoxx/genie/ui/webview/template/ConversationTemplate.java
+++ b/src/main/java/com/devoxx/genie/ui/webview/template/ConversationTemplate.java
@@ -58,7 +58,7 @@ public class ConversationTemplate extends HtmlTemplate {
                 .replace("${headerFontSize}", String.valueOf(headerFontSize))
                 .replace("${subtextFontSize}", String.valueOf(subtextFontSize))
                 .replace("${filePathFontSize}", String.valueOf(filePathFontSize));
-        
+
         // Apply appearance settings to the custom appearance CSS template
         com.devoxx.genie.ui.settings.DevoxxGenieStateService stateService = 
                 com.devoxx.genie.ui.settings.DevoxxGenieStateService.getInstance();
@@ -83,16 +83,18 @@ public class ConversationTemplate extends HtmlTemplate {
         StringBuilder styleBuilder = new StringBuilder();
         styleBuilder.append("<style>\n");
         styleBuilder.append(themeVariables).append("\n");
-        
+
         // Apply dark theme overrides if needed
         if (isDarkMode) {
             styleBuilder.append(darkThemeOverrides).append("\n");
         }
-        
+
         styleBuilder.append(css).append("\n");
         
         // Apply custom appearance styles
-        styleBuilder.append(customAppearanceCss).append("\n");
+        if (Boolean.TRUE.equals(stateService.getUseCustomColors())) {
+            styleBuilder.append(customAppearanceCss).append("\n");
+        }
         
         // Apply MCP formatting styles
         styleBuilder.append("<style>\n");


### PR DESCRIPTION
The custom CSS should only be applied during startup if the custom flag is enabled. Otherwise, the dark theme CSS is overridden by not enabled custom formatting.
Fixes #682 