### PR TITLE
Fix welcome text not cleared on first chat message

### DIFF
--- a/src/main/java/com/devoxx/genie/ui/panel/conversation/ConversationUIController.java
+++ b/src/main/java/com/devoxx/genie/ui/panel/conversation/ConversationUIController.java
@@ -109,7 +109,7 @@ public class ConversationUIController implements CustomPromptChangeListener {
      * Used when restoring conversation history or submitting the first prompt.
      */
     public void clearWithoutWelcome() {
-        messageRenderer.clear();
+        messageRenderer.clearWithoutWelcome();
     }
 
     /**

--- a/src/main/java/com/devoxx/genie/ui/panel/conversation/MessageRenderer.java
+++ b/src/main/java/com/devoxx/genie/ui/panel/conversation/MessageRenderer.java
@@ -91,6 +91,8 @@ public class MessageRenderer implements FileReferencesListener {
      * Used when restoring conversation history.
      */
     public void clearWithoutWelcome() {
+        // Cancel any pending deferred welcome load to prevent it from overwriting chat messages
+        webViewController.cancelPendingWelcomeLoad();
         // Set the restoration flag to prevent welcome content during theme changes
         webViewController.setRestoringConversation(true);
         webViewController.clearConversation();

--- a/src/main/java/com/devoxx/genie/ui/webview/ConversationWebViewController.java
+++ b/src/main/java/com/devoxx/genie/ui/webview/ConversationWebViewController.java
@@ -647,6 +647,14 @@ public class ConversationWebViewController implements ThemeChangeNotifier, MCPLo
     }
     
     /**
+     * Cancel any pending welcome content load.
+     * This prevents a deferred welcome load from overwriting chat messages.
+     */
+    public void cancelPendingWelcomeLoad() {
+        messageRenderer.cancelPendingWelcomeLoad();
+    }
+
+    /**
      * Mark that conversation restoration is starting.
      * This prevents automatic welcome content loading during restoration.
      */


### PR DESCRIPTION
## Summary
- Fix `ConversationUIController.clearWithoutWelcome()` calling `messageRenderer.clear()` instead of `clearWithoutWelcome()`, which prevented the `restoringConversation` flag from being set and allowed theme changes to re-inject welcome content
- Fix race condition where deferred welcome loading could overwrite chat messages by adding a cancellation flag and a JS-level guard that only injects welcome HTML when no `.message-pair` elements exist

## Test plan
- [ ] Open plugin, immediately submit a prompt before welcome fully loads — message should appear, not welcome
- [ ] Submit a prompt, then change IDE theme — conversation should remain, welcome should not reappear
- [ ] Click "+" for new conversation after chatting — welcome should appear correctly
- [ ] Select a conversation from history, change theme — restored conversation should persist

🤖 Generated with [Claude Code](https://claude.com/claude-code)