### PR TITLE
fix: add fallback for empty submit and newline shortcuts

### DIFF
--- a/src/main/java/com/devoxx/genie/ui/component/input/CommandAutoCompleteTextField.java
+++ b/src/main/java/com/devoxx/genie/ui/component/input/CommandAutoCompleteTextField.java
@@ -108,6 +108,13 @@ public class CommandAutoCompleteTextField extends JBTextArea implements CustomPr
                 newlineShortcutString = stateService.getNewlineShortcutWindows();
             }
 
+            if (submitShortcutString == null || submitShortcutString.isEmpty()) {
+                submitShortcutString = "shift ENTER";
+            }
+            if (newlineShortcutString == null || newlineShortcutString.isEmpty()) {
+                newlineShortcutString = SystemInfo.isMac ? "meta ENTER" : "ctrl ENTER";
+            }
+
             KeyStroke submitKeyStroke = KeyStroke.getKeyStroke(submitShortcutString);
             KeyStroke newlineKeyStroke = KeyStroke.getKeyStroke(newlineShortcutString);
             

--- a/src/main/java/com/devoxx/genie/ui/component/input/PromptInputArea.java
+++ b/src/main/java/com/devoxx/genie/ui/component/input/PromptInputArea.java
@@ -142,6 +142,9 @@ public class PromptInputArea extends JPanel implements ShortcutChangeListener, N
     }
 
     private void setPlaceholderWithKeyboardShortcut(String shortcut) {
+        if (shortcut == null || shortcut.isEmpty()) {
+            shortcut = "shift Enter";
+        }
         // Clean up the shortcut text
         shortcut = shortcut.replace("pressed", "+")
                 .replace("meta", "command");
@@ -160,6 +163,10 @@ public class PromptInputArea extends JPanel implements ShortcutChangeListener, N
             newlineShortcut = DevoxxGenieStateService.getInstance().getNewlineShortcutLinux();
         } else {
             newlineShortcut = DevoxxGenieStateService.getInstance().getNewlineShortcutMac();
+        }
+
+        if (newlineShortcut == null || newlineShortcut.isEmpty()) {
+            newlineShortcut = SystemInfo.isMac ? "meta Enter" : "ctrl Enter";
         }
         
         // Format the newline shortcut text


### PR DESCRIPTION
Adds a fallback for null or empty submit or newline shortcuts.

On v0.6.9, macOS 15.5, IntelliJ IDEA 2025.1.3, the plugin crashed with a nullpointer in `PromptInputArea`.

Fixing this made the plugin load again, the shortcuts to send a prompt from the chat window did not work however.

Adding a fallback in `CommandAutoCompleteTextField` fixed this issue as well.