### PR TITLE
Issue 746 - use temperature and topP 1,0 for azure openai reasoning models

### DIFF
--- a/src/main/java/com/devoxx/genie/chatmodel/cloud/azureopenai/AzureOpenAIChatModelFactory.java
+++ b/src/main/java/com/devoxx/genie/chatmodel/cloud/azureopenai/AzureOpenAIChatModelFactory.java
@@ -18,7 +18,7 @@ import java.util.function.Function;
 
 public class AzureOpenAIChatModelFactory implements ChatModelFactory {
 
-    private final ModelProvider MODEL_PROVIDER = ModelProvider.AzureOpenAI;;
+    private final ModelProvider MODEL_PROVIDER = ModelProvider.AzureOpenAI;
 
     @Override
     public ChatLanguageModel createChatModel(@NotNull ChatModel chatModel) {

--- a/src/test/java/com/devoxx/genie/chatmodel/cloud/azureopenai/AzureOpenAiChatModelFactoryTest.java
+++ b/src/test/java/com/devoxx/genie/chatmodel/cloud/azureopenai/AzureOpenAiChatModelFactoryTest.java
@@ -6,6 +6,7 @@ import com.devoxx.genie.model.LanguageModel;
 import com.devoxx.genie.ui.settings.DevoxxGenieStateService;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.testFramework.ServiceContainerUtil;
+import dev.langchain4j.model.azure.AzureOpenAiChatModel;
 import dev.langchain4j.model.chat.ChatLanguageModel;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -38,12 +39,13 @@ class AzureOpenAiChatModelFactoryTest extends AbstractLightPlatformTestCase {
         AzureOpenAIChatModelFactory factory = new AzureOpenAIChatModelFactory();
         ChatModel chatModel = new ChatModel();
         chatModel.setModelName("gpt-3.5-turbo");
-        chatModel.setTemperature(0.7);
+        chatModel.setTemperature(0.6);
         chatModel.setMaxTokens(100);
 
         ChatLanguageModel result = factory.createChatModel(chatModel);
 
-        assertThat(result).isNotNull();
+        // cannot verify more because model does not offer more access to data inside
+        assertThat(result).isInstanceOf(AzureOpenAiChatModel.class);
     }
 
     @Test


### PR DESCRIPTION
PullRequest to fix #746 