### PR TITLE
fix: preserve image attachments through entire prompt pipeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project will be documented in this file.
 - Filter MCP Activity to only show tool calls and log messages, excluding redundant full AI responses
 
 ### Fixed
+- Fix image attachments not sent to LLM: images were stripped at multiple points (FileListManager cleared prematurely, multimodal content dropped by chat memory and AiServices text-only interface)
 - Issue #698: Fix black screen after idle — WebView sleep/wake recovery with proper resource disposal (#824)
 - Issue #804: Pass context window (numCtx) to Ollama to use model's full context instead of 4096 default
 - MCP "Test Connection & Fetch Tools" no longer blocks the IDE; runs with cancellable progress dialog and fixes MCP client resource leak on error (#826)

--- a/src/main/java/com/devoxx/genie/service/FileListManager.java
+++ b/src/main/java/com/devoxx/genie/service/FileListManager.java
@@ -98,6 +98,10 @@ public final class FileListManager {
         return allFiles;
     }
 
+    public @NotNull List<VirtualFile> getNonImageFiles(@NotNull Project project) {
+        return Collections.unmodifiableList(filesMap.computeIfAbsent(project.getLocationHash(), k -> new ArrayList<>()));
+    }
+
     public @NotNull List<VirtualFile> getImageFiles(@NotNull Project project) {
         return Collections.unmodifiableList(imageFilesMap.computeIfAbsent(project.getLocationHash(), k -> new ArrayList<>()));
     }
@@ -152,6 +156,17 @@ public final class FileListManager {
         String projectHash = project.getLocationHash();
         filesMap.remove(projectHash);
         imageFilesMap.remove(projectHash);
+        notifyAllObservers(project);
+    }
+
+    /**
+     * Clear only non-image files and previously added files, preserving image files.
+     * Used when switching to editor context to avoid destroying attached images.
+     */
+    public void clearNonImageFiles(@NotNull Project project) {
+        String projectHash = project.getLocationHash();
+        filesMap.remove(projectHash);
+        previouslyAddedFiles.remove(projectHash);
         notifyAllObservers(project);
     }
 

--- a/src/test/java/com/devoxx/genie/service/prompt/memory/ChatMemoryManagerTest.java
+++ b/src/test/java/com/devoxx/genie/service/prompt/memory/ChatMemoryManagerTest.java
@@ -1,0 +1,138 @@
+package com.devoxx.genie.service.prompt.memory;
+
+import com.devoxx.genie.model.request.ChatMessageContext;
+import com.intellij.openapi.project.Project;
+import dev.langchain4j.data.message.*;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class ChatMemoryManagerTest {
+
+    @Mock
+    private ChatMemoryService mockChatMemoryService;
+
+    @Mock
+    private Project mockProject;
+
+    @Mock
+    private ChatMessageContext mockContext;
+
+    private ChatMemoryManager chatMemoryManager;
+
+    @BeforeEach
+    void setUp() {
+        lenient().when(mockContext.getProject()).thenReturn(mockProject);
+        lenient().when(mockContext.getId()).thenReturn("test-id");
+
+        try (MockedStatic<ChatMemoryService> chatMemoryServiceMockedStatic = Mockito.mockStatic(ChatMemoryService.class)) {
+            chatMemoryServiceMockedStatic.when(ChatMemoryService::getInstance).thenReturn(mockChatMemoryService);
+            chatMemoryManager = new ChatMemoryManager();
+        }
+    }
+
+    @Test
+    void testAddUserMessagePreservesImageContent() {
+        // Create a multimodal UserMessage with text + image
+        UserMessage multimodalMessage = UserMessage.from(
+                TextContent.from("Describe this image"),
+                ImageContent.from("base64data", "image/png")
+        );
+
+        when(mockContext.getUserMessage()).thenReturn(multimodalMessage);
+
+        // Capture the message added to memory
+        ArgumentCaptor<ChatMessage> messageCaptor = ArgumentCaptor.forClass(ChatMessage.class);
+
+        chatMemoryManager.addUserMessage(mockContext);
+
+        verify(mockChatMemoryService).addMessage(eq(mockProject), messageCaptor.capture());
+
+        ChatMessage captured = messageCaptor.getValue();
+        assertInstanceOf(UserMessage.class, captured);
+        UserMessage capturedUserMessage = (UserMessage) captured;
+
+        // Should still be multimodal
+        assertFalse(capturedUserMessage.hasSingleText());
+
+        List<Content> contents = capturedUserMessage.contents();
+        assertEquals(2, contents.size());
+        assertInstanceOf(TextContent.class, contents.get(0));
+        assertInstanceOf(ImageContent.class, contents.get(1));
+
+        // Verify the image data is preserved
+        ImageContent imageContent = (ImageContent) contents.get(1);
+        assertEquals("image/png", imageContent.image().mimeType());
+        assertEquals("base64data", imageContent.image().base64Data());
+    }
+
+    @Test
+    void testAddUserMessageTextOnlyPath() {
+        UserMessage textMessage = UserMessage.from("Hello world");
+        when(mockContext.getUserMessage()).thenReturn(textMessage);
+
+        ArgumentCaptor<ChatMessage> messageCaptor = ArgumentCaptor.forClass(ChatMessage.class);
+
+        chatMemoryManager.addUserMessage(mockContext);
+
+        verify(mockChatMemoryService).addMessage(eq(mockProject), messageCaptor.capture());
+
+        ChatMessage captured = messageCaptor.getValue();
+        assertInstanceOf(UserMessage.class, captured);
+        UserMessage capturedUserMessage = (UserMessage) captured;
+
+        // Should be single text
+        assertTrue(capturedUserMessage.hasSingleText());
+        assertEquals("Hello world", capturedUserMessage.singleText());
+    }
+
+    @Test
+    void testAddUserMessageWithTemplateVariablesInMultimodal() {
+        // Template variables like {{var}} should be escaped in text but images preserved
+        UserMessage multimodalMessage = UserMessage.from(
+                TextContent.from("Describe {{this}} image"),
+                ImageContent.from("imagedata", "image/jpeg")
+        );
+
+        when(mockContext.getUserMessage()).thenReturn(multimodalMessage);
+
+        ArgumentCaptor<ChatMessage> messageCaptor = ArgumentCaptor.forClass(ChatMessage.class);
+
+        chatMemoryManager.addUserMessage(mockContext);
+
+        verify(mockChatMemoryService).addMessage(eq(mockProject), messageCaptor.capture());
+
+        ChatMessage captured = messageCaptor.getValue();
+        UserMessage capturedUserMessage = (UserMessage) captured;
+
+        // Should still be multimodal
+        assertFalse(capturedUserMessage.hasSingleText());
+
+        List<Content> contents = capturedUserMessage.contents();
+        assertEquals(2, contents.size());
+
+        // Text should have template variables escaped
+        TextContent textContent = (TextContent) contents.get(0);
+        assertNotNull(textContent.text());
+
+        // Image should be preserved as-is
+        ImageContent imageContent = (ImageContent) contents.get(1);
+        assertEquals("imagedata", imageContent.image().base64Data());
+    }
+}


### PR DESCRIPTION
Images were stripped at multiple points before reaching the LLM:

1. FileListManager.clear() wiped image files prematurely when addDefaultEditorInfoToMessageContext() was called — added getNonImageFiles()/clearNonImageFiles() to preserve images
2. MessageCreationService.addImages() overwrote previous images in a loop — now collects all into a single multimodal message
3. ChatMemoryManager.addUserMessage() converted multimodal UserMessage to text-only via singleText() — now preserves ImageContent while escaping only TextContent
4. Both streaming and non-streaming execution used AiServices text-only chat(String) interface — added direct model call bypass when multimodal content is detected