### PR TITLE
Add approval dialog box for MCP actions before they are executed

### DIFF
--- a/src/main/java/com/devoxx/genie/service/mcp/ApprovalRequiredToolProvider.java
+++ b/src/main/java/com/devoxx/genie/service/mcp/ApprovalRequiredToolProvider.java
@@ -1,0 +1,54 @@
+package com.devoxx.genie.service.mcp;
+
+import com.intellij.openapi.project.Project;
+
+import org.jetbrains.annotations.NotNull;
+
+import dev.langchain4j.agent.tool.ToolSpecification;
+import dev.langchain4j.service.tool.ToolExecutor;
+import dev.langchain4j.service.tool.ToolProvider;
+import dev.langchain4j.service.tool.ToolProviderRequest;
+import dev.langchain4j.service.tool.ToolProviderResult;
+
+public class ApprovalRequiredToolProvider implements ToolProvider {
+
+    private final ToolProvider delegate;
+    private final Project project;
+
+    public ApprovalRequiredToolProvider(ToolProvider delegate, Project project) {
+        this.delegate = delegate;
+        this.project = project;
+    }
+
+    @Override
+    public ToolProviderResult provideTools(@NotNull ToolProviderRequest request) {
+        ToolProviderResult delegateResult = delegate.provideTools(request);
+
+        ToolProviderResult.Builder builder = ToolProviderResult.builder();
+
+        for (var entry : delegateResult.tools().entrySet()) {
+            ToolSpecification spec = entry.getKey();
+            ToolExecutor originalExecutor = entry.getValue();
+
+            // Wrap the original executor
+            ToolExecutor approvalExecutor = (toolExecutionRequest, memoryId) -> {
+                boolean approved = MCPApprovalService.requestApproval(
+                        project,
+                        toolExecutionRequest.name(),
+                        toolExecutionRequest.arguments()
+                );
+                if (approved) {
+                    MCPService.logDebug("MCP tool execution approved: " + toolExecutionRequest.name());
+                    return originalExecutor.execute(toolExecutionRequest, memoryId);
+                } else {
+                    MCPService.logDebug("MCP tool execution denied: " + toolExecutionRequest.name());
+                    return "Tool execution was denied by the user.";
+                }
+            };
+
+            builder.add(spec, approvalExecutor);
+        }
+
+        return builder.build();
+    }
+}

--- a/src/main/java/com/devoxx/genie/service/mcp/MCPApprovalService.java
+++ b/src/main/java/com/devoxx/genie/service/mcp/MCPApprovalService.java
@@ -1,0 +1,155 @@
+package com.devoxx.genie.service.mcp;
+
+import java.awt.BorderLayout;
+import java.awt.Dimension;
+import java.awt.GridBagConstraints;
+import java.awt.GridBagLayout;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import javax.swing.Action;
+import javax.swing.JComponent;
+import javax.swing.JPanel;
+import javax.swing.JTextArea;
+
+import com.devoxx.genie.ui.settings.DevoxxGenieStateService;
+import com.devoxx.genie.ui.util.NotificationUtil;
+import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.ui.DialogWrapper;
+import com.intellij.openapi.ui.Messages;
+import com.intellij.ui.JBColor;
+import com.intellij.ui.components.JBLabel;
+import com.intellij.ui.components.JBScrollPane;
+import com.intellij.util.ui.JBUI;
+
+import lombok.extern.slf4j.Slf4j;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Service for handling MCP function call approvals
+ */
+@Slf4j
+public class MCPApprovalService {
+
+    private static final int APPROVAL_TIMEOUT_SECONDS = 30;
+
+    /**
+     * Request user approval for an MCP tool execution
+     *
+     * @param project The current project
+     * @param toolName The name of the tool being called
+     * @param arguments The arguments being passed to the tool
+     * @return true if approved, false if denied or timed out
+     */
+    public static boolean requestApproval(@Nullable Project project, @NotNull String toolName, @NotNull String arguments) {
+        // Skip approval if running in headless mode or if approval is not required
+        if (ApplicationManager.getApplication().isHeadlessEnvironment() ||
+                !DevoxxGenieStateService.getInstance().getMcpApprovalRequired()) {
+            return true;
+        }
+
+        CompletableFuture<Boolean> approvalFuture = new CompletableFuture<>();
+
+        ApplicationManager.getApplication().invokeLater(() -> {
+            MCPApprovalDialog dialog = new MCPApprovalDialog(project, toolName, arguments);
+            boolean approved = dialog.showAndGet();
+            approvalFuture.complete(approved);
+        });
+
+        try {
+            // Wait for user response with timeout
+            return approvalFuture.get(APPROVAL_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+        } catch (InterruptedException | ExecutionException | TimeoutException e) {
+            log.warn("MCP approval request timed out or was interrupted", e);
+            NotificationUtil.sendNotification(project, "MCP tool execution was cancelled due to timeout");
+            return false;
+        }
+    }
+
+    /**
+     * Dialog for requesting MCP tool execution approval
+     */
+    private static class MCPApprovalDialog extends DialogWrapper {
+        private final String toolName;
+        private final String arguments;
+
+        protected MCPApprovalDialog(@Nullable Project project, @NotNull String toolName, @NotNull String arguments) {
+            super(project, false);
+            this.toolName = toolName;
+            this.arguments = arguments;
+            setTitle("Approve MCP Tool Execution");
+            setOKButtonText("Approve");
+            setCancelButtonText("Deny");
+            init();
+        }
+
+        @Override
+        protected @Nullable JComponent createCenterPanel() {
+            JPanel panel = new JPanel(new BorderLayout());
+            panel.setBorder(JBUI.Borders.empty(10));
+            panel.setPreferredSize(new Dimension(500, 300));
+
+            // Create warning icon and message
+            JPanel headerPanel = new JPanel(new BorderLayout());
+            JBLabel iconLabel = new JBLabel(Messages.getWarningIcon());
+            headerPanel.add(iconLabel, BorderLayout.WEST);
+
+            JBLabel messageLabel = new JBLabel("<html><b>The AI assistant wants to execute the following MCP tool:</b></html>");
+            headerPanel.add(messageLabel, BorderLayout.CENTER);
+            panel.add(headerPanel, BorderLayout.NORTH);
+
+            // Create tool info panel
+            JPanel infoPanel = new JPanel(new GridBagLayout());
+            GridBagConstraints c = new GridBagConstraints();
+            c.fill = GridBagConstraints.HORIZONTAL;
+            c.insets = JBUI.insets(5);
+
+            // Tool name
+            c.gridx = 0;
+            c.gridy = 0;
+            c.weightx = 0.2;
+            infoPanel.add(new JBLabel("<html><b>Tool:</b></html>"), c);
+
+            c.gridx = 1;
+            c.weightx = 0.8;
+            infoPanel.add(new JBLabel(toolName), c);
+
+            // Arguments
+            c.gridx = 0;
+            c.gridy = 1;
+            c.weightx = 0.2;
+            c.anchor = GridBagConstraints.NORTHWEST;
+            infoPanel.add(new JBLabel("<html><b>Arguments:</b></html>"), c);
+
+            c.gridx = 1;
+            c.weightx = 0.8;
+            JTextArea argumentsArea = new JTextArea(arguments);
+            argumentsArea.setEditable(false);
+            argumentsArea.setLineWrap(true);
+            argumentsArea.setWrapStyleWord(true);
+            JBScrollPane scrollPane = new JBScrollPane(argumentsArea);
+            scrollPane.setPreferredSize(new Dimension(350, 150));
+            infoPanel.add(scrollPane, c);
+
+            panel.add(infoPanel, BorderLayout.CENTER);
+
+            // Add warning message
+            JBLabel warningLabel = new JBLabel("<html><i>Warning: Only approve if you trust this tool execution.</i></html>");
+            warningLabel.setForeground(JBColor.RED);
+            panel.add(warningLabel, BorderLayout.SOUTH);
+
+            return panel;
+        }
+
+        @Override
+        protected Action @NotNull [] createActions() {
+            return new Action[]{getOKAction(), getCancelAction()};
+        }
+
+    }
+}

--- a/src/main/java/com/devoxx/genie/service/mcp/MCPExecutionService.java
+++ b/src/main/java/com/devoxx/genie/service/mcp/MCPExecutionService.java
@@ -4,6 +4,8 @@ import com.devoxx.genie.model.mcp.MCPServer;
 import com.devoxx.genie.ui.settings.DevoxxGenieStateService;
 import com.intellij.openapi.Disposable;
 import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.project.Project;
+
 import dev.langchain4j.mcp.McpToolProvider;
 import dev.langchain4j.mcp.client.DefaultMcpClient;
 import dev.langchain4j.mcp.client.McpClient;
@@ -76,10 +78,11 @@ public class MCPExecutionService implements Disposable {
     
     /**
      * Creates tool providers for all configured MCP servers
-     * 
+     *
+     * @param project Holds the project information
      * @return A ToolProvider that includes all enabled MCP tools, or null if MCP is disabled or no servers are configured
      */
-    public ToolProvider createMCPToolProvider() {
+    public ToolProvider createMCPToolProvider(Project project) {
         log.debug("Creating MCP Tool Provider");
 
         // Get all configured MCP servers
@@ -107,9 +110,13 @@ public class MCPExecutionService implements Disposable {
         }
 
         MCPService.logDebug("Creating MCP Tool Provider with " + mcpClients.size() + " clients");
-        return McpToolProvider.builder()
+        // Create the original MCP tool provider
+        ToolProvider originalProvider = McpToolProvider.builder()
                 .mcpClients(mcpClients)
                 .build();
+
+        // Wrap it with the custom approval-requiring provider
+        return new ApprovalRequiredToolProvider(originalProvider, project);
     }
 
     /**

--- a/src/main/java/com/devoxx/genie/service/prompt/response/nonstreaming/NonStreamingPromptExecutionService.java
+++ b/src/main/java/com/devoxx/genie/service/prompt/response/nonstreaming/NonStreamingPromptExecutionService.java
@@ -155,7 +155,7 @@ public class NonStreamingPromptExecutionService {
                     MCPService.logDebug("MCP is enabled and we have active tools. Creating MCP tool provider");
 
                     // Use project-specific tool provider with filesystem access
-                    ToolProvider mcpToolProvider = MCPExecutionService.getInstance().createMCPToolProvider();
+                    ToolProvider mcpToolProvider = MCPExecutionService.getInstance().createMCPToolProvider(project);
 
                     if (mcpToolProvider != null) {
                         MCPService.logDebug("Successfully created MCP tool provider with filesystem access");

--- a/src/main/java/com/devoxx/genie/service/prompt/strategy/StreamingPromptStrategy.java
+++ b/src/main/java/com/devoxx/genie/service/prompt/strategy/StreamingPromptStrategy.java
@@ -159,7 +159,7 @@ public class StreamingPromptStrategy extends AbstractPromptExecutionStrategy {
 
                 Assistant assistant;
 
-                ToolProvider mcpToolProvider = MCPExecutionService.getInstance().createMCPToolProvider();
+                ToolProvider mcpToolProvider = MCPExecutionService.getInstance().createMCPToolProvider(project);
                 if (mcpToolProvider != null) {
                     MCPService.logDebug("Successfully created MCP tool provider with filesystem access");
 

--- a/src/main/java/com/devoxx/genie/ui/settings/DevoxxGenieStateService.java
+++ b/src/main/java/com/devoxx/genie/ui/settings/DevoxxGenieStateService.java
@@ -200,6 +200,9 @@ public final class DevoxxGenieStateService implements PersistentStateComponent<D
     @Setter
     @Getter
     private Boolean mcpDebugLogsEnabled = false;
+    @Getter
+    @Setter
+    private Boolean mcpApprovalRequired = true;
 
     // Appearance settings
     private Double lineHeight = 1.6;  // Default line height multiplier

--- a/src/main/java/com/devoxx/genie/ui/settings/mcp/MCPSettingsComponent.java
+++ b/src/main/java/com/devoxx/genie/ui/settings/mcp/MCPSettingsComponent.java
@@ -35,6 +35,7 @@ public class MCPSettingsComponent extends AbstractSettingsComponent {
     private boolean isModified = false;
     private final JCheckBox enableMcpCheckbox;
     private final JCheckBox enableDebugLogsCheckbox;
+    private final JCheckBox enableApprovalRequiredCheckbox;
 
     public MCPSettingsComponent() {
 
@@ -47,6 +48,9 @@ public class MCPSettingsComponent extends AbstractSettingsComponent {
         
         enableDebugLogsCheckbox = new JCheckBox("Enable MCP Logging");
         enableDebugLogsCheckbox.addActionListener(e -> isModified = true);
+
+        enableApprovalRequiredCheckbox = new JCheckBox("Enable Approval Required");
+        enableApprovalRequiredCheckbox.addActionListener(e -> isModified = true);
         
         setupTable();
 
@@ -67,6 +71,7 @@ public class MCPSettingsComponent extends AbstractSettingsComponent {
         JPanel checkboxPanel = new JPanel(new FlowLayout(FlowLayout.LEFT));
         checkboxPanel.add(enableMcpCheckbox);
         checkboxPanel.add(enableDebugLogsCheckbox);
+        checkboxPanel.add(enableApprovalRequiredCheckbox);
         
         // Create the top panel that combines both
         JPanel topPanel = new JPanel(new BorderLayout());
@@ -87,6 +92,7 @@ public class MCPSettingsComponent extends AbstractSettingsComponent {
             DevoxxGenieStateService stateService = DevoxxGenieStateService.getInstance();
             enableMcpCheckbox.setSelected(stateService.getMcpEnabled());
             enableDebugLogsCheckbox.setSelected(stateService.getMcpDebugLogsEnabled());
+            enableApprovalRequiredCheckbox.setSelected(stateService.getMcpApprovalRequired());
             // Reset modified flag if needed, as initial load shouldn't count as modification
             isModified = false;
         });
@@ -215,6 +221,7 @@ public class MCPSettingsComponent extends AbstractSettingsComponent {
             // Save checkbox settings
             stateService.setMcpEnabled(enableMcpCheckbox.isSelected());
             stateService.setMcpDebugLogsEnabled(enableDebugLogsCheckbox.isSelected());
+            stateService.setMcpApprovalRequired(enableApprovalRequiredCheckbox.isSelected());
             
             // Refresh the tool window visibility if MCP enabled state changed
             if (oldMcpEnabled != enableMcpCheckbox.isSelected()) {
@@ -251,7 +258,8 @@ public class MCPSettingsComponent extends AbstractSettingsComponent {
         DevoxxGenieStateService stateService = DevoxxGenieStateService.getInstance();
         return isModified || 
                enableMcpCheckbox.isSelected() != stateService.getMcpEnabled() ||
-               enableDebugLogsCheckbox.isSelected() != stateService.getMcpDebugLogsEnabled();
+               enableDebugLogsCheckbox.isSelected() != stateService.getMcpDebugLogsEnabled() ||
+               enableApprovalRequiredCheckbox.isSelected() != stateService.getMcpApprovalRequired();
     }
     
     /**
@@ -429,6 +437,7 @@ public class MCPSettingsComponent extends AbstractSettingsComponent {
         loadCurrentSettings();
         enableMcpCheckbox.setSelected(stateService.getMcpEnabled());
         enableDebugLogsCheckbox.setSelected(stateService.getMcpDebugLogsEnabled());
+        enableApprovalRequiredCheckbox.setSelected(stateService.getMcpApprovalRequired());
         isModified = false;
         
         // Find and update the Open MCP Log Panel button if it exists


### PR DESCRIPTION
By default set Approval required for MCP in the settings.
![image](https://github.com/user-attachments/assets/c8c536fe-2fcd-43ee-bf8f-de869278100e)

Prompt: 'create a directory 'temp' in this repository'
The command is shown which will be executed, you can approve or deny.
![Screenshot from 2025-07-06 12-50-37](https://github.com/user-attachments/assets/b76cc304-b888-4511-aad1-e993e93604b9)

If you deny, the LLM will probably just show you which command needs to be executed.

This provides a safe way for using MCP with DevoxxGenie.



