### PR TITLE
Fix: Pass context window (numCtx) to Ollama - Fixes #804

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 - Issue #698: Fix black screen after idle — WebView sleep/wake recovery with proper resource disposal (#824)
+- Issue #804: Pass context window (numCtx) to Ollama to use model's full context instead of 4096 default
 - MCP "Test Connection & Fetch Tools" no longer blocks the IDE; runs with cancellable progress dialog and fixes MCP client resource leak on error (#826)
 - Fix MCP debug logging: show JSON-RPC traffic in MCP Logs panel (#829)
 - Fix welcome text not cleared on first chat message (#825)

--- a/src/main/java/com/devoxx/genie/chatmodel/ChatModelProvider.java
+++ b/src/main/java/com/devoxx/genie/chatmodel/ChatModelProvider.java
@@ -54,6 +54,11 @@ public class ChatModelProvider {
         LanguageModel languageModel = chatMessageContext.getLanguageModel();
         customChatModel.setModelName(languageModel.getModelName() == null ? TEST_MODEL : languageModel.getModelName());
 
+        // Set context window if available (for providers like Ollama that support it)
+        if (languageModel.getInputMaxTokens() > 0) {
+            customChatModel.setContextWindow(languageModel.getInputMaxTokens());
+        }
+
         setLocalBaseUrl(languageModel, customChatModel, stateService);
 
         return customChatModel;

--- a/src/main/java/com/devoxx/genie/chatmodel/local/ollama/OllamaChatModelFactory.java
+++ b/src/main/java/com/devoxx/genie/chatmodel/local/ollama/OllamaChatModelFactory.java
@@ -24,26 +24,38 @@ public class OllamaChatModelFactory extends LocalChatModelFactory {
     @Override
     public ChatModel createChatModel(@NotNull CustomChatModel customChatModel) {
 
-        return OllamaChatModel.builder()
+        var builder = OllamaChatModel.builder()
                 .baseUrl(DevoxxGenieStateService.getInstance().getOllamaModelUrl())
                 .modelName(customChatModel.getModelName())
                 .temperature(customChatModel.getTemperature())
                 .topP(customChatModel.getTopP())
                 .maxRetries(customChatModel.getMaxRetries())
                 .timeout(Duration.ofSeconds(customChatModel.getTimeout()))
-                .listeners(getListener())
-                .build();
+                .listeners(getListener());
+
+        // Pass context window to Ollama if available (fixes issue #804)
+        if (customChatModel.getContextWindow() != null) {
+            builder.numCtx(customChatModel.getContextWindow());
+        }
+
+        return builder.build();
     }
 
     @Override
     public StreamingChatModel createStreamingChatModel(@NotNull CustomChatModel customChatModel) {
-        return OllamaStreamingChatModel.builder()
+        var builder = OllamaStreamingChatModel.builder()
                 .baseUrl(DevoxxGenieStateService.getInstance().getOllamaModelUrl())
                 .modelName(customChatModel.getModelName())
                 .temperature(customChatModel.getTemperature())
                 .topP(customChatModel.getTopP())
-                .timeout(Duration.ofSeconds(customChatModel.getTimeout()))
-                .build();
+                .timeout(Duration.ofSeconds(customChatModel.getTimeout()));
+
+        // Pass context window to Ollama if available (fixes issue #804)
+        if (customChatModel.getContextWindow() != null) {
+            builder.numCtx(customChatModel.getContextWindow());
+        }
+
+        return builder.build();
     }
 
     @Override

--- a/src/main/java/com/devoxx/genie/model/CustomChatModel.java
+++ b/src/main/java/com/devoxx/genie/model/CustomChatModel.java
@@ -14,4 +14,5 @@ public class CustomChatModel {
     private int maxTokens = Constant.MAX_OUTPUT_TOKENS;
     private int maxRetries = Constant.MAX_RETRIES;
     private int timeout = Constant.TIMEOUT;
+    private Integer contextWindow; // Context window size (null = use provider default)
 }


### PR DESCRIPTION
## Summary
Fixes #804 - Ollama was using the default 4096 token context window instead of the model's actual maximum context size.

## Problem
The plugin correctly retrieves the model's context window from Ollama's `/api/show` endpoint but was not passing it to LangChain4j when creating chat model instances. This caused Ollama to default to 4096 tokens even for models with much larger context windows (e.g., llama3.2:128k with 128k tokens).

## Solution
### Changes Made:
1. **Added `contextWindow` field to `CustomChatModel`** - Stores the model's context window size (null = use provider default)
2. **Updated `ChatModelProvider.initChatModel()`** - Populates `contextWindow` from `LanguageModel.inputMaxTokens` 
3. **Modified `OllamaChatModelFactory`** - Both `createChatModel()` and `createStreamingChatModel()` now pass `numCtx` to the LangChain4j builders when available
4. **Updated CHANGELOG.md** - Added entry under version 0.8.1

### Technical Details
The fix uses LangChain4j's `numCtx()` builder method which passes the `num_ctx` parameter to Ollama's API:
```java
var builder = OllamaChatModel.builder()
    .baseUrl(...)
    .modelName(...)
    // ... other params ...

if (customChatModel.getContextWindow() != null) {
    builder.numCtx(customChatModel.getContextWindow());
}

return builder.build();
```

## Testing
- ✅ Code compiles successfully
- ✅ All Ollama-related tests pass
- ✅ Verified LangChain4j 1.10.0 supports `numCtx()` method

## Impact
This ensures models like llama3.2:128k properly use their full 128k context window instead of defaulting to 4096 tokens, significantly improving the ability to handle larger contexts.

## References
- Issue: #804
- LangChain4j Ollama Documentation: https://docs.langchain4j.dev/integrations/language-models/ollama/