### PR TITLE
[Issue 731] Fix duplicated user message in streaming mode

### DIFF
--- a/src/main/java/com/devoxx/genie/service/prompt/strategy/StreamingPromptStrategy.java
+++ b/src/main/java/com/devoxx/genie/service/prompt/strategy/StreamingPromptStrategy.java
@@ -14,6 +14,7 @@ import com.devoxx.genie.service.prompt.threading.ThreadPoolManager;
 import com.devoxx.genie.ui.panel.PromptOutputPanel;
 import com.devoxx.genie.ui.util.NotificationUtil;
 import com.devoxx.genie.ui.webview.ConversationWebViewController;
+import com.devoxx.genie.util.TemplateVariableEscaper;
 import com.intellij.openapi.project.Project;
 import dev.langchain4j.memory.ChatMemory;
 import dev.langchain4j.model.chat.StreamingChatLanguageModel;
@@ -79,9 +80,6 @@ public class StreamingPromptStrategy extends AbstractPromptExecutionStrategy {
 
         // Prepare memory which already adds the user message
         prepareMemory(context);
-
-        // We need to add this to chat memory when streaming response
-        chatMemoryManager.addUserMessage(context);
 
         // Create the streaming handler that will process chunks of response
         StreamingResponseHandler streamingResponseHandler;
@@ -181,7 +179,10 @@ public class StreamingPromptStrategy extends AbstractPromptExecutionStrategy {
                             .build();
                 }
 
-                TokenStream chat = assistant.chat(context.getUserPrompt());
+                String userMessage = context.getUserMessage().singleText();
+                String cleanText = TemplateVariableEscaper.escape(userMessage);
+
+                TokenStream chat = assistant.chat(cleanText);
 
                 chat.onPartialResponse(streamingResponseHandler::onPartialResponse)
                     .onToolExecuted(ToolExecution::request)

--- a/src/test/java/com/devoxx/genie/service/prompt/PromptMessageFlowIntegrationTest.java
+++ b/src/test/java/com/devoxx/genie/service/prompt/PromptMessageFlowIntegrationTest.java
@@ -35,7 +35,7 @@ public class PromptMessageFlowIntegrationTest extends AbstractLightPlatformTestC
     
     @Spy
     @InjectMocks
-    private MessageCreationService messageCreationService;
+    private MessageCreationService spyMessageCreationService;
     
     @Captor
     private ArgumentCaptor<ChatMessageContext> contextCaptor;
@@ -59,7 +59,7 @@ public class PromptMessageFlowIntegrationTest extends AbstractLightPlatformTestC
                     .thenReturn(mockChatMemoryManager);
                     
             messageCreationServiceStaticMock.when(MessageCreationService::getInstance)
-                    .thenReturn(messageCreationService);
+                    .thenReturn(spyMessageCreationService);
         }
         
         // Set up a strategy with mocked dependencies using anonymous class for test
@@ -67,7 +67,7 @@ public class PromptMessageFlowIntegrationTest extends AbstractLightPlatformTestC
             {
                 // Manually inject mocked dependencies
                 this.chatMemoryManager = mockChatMemoryManager;
-                this.messageCreationService = messageCreationService;
+                this.messageCreationService = spyMessageCreationService;
                 // For this test we don't need to mock ThreadPoolManager or PromptExecutionService
                 // since we're only testing prepareMemory
             }
@@ -117,7 +117,7 @@ public class PromptMessageFlowIntegrationTest extends AbstractLightPlatformTestC
         verify(mockChatMemoryManager).prepareMemory(testContext);
         
         // Verify MessageCreationService.addUserMessageToContext was called
-        verify(messageCreationService).addUserMessageToContext(testContext);
+        verify(spyMessageCreationService).addUserMessageToContext(testContext);
         
         // Verify addUserMessage was called after context enrichment
         verify(mockChatMemoryManager).addUserMessage(testContext);
@@ -142,7 +142,7 @@ public class PromptMessageFlowIntegrationTest extends AbstractLightPlatformTestC
         testContext.setUserMessage(existingMessage);
         
         // Act - call the context enrichment method directly
-        messageCreationService.addUserMessageToContext(testContext);
+        spyMessageCreationService.addUserMessageToContext(testContext);
         
         // Assert - verify the existing message wasn't changed
         assertSame(String.valueOf(existingMessage), testContext.getUserMessage(),


### PR DESCRIPTION
Manual addiation to history removed and usermessage exchanged with the contextualized message. Flow in streaming strategy now closer resembles the one in non-streaming strategy.

BEFORE:
```
{
  "model" : "Mistral",
  "messages" : [ {
    "role" : "system",
    "content" : "You are a software developer IDEA plugin with expert knowledge in any programming language.\n\nThe Devoxx Genie is open source and available at https://github.com/devoxx/DevoxxGenieIDEAPlugin.\nYou can follow us
 on Bluesky @ https://bsky.app/profile/devoxxgenie.bsky.social.\nDo not include any more info which might be incorrect, like discord, documentation or other websites.\nOnly provide info that is correct and relevant to the code o
r plugin.\n\nAlways use markdown to format your prompt. For example, use **bold** or *italic* text and ``` code blocks ```.<MCP_INSTRUCTION>The project base directory is C:/Users/fchill/IdeaProjects/untitled\nMake sure to use this information for your MCP tooling calls\n</MCP_INSTRUCTION>"
  }, {
    "role" : "user",
    "content" : "<ProjectPath>\nC:/Users/fchill/IdeaProjects/untitled</ProjectPath><UserPrompt>\ntest\n</UserPrompt>\n\n"
  }, {
    "role" : "user",
    "content" : "test"
  } ],
  "temperature" : 0.0,
  "top_p" : 0.9,
  "stream" : true,
  "stream_options" : {
    "include_usage" : true
  }
}
```

AFTER:
```
{
  "model" : "Mistral",
  "messages" : [ {
    "role" : "system",
    "content" : "You are a software developer IDEA plugin with expert knowledge in any programming language.\n\nThe Devoxx Genie is open source and available at https://github.com/devoxx/DevoxxGenieIDEAPlugin.\nYou can follow us
 on Bluesky @ https://bsky.app/profile/devoxxgenie.bsky.social.\nDo not include any more info which might be incorrect, like discord, documentation or other websites.\nOnly provide info that is correct and relevant to the code o
r plugin.\n\nAlways use markdown to format your prompt. For example, use **bold** or *italic* text and ``` code blocks ```.<MCP_INSTRUCTION>The project base directory is C:/Users/fchill/IdeaProjects/untitled\nMake sure to use this information for your MCP tooling calls\n</MCP_INSTRUCTION>"
  }, {
    "role" : "user",
    "content" : "<ProjectPath>\nC:/Users/fchill/IdeaProjects/untitled</ProjectPath><UserPrompt>\ntest\n</UserPrompt>\n\n"
  } ],
  "temperature" : 0.0,
  "top_p" : 0.9,
  "stream" : true,
  "stream_options" : {
    "include_usage" : true
  }
}
```

History is also still working:
<think> Okay, the user asked, "What is the word?" after the previous interaction where they were told the word was "BIRD!". Let me think about how to respond.