### PR TITLE
Fix MCP debug logging: show JSON-RPC traffic in MCP Logs panel

### DIFF
--- a/core/src/main/java/dev/langchain4j/mcp/client/transport/http/McpRequestLoggingInterceptor.java
+++ b/core/src/main/java/dev/langchain4j/mcp/client/transport/http/McpRequestLoggingInterceptor.java
@@ -9,6 +9,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
@@ -16,6 +17,11 @@ class McpRequestLoggingInterceptor implements Interceptor {
 
     private static final Logger log = LoggerFactory.getLogger(McpRequestLoggingInterceptor.class);
     private static final Logger trafficLog = LoggerFactory.getLogger("MCP");
+    private final Consumer<String> trafficConsumer;
+
+    McpRequestLoggingInterceptor(Consumer<String> trafficConsumer) {
+        this.trafficConsumer = trafficConsumer;
+    }
 
     @Override
     public Response intercept(Chain chain) throws IOException {
@@ -32,6 +38,9 @@ class McpRequestLoggingInterceptor implements Interceptor {
                     request.url(),
                     getHeaders(request.headers()),
                     getBody(request));
+            if (trafficConsumer != null) {
+                trafficConsumer.accept("> " + getBody(request));
+            }
         } catch (Exception e) {
             log.warn("Error while logging request: {}", e.getMessage());
         }

--- a/core/src/main/java/dev/langchain4j/mcp/client/transport/http/SseEventListener.java
+++ b/core/src/main/java/dev/langchain4j/mcp/client/transport/http/SseEventListener.java
@@ -11,6 +11,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.concurrent.CompletableFuture;
+import java.util.function.Consumer;
 
 public class SseEventListener extends EventSourceListener {
 
@@ -22,16 +23,19 @@ public class SseEventListener extends EventSourceListener {
     private final CompletableFuture<String> initializationFinished;
     private final McpOperationHandler messageHandler;
     private final Runnable onFailure;
+    private final Consumer<String> trafficConsumer;
 
     public SseEventListener(
             McpOperationHandler messageHandler,
             boolean logEvents,
             CompletableFuture initializationFinished,
-            Runnable onFailure) {
+            Runnable onFailure,
+            Consumer<String> trafficConsumer) {
         this.messageHandler = messageHandler;
         this.logEvents = logEvents;
         this.initializationFinished = initializationFinished;
         this.onFailure = onFailure;
+        this.trafficConsumer = trafficConsumer;
     }
 
     @Override
@@ -44,6 +48,9 @@ public class SseEventListener extends EventSourceListener {
         if (type.equals("message")) {
             if (logEvents) {
                 trafficLog.info("< {}", data);
+                if (trafficConsumer != null) {
+                    trafficConsumer.accept("< " + data);
+                }
             }
             try {
                 JsonNode jsonNode = OBJECT_MAPPER.readTree(data);

--- a/src/main/java/com/devoxx/genie/service/mcp/MCPTrafficLogger.java
+++ b/src/main/java/com/devoxx/genie/service/mcp/MCPTrafficLogger.java
@@ -1,0 +1,138 @@
+package com.devoxx.genie.service.mcp;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.Marker;
+
+import java.util.function.Consumer;
+
+/**
+ * A delegating SLF4J Logger that wraps the real "MCP" logger and also
+ * forwards traffic-related log calls to a {@link Consumer}.
+ * <p>
+ * {@link dev.langchain4j.mcp.client.transport.http.StreamableHttpMcpTransport}
+ * is a pre-compiled class from the langchain4j-mcp jar. It accepts a custom
+ * {@code Logger} via its builder ({@code .logger(Logger)}). Internally it logs
+ * outgoing requests as {@code trafficLog.info("Request: {}", body)} and
+ * incoming responses as {@code trafficLog.info("< {}", data)}.
+ * <p>
+ * This wrapper delegates every call to the real logger unchanged, and
+ * additionally calls the {@code trafficConsumer} for {@code info(String, Object)}
+ * and {@code debug(String, Object)} invocations so that traffic lines reach the
+ * MCP Log Panel.
+ */
+public class MCPTrafficLogger implements Logger {
+
+    private final Logger delegate;
+    private final Consumer<String> trafficConsumer;
+
+    public MCPTrafficLogger(Consumer<String> trafficConsumer) {
+        this.delegate = LoggerFactory.getLogger("MCP");
+        this.trafficConsumer = trafficConsumer;
+    }
+
+    // ── traffic-intercepting overrides ──────────────────────────────────
+
+    @Override
+    public void info(String format, Object arg) {
+        delegate.info(format, arg);
+        if (trafficConsumer != null) {
+            forwardToConsumer(format, arg);
+        }
+    }
+
+    @Override
+    public void debug(String format, Object arg) {
+        delegate.debug(format, arg);
+        if (trafficConsumer != null) {
+            forwardToConsumer(format, arg);
+        }
+    }
+
+    /**
+     * Extract direction prefix from the format pattern and forward the
+     * formatted message to the traffic consumer.
+     * <p>
+     * Expected patterns from StreamableHttpMcpTransport:
+     * <ul>
+     *   <li>{@code "Request: {}"} → outgoing, prefix with {@code "> "}</li>
+     *   <li>{@code "> {}"} → outgoing, already prefixed</li>
+     *   <li>{@code "< {}"} → incoming, already prefixed</li>
+     * </ul>
+     */
+    private void forwardToConsumer(String format, Object arg) {
+        String message = String.valueOf(arg);
+        if (format.startsWith("> ") || format.startsWith("Request")) {
+            trafficConsumer.accept("> " + message);
+        } else if (format.startsWith("< ")) {
+            trafficConsumer.accept("< " + message);
+        }
+    }
+
+    // ── pure delegation ─────────────────────────────────────────────────
+
+    @Override public String getName() { return delegate.getName(); }
+
+    @Override public boolean isTraceEnabled() { return delegate.isTraceEnabled(); }
+    @Override public boolean isTraceEnabled(Marker marker) { return delegate.isTraceEnabled(marker); }
+    @Override public void trace(String msg) { delegate.trace(msg); }
+    @Override public void trace(String format, Object arg) { delegate.trace(format, arg); }
+    @Override public void trace(String format, Object arg1, Object arg2) { delegate.trace(format, arg1, arg2); }
+    @Override public void trace(String format, Object... arguments) { delegate.trace(format, arguments); }
+    @Override public void trace(String msg, Throwable t) { delegate.trace(msg, t); }
+    @Override public void trace(Marker marker, String msg) { delegate.trace(marker, msg); }
+    @Override public void trace(Marker marker, String format, Object arg) { delegate.trace(marker, format, arg); }
+    @Override public void trace(Marker marker, String format, Object arg1, Object arg2) { delegate.trace(marker, format, arg1, arg2); }
+    @Override public void trace(Marker marker, String format, Object... arguments) { delegate.trace(marker, format, arguments); }
+    @Override public void trace(Marker marker, String msg, Throwable t) { delegate.trace(marker, msg, t); }
+
+    @Override public boolean isDebugEnabled() { return delegate.isDebugEnabled(); }
+    @Override public boolean isDebugEnabled(Marker marker) { return delegate.isDebugEnabled(marker); }
+    @Override public void debug(String msg) { delegate.debug(msg); }
+    @Override public void debug(String format, Object arg1, Object arg2) { delegate.debug(format, arg1, arg2); }
+    @Override public void debug(String format, Object... arguments) { delegate.debug(format, arguments); }
+    @Override public void debug(String msg, Throwable t) { delegate.debug(msg, t); }
+    @Override public void debug(Marker marker, String msg) { delegate.debug(marker, msg); }
+    @Override public void debug(Marker marker, String format, Object arg) { delegate.debug(marker, format, arg); }
+    @Override public void debug(Marker marker, String format, Object arg1, Object arg2) { delegate.debug(marker, format, arg1, arg2); }
+    @Override public void debug(Marker marker, String format, Object... arguments) { delegate.debug(marker, format, arguments); }
+    @Override public void debug(Marker marker, String msg, Throwable t) { delegate.debug(marker, msg, t); }
+
+    @Override public boolean isInfoEnabled() { return delegate.isInfoEnabled(); }
+    @Override public boolean isInfoEnabled(Marker marker) { return delegate.isInfoEnabled(marker); }
+    @Override public void info(String msg) { delegate.info(msg); }
+    @Override public void info(String format, Object arg1, Object arg2) { delegate.info(format, arg1, arg2); }
+    @Override public void info(String format, Object... arguments) { delegate.info(format, arguments); }
+    @Override public void info(String msg, Throwable t) { delegate.info(msg, t); }
+    @Override public void info(Marker marker, String msg) { delegate.info(marker, msg); }
+    @Override public void info(Marker marker, String format, Object arg) { delegate.info(marker, format, arg); }
+    @Override public void info(Marker marker, String format, Object arg1, Object arg2) { delegate.info(marker, format, arg1, arg2); }
+    @Override public void info(Marker marker, String format, Object... arguments) { delegate.info(marker, format, arguments); }
+    @Override public void info(Marker marker, String msg, Throwable t) { delegate.info(marker, msg, t); }
+
+    @Override public boolean isWarnEnabled() { return delegate.isWarnEnabled(); }
+    @Override public boolean isWarnEnabled(Marker marker) { return delegate.isWarnEnabled(marker); }
+    @Override public void warn(String msg) { delegate.warn(msg); }
+    @Override public void warn(String format, Object arg) { delegate.warn(format, arg); }
+    @Override public void warn(String format, Object arg1, Object arg2) { delegate.warn(format, arg1, arg2); }
+    @Override public void warn(String format, Object... arguments) { delegate.warn(format, arguments); }
+    @Override public void warn(String msg, Throwable t) { delegate.warn(msg, t); }
+    @Override public void warn(Marker marker, String msg) { delegate.warn(marker, msg); }
+    @Override public void warn(Marker marker, String format, Object arg) { delegate.warn(marker, format, arg); }
+    @Override public void warn(Marker marker, String format, Object arg1, Object arg2) { delegate.warn(marker, format, arg1, arg2); }
+    @Override public void warn(Marker marker, String format, Object... arguments) { delegate.warn(marker, format, arguments); }
+    @Override public void warn(Marker marker, String msg, Throwable t) { delegate.warn(marker, msg, t); }
+
+    @Override public boolean isErrorEnabled() { return delegate.isErrorEnabled(); }
+    @Override public boolean isErrorEnabled(Marker marker) { return delegate.isErrorEnabled(marker); }
+    @Override public void error(String msg) { delegate.error(msg); }
+    @Override public void error(String format, Object arg) { delegate.error(format, arg); }
+    @Override public void error(String format, Object arg1, Object arg2) { delegate.error(format, arg1, arg2); }
+    @Override public void error(String format, Object... arguments) { delegate.error(format, arguments); }
+    @Override public void error(String msg, Throwable t) { delegate.error(msg, t); }
+    @Override public void error(Marker marker, String msg) { delegate.error(marker, msg); }
+    @Override public void error(Marker marker, String format, Object arg) { delegate.error(marker, format, arg); }
+    @Override public void error(Marker marker, String format, Object arg1, Object arg2) { delegate.error(marker, format, arg1, arg2); }
+    @Override public void error(Marker marker, String format, Object... arguments) { delegate.error(marker, format, arguments); }
+    @Override public void error(Marker marker, String msg, Throwable t) { delegate.error(marker, msg, t); }
+}

--- a/src/main/java/com/devoxx/genie/ui/settings/mcp/MCPSettingsConfigurable.java
+++ b/src/main/java/com/devoxx/genie/ui/settings/mcp/MCPSettingsConfigurable.java
@@ -1,8 +1,11 @@
 package com.devoxx.genie.ui.settings.mcp;
 
+import com.devoxx.genie.service.mcp.MCPService;
 import com.devoxx.genie.ui.topic.AppTopics;
 import com.intellij.openapi.options.Configurable;
 import com.intellij.openapi.project.Project;
+import com.intellij.openapi.wm.ToolWindow;
+import com.intellij.openapi.wm.ToolWindowManager;
 import com.intellij.util.messages.MessageBus;
 import org.jetbrains.annotations.Nls;
 import org.jetbrains.annotations.NotNull;
@@ -15,10 +18,12 @@ import javax.swing.*;
  */
 public class MCPSettingsConfigurable implements Configurable {
 
+    private final Project project;
     private final MessageBus messageBus;
     private MCPSettingsComponent mcpSettingsComponent;
 
     public MCPSettingsConfigurable(@NotNull Project project) {
+        this.project = project;
         this.messageBus = project.getMessageBus();
     }
 
@@ -44,9 +49,18 @@ public class MCPSettingsConfigurable implements Configurable {
     public void apply() {
         if (mcpSettingsComponent != null) {
             mcpSettingsComponent.apply();
-            
+
             // TODO Check if things have changed, if so Notify listeners that settings have changed
             messageBus.syncPublisher(AppTopics.SETTINGS_CHANGED_TOPIC).settingsChanged(true);
+
+            // Auto-open the MCP Logs panel when debug logging is enabled
+            if (MCPService.isDebugLogsEnabled()) {
+                ToolWindow toolWindow = ToolWindowManager.getInstance(project)
+                        .getToolWindow("DevoxxGenieMCPLogs");
+                if (toolWindow != null) {
+                    toolWindow.show();
+                }
+            }
         }
     }
 

--- a/src/main/java/com/devoxx/genie/ui/topic/AppTopics.java
+++ b/src/main/java/com/devoxx/genie/ui/topic/AppTopics.java
@@ -45,6 +45,9 @@ public class AppTopics {
     public static final Topic<MCPLoggingMessage> MCP_LOGGING_MSG =
             Topic.create("mcpLoggingMessage", MCPLoggingMessage.class);
 
+    public static final Topic<MCPLoggingMessage> MCP_TRAFFIC_MSG =
+            Topic.create("mcpTrafficMessage", MCPLoggingMessage.class);
+
     public static final Topic<FileReferencesListener> FILE_REFERENCES_TOPIC =
             Topic.create("fileReferences", FileReferencesListener.class);
 


### PR DESCRIPTION
## Summary

- Fix MCP Log Panel not showing raw JSON-RPC request/response traffic (`{"jsonrpc":"2.0","method":"tools/call",...}`) — the `MCPLogMessageHandler` only receives `notifications/message`, not actual wire traffic
- Add `Consumer<String>` trafficConsumer callback to all three transport types (STDIO, HTTP SSE, Streamable HTTP) to forward raw JSON-RPC lines to the MCP Log Panel
- Separate JSON-RPC traffic from LLM notifications using a dedicated `MCP_TRAFFIC_MSG` topic so traffic only appears in the MCP Logs panel, not the MCP Activity view in the chat
- Pretty-print JSON when double-clicking log entries to open them in editor tabs
- Auto-open MCP Logs tool window when debug logging is enabled in settings
- Add `logHandler(MCPLogMessageHandler)` to HTTP SSE and Streamable HTTP client builders (was only on STDIO)

## Test plan

- [ ] Enable MCP debug logging in Settings > MCP Settings
- [ ] Verify the MCP Logs tool window auto-opens
- [ ] Configure a STDIO MCP server and interact with it — verify raw JSON-RPC requests (`> {...}`) and responses (`< {...}`) appear color-coded in the MCP Logs panel
- [ ] Verify the MCP Activity view in the chat only shows LLM notification messages, not JSON-RPC traffic
- [ ] Double-click a JSON-RPC log entry and verify it opens as pretty-printed JSON in an editor tab
- [ ] Test with HTTP SSE and Streamable HTTP transports if available

🤖 Generated with [Claude Code](https://claude.com/claude-code)