### PR TITLE
Match Intellij IDEA releases until 252.*

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -127,7 +127,7 @@ tasks {
 
     patchPluginXml {
         sinceBuild.set("233")
-        untilBuild.set("251.*")
+        untilBuild.set("252.*")
     }
 
     shadowJar {


### PR DESCRIPTION
The current plugin release (v0.6.7) does not support IDE releases matching 252.*, e.g. the current EAP release. Updated to match releases up to and including 252.

See also https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html#platformVersions.