### PR TITLE
allow add project for AzureOpenAI provider

### DIFF
--- a/src/main/java/com/devoxx/genie/controller/ProjectContextController.java
+++ b/src/main/java/com/devoxx/genie/controller/ProjectContextController.java
@@ -107,7 +107,8 @@ public class ProjectContextController {
                 modelProvider.equals(Ollama) ||
                 modelProvider.equals(Jan) ||
                 modelProvider.equals(Bedrock) ||
-                modelProvider.equals(LMStudio);
+                modelProvider.equals(LMStudio) ||
+                modelProvider.equals(AzureOpenAI);
                 // Note : NOT GPT4All because the selected context window is not provided in JSON model response
     }
 


### PR DESCRIPTION
Azure Open AI models also allow large context windows, enabling them to add project in this context