### PR TITLE
Split Prompts/Skills settings and add skill argument templates

### DIFF
--- a/src/main/java/com/devoxx/genie/controller/PromptExecutionController.java
+++ b/src/main/java/com/devoxx/genie/controller/PromptExecutionController.java
@@ -58,20 +58,19 @@ public class PromptExecutionController implements PromptExecutionListener {
             promptOutputPanel.markConversationAsStarted();
         }
         
-        // Check if this is a help command before showing the user message
-        String prompt = currentChatMessageContext.getUserPrompt().trim();
-        boolean isHelpCommand = prompt.startsWith("/help");
-        
-        if (!isHelpCommand) {
-            // Only show user message if it's not a help command
-            promptOutputPanel.getConversationPanel().addUserPromptMessage(currentChatMessageContext);
-        }
-
         AtomicBoolean response = new AtomicBoolean(true);
+        String originalPrompt = currentChatMessageContext.getUserPrompt().trim();
+        boolean isHelpCommand = originalPrompt.startsWith("/help");
         Optional<String> processedPrompt = commandProcessor.processCommands(currentChatMessageContext, promptOutputPanel);
         
         processedPrompt.ifPresentOrElse(
-                command -> executePromptWithContext(),
+                command -> {
+                    if (!isHelpCommand) {
+                        // Show the resolved prompt (e.g. expanded custom skill), not the raw /command
+                        promptOutputPanel.getConversationPanel().addUserPromptMessage(currentChatMessageContext);
+                    }
+                    executePromptWithContext();
+                },
                 () -> {
                     // Command handling indicated execution should stop
                     response.set(false);

--- a/src/main/java/com/devoxx/genie/service/mcp/MCPExecutionService.java
+++ b/src/main/java/com/devoxx/genie/service/mcp/MCPExecutionService.java
@@ -14,7 +14,6 @@ import dev.langchain4j.mcp.McpToolProvider;
 import dev.langchain4j.mcp.client.DefaultMcpClient;
 import dev.langchain4j.mcp.client.McpClient;
 import dev.langchain4j.mcp.client.transport.McpTransport;
-import dev.langchain4j.mcp.client.transport.http.HttpMcpTransport;
 import dev.langchain4j.mcp.client.transport.http.StreamableHttpMcpTransport;
 import dev.langchain4j.mcp.client.transport.stdio.StdioMcpTransport;
 import dev.langchain4j.service.tool.ToolProvider;
@@ -197,11 +196,11 @@ public class MCPExecutionService implements Disposable {
                 return null;
             }
             
-            MCPService.logDebug("Initializing HTTP SSE transport with URL: " + sseUrl);
+            MCPService.logDebug("Initializing streamable HTTP transport for HTTP_SSE config with URL: " + sseUrl);
 
-            // Create the transport using the official langchain4j-mcp API
-            HttpMcpTransport.Builder transportBuilder = new HttpMcpTransport.Builder()
-                    .sseUrl(sseUrl)
+            // Use Streamable HTTP transport as replacement for legacy HTTP/SSE transport
+            StreamableHttpMcpTransport.Builder transportBuilder = new StreamableHttpMcpTransport.Builder()
+                    .url(sseUrl)
                     .timeout(java.time.Duration.ofSeconds(DevoxxGenieStateService.getInstance().getTimeout()))
                     .logRequests(MCPService.isDebugLogsEnabled())
                     .logResponses(MCPService.isDebugLogsEnabled())
@@ -211,7 +210,7 @@ public class MCPExecutionService implements Disposable {
                 transportBuilder.customHeaders(mcpServer.getHeaders());
             }
 
-            HttpMcpTransport transport = transportBuilder.build();
+            McpTransport transport = transportBuilder.build();
 
             // Create and return the client
             return new DefaultMcpClient.Builder()

--- a/src/main/java/com/devoxx/genie/service/prompt/command/CustomPromptCommand.java
+++ b/src/main/java/com/devoxx/genie/service/prompt/command/CustomPromptCommand.java
@@ -20,6 +20,8 @@ import static com.devoxx.genie.model.Constant.HELP_COMMAND;
 @Slf4j
 public class CustomPromptCommand implements PromptCommand {
 
+    private static final String ARGUMENT_PLACEHOLDER = "$ARGUMENT";
+
     @Override
     public boolean matches(@NotNull String prompt) {
         String trimmedPrompt = prompt.trim();
@@ -37,9 +39,14 @@ public class CustomPromptCommand implements PromptCommand {
         DevoxxGenieSettingsService settings = DevoxxGenieStateService.getInstance();
         List<CustomPrompt> customPrompts = settings.getCustomPrompts();
         
-        // Check if any custom command matches
+        String commandName = extractCommandName(trimmedPrompt);
+        if (commandName == null) {
+            return false;
+        }
+
+        // Check if any custom command matches exactly (avoid prefix collisions)
         return customPrompts.stream()
-                .anyMatch(prompt1 -> trimmedPrompt.startsWith(COMMAND_PREFIX + prompt1.getName()));
+                .anyMatch(prompt1 -> commandName.equalsIgnoreCase(prompt1.getName()));
     }
 
     @Override
@@ -52,9 +59,14 @@ public class CustomPromptCommand implements PromptCommand {
 
         String prompt = chatMessageContext.getUserPrompt().trim();
 
+        String commandName = extractCommandName(prompt);
+        if (commandName == null) {
+            return Optional.of(prompt);
+        }
+
         // Find the matching custom prompt
         Optional<CustomPrompt> matchingPrompt = customPrompts.stream()
-                .filter(customPrompt -> prompt.startsWith(COMMAND_PREFIX + customPrompt.getName()))
+                .filter(customPrompt -> commandName.equalsIgnoreCase(customPrompt.getName()))
                 .findFirst();
                 
         if (matchingPrompt.isEmpty()) {
@@ -65,10 +77,39 @@ public class CustomPromptCommand implements PromptCommand {
         CustomPrompt customPrompt = matchingPrompt.get();
         chatMessageContext.setCommandName(customPrompt.getName());
         
-        // Extract user arguments and combine with custom prompt template
-        String userArgs = prompt.substring(COMMAND_PREFIX.length() + customPrompt.getName().length()).trim();
-        String processedPrompt = customPrompt.getPrompt() + " " + userArgs;
+        // Extract user arguments and apply them to the custom prompt template
+        String userArgs = extractUserArguments(prompt, commandName);
+        String processedPrompt = applyArguments(customPrompt.getPrompt(), userArgs);
         
         return Optional.of(processedPrompt);
+    }
+
+    private String applyArguments(@NotNull String template, @NotNull String userArgs) {
+        if (template.contains(ARGUMENT_PLACEHOLDER)) {
+            return template.replace(ARGUMENT_PLACEHOLDER, userArgs);
+        }
+        if (userArgs.isEmpty()) {
+            return template;
+        }
+        return template + " " + userArgs;
+    }
+
+    private String extractUserArguments(@NotNull String prompt, @NotNull String commandName) {
+        int start = COMMAND_PREFIX.length() + commandName.length();
+        if (prompt.length() <= start) {
+            return "";
+        }
+        return prompt.substring(start).trim();
+    }
+
+    private String extractCommandName(@NotNull String prompt) {
+        if (!prompt.startsWith(COMMAND_PREFIX) || prompt.length() <= COMMAND_PREFIX.length()) {
+            return null;
+        }
+        int firstSpace = prompt.indexOf(' ');
+        if (firstSpace == -1) {
+            return prompt.substring(COMMAND_PREFIX.length());
+        }
+        return prompt.substring(COMMAND_PREFIX.length(), firstSpace).trim();
     }
 }

--- a/src/main/java/com/devoxx/genie/ui/dialog/CustomPromptDialog.java
+++ b/src/main/java/com/devoxx/genie/ui/dialog/CustomPromptDialog.java
@@ -23,7 +23,7 @@ public class CustomPromptDialog extends DialogWrapper {
     // New constructor for editing existing prompts
     public CustomPromptDialog(Project project, @NotNull String initialCommand, String initialPrompt) {
         super(project);
-        setTitle(initialCommand.isEmpty() ? "Add Custom Prompt" : "Edit Custom Prompt");
+        setTitle(initialCommand.isEmpty() ? "Add Custom Skill" : "Edit Custom Skill");
 
         nameField = new JBTextField(20);
         promptArea = new JBTextArea(10, 40);
@@ -47,9 +47,9 @@ public class CustomPromptDialog extends DialogWrapper {
         namePanel.add(new JLabel("Command Name:"), BorderLayout.WEST);
         namePanel.add(nameField, BorderLayout.CENTER);
 
-        // Prompt input
+        // Skill input
         JPanel promptPanel = new JPanel(new BorderLayout());
-        promptPanel.add(new JLabel("Prompt:"), BorderLayout.NORTH);
+        promptPanel.add(new JLabel("Skill:"), BorderLayout.NORTH);
         JBScrollPane scrollPane = new JBScrollPane(promptArea);
         promptPanel.add(scrollPane, BorderLayout.CENTER);
 
@@ -72,7 +72,7 @@ public class CustomPromptDialog extends DialogWrapper {
             return false;
         }
         if (promptArea.getText().trim().isEmpty()) {
-            Messages.showErrorDialog("The prompt cannot be empty.", "Invalid Prompt");
+            Messages.showErrorDialog("The skill cannot be empty.", "Invalid Skill");
             return false;
         }
         return true;

--- a/src/main/java/com/devoxx/genie/ui/settings/mcp/dialog/transport/HttpSseTransportPanel.java
+++ b/src/main/java/com/devoxx/genie/ui/settings/mcp/dialog/transport/HttpSseTransportPanel.java
@@ -16,7 +16,8 @@ import lombok.extern.slf4j.Slf4j;
 
 import dev.langchain4j.mcp.client.DefaultMcpClient;
 import dev.langchain4j.mcp.client.McpClient;
-import dev.langchain4j.mcp.client.transport.http.HttpMcpTransport;
+import dev.langchain4j.mcp.client.transport.McpTransport;
+import dev.langchain4j.mcp.client.transport.http.StreamableHttpMcpTransport;
 
 /**
  * Panel for configuring HTTP SSE MCP transport
@@ -106,9 +107,9 @@ public class HttpSseTransportPanel implements TransportPanel {
 
         log.debug("Creating HTTP SSE transport with URL: {}", sseUrl);
 
-        // Create the transport
-        HttpMcpTransport.Builder transportBuilder = new HttpMcpTransport.Builder()
-                .sseUrl(sseUrl)
+        // Use Streamable HTTP transport (recommended replacement for legacy HTTP/SSE transport)
+        StreamableHttpMcpTransport.Builder transportBuilder = new StreamableHttpMcpTransport.Builder()
+                .url(sseUrl)
                 .timeout(Duration.ofSeconds(60))
                 .logRequests(true)
                 .logResponses(true);
@@ -117,7 +118,7 @@ public class HttpSseTransportPanel implements TransportPanel {
             transportBuilder.customHeaders(headers);
         }
 
-        HttpMcpTransport transport = transportBuilder.build();
+        McpTransport transport = transportBuilder.build();
 
         // Create and return the client
         return new DefaultMcpClient.Builder()

--- a/src/main/java/com/devoxx/genie/ui/settings/prompt/PromptSettingsComponent.java
+++ b/src/main/java/com/devoxx/genie/ui/settings/prompt/PromptSettingsComponent.java
@@ -1,10 +1,7 @@
 package com.devoxx.genie.ui.settings.prompt;
 
-import com.devoxx.genie.model.CustomPrompt;
 import com.devoxx.genie.service.analyzer.DevoxxGenieGenerator;
-import com.devoxx.genie.ui.dialog.CustomPromptDialog;
 import com.devoxx.genie.ui.settings.AbstractSettingsComponent;
-import com.devoxx.genie.ui.settings.DevoxxGenieStateService;
 import com.devoxx.genie.ui.topic.AppTopics;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.progress.ProgressIndicator;
@@ -13,29 +10,15 @@ import com.intellij.openapi.progress.Task;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.SystemInfo;
 import com.intellij.ui.components.JBScrollPane;
-import com.intellij.ui.table.JBTable;
 import com.intellij.util.ui.JBUI;
 import lombok.Getter;
 import lombok.Setter;
 import org.jetbrains.annotations.NotNull;
 
 import javax.swing.*;
-import javax.swing.table.DefaultTableCellRenderer;
-import javax.swing.table.DefaultTableModel;
 import java.awt.*;
-import java.awt.event.MouseAdapter;
-import java.awt.event.MouseEvent;
-import java.util.ArrayList;
-import java.util.List;
-
-import static com.devoxx.genie.ui.component.button.ButtonFactory.createActionButton;
-import static com.devoxx.genie.ui.util.DevoxxGenieIconsUtil.*;
 
 public class PromptSettingsComponent extends AbstractSettingsComponent {
-
-    private static final int PROMPT_COLUMN = 1;
-
-    private final DevoxxGenieStateService settings;
 
     @Getter
     @Setter
@@ -48,7 +31,7 @@ public class PromptSettingsComponent extends AbstractSettingsComponent {
     @Getter
     @Setter
     private String submitShortcutLinux;
-    
+
     @Getter
     @Setter
     private String newlineShortcutWindows;
@@ -60,50 +43,30 @@ public class PromptSettingsComponent extends AbstractSettingsComponent {
     @Getter
     @Setter
     private String newlineShortcutLinux;
-    
+
     @Getter
     private final JTextArea systemPromptField = new JTextArea(stateService.getSystemPrompt());
-    @Getter
-    private final JTextArea testPromptField = new JTextArea(stateService.getTestPrompt());
-    @Getter
-    private final JTextArea explainPromptField = new JTextArea(stateService.getExplainPrompt());
-    @Getter
-    private final JTextArea reviewPromptField = new JTextArea(stateService.getReviewPrompt());
-    
-    // DEVOXXGENIE.md generation options
+
     @Getter
     private final JCheckBox createDevoxxGenieMdCheckbox = new JCheckBox("Generate DEVOXXGENIE.md file", stateService.getCreateDevoxxGenieMd());
+
     @Getter
     private final JCheckBox includeProjectTreeCheckbox = new JCheckBox("Include project tree", stateService.getIncludeProjectTree());
+
     @Getter
     private final JSpinner projectTreeDepthSpinner = new JSpinner(new SpinnerNumberModel(stateService.getProjectTreeDepth().intValue(), 1, 10, 1));
+
     @Getter
     private final JCheckBox useDevoxxGenieMdInPromptCheckbox = new JCheckBox("Use DEVOXXGENIE.md in prompt", stateService.getUseDevoxxGenieMdInPrompt());
+
     @Getter
     private final JButton createDevoxxGenieMdButton = new JButton("Create DEVOXXGENIE.md");
-
-    private final DefaultTableModel customPromptsTableModel = new DefaultTableModel(new String[]{"Command", "Prompt"}, 0);
-
-    private final JBTable customPromptsTable = new JBTable(customPromptsTableModel) {
-        @Override
-        public boolean isCellEditable(int row, int column) {
-            return false;
-        }
-    };
 
     private final Project project;
 
     public PromptSettingsComponent(Project project) {
         this.project = project;
-
-        settings = DevoxxGenieStateService.getInstance();
-
-        setupCustomPromptsTable();
-        setCustomPrompts(settings.getCustomPrompts());
-        
-        // Set up the action listener for the Create DEVOXXGENIE.md button
         createDevoxxGenieMdButton.addActionListener(e -> createDevoxxGenieMdFile());
-
         addListeners();
     }
 
@@ -120,77 +83,45 @@ public class PromptSettingsComponent extends AbstractSettingsComponent {
 
         addSection(panel, gbc, "Prompts");
         addPromptArea(panel, gbc, systemPromptField);
-        addSection(panel, gbc, "Custom Prompts");
 
-        gbc.gridy++;
-        gbc.weighty = 0.0;
-        gbc.fill = GridBagConstraints.HORIZONTAL;
-        panel.add(new JEditorPane(
-                "text/html",
-                "<html><body>Create custom command prompts which can be called using the / prefix in the prompt input field.</body></html>"),
-            gbc);
-
-        JPanel buttonPanel = new JPanel(new FlowLayout(FlowLayout.LEFT));
-        buttonPanel.add(createActionButton("Add", PlusIcon, "Add custom prompt", e -> addCustomPrompt()));
-        buttonPanel.add(createActionButton("Remove", TrashIcon, "Remove custom prompt", e -> removeCustomPrompt()));
-        buttonPanel.add(createActionButton("Restore", RefreshIcon, "Restore custom prompts", e -> restoreDefaultPrompts()));
-
-        gbc.gridy++;
-        gbc.weighty = 0.0;
-        gbc.fill = GridBagConstraints.HORIZONTAL;
-        panel.add(buttonPanel, gbc);
-
-        JBScrollPane tableScrollPane = new JBScrollPane(customPromptsTable);
-        tableScrollPane.setPreferredSize(new Dimension(-1, 200));
-        gbc.gridy++;
-        gbc.weighty = 1.0;
-        gbc.fill = GridBagConstraints.BOTH;
-        panel.add(tableScrollPane, gbc);
-
-        // Add DEVOXXGENIE.md section
         addSection(panel, gbc, "DEVOXXGENIE.md Generation");
-        
+
         gbc.gridy++;
         gbc.weighty = 0.0;
         gbc.fill = GridBagConstraints.HORIZONTAL;
         panel.add(createDevoxxGenieMdCheckbox, gbc);
-        
-        // Create a panel for the project tree options
+
         JPanel projectTreePanel = new JPanel(new FlowLayout(FlowLayout.LEFT));
         projectTreePanel.add(includeProjectTreeCheckbox);
         projectTreePanel.add(new JLabel("Tree depth:"));
         projectTreePanel.add(projectTreeDepthSpinner);
-        
+
         gbc.gridy++;
         panel.add(projectTreePanel, gbc);
-        
-        // Add the use in prompt checkbox with explanation
+
         gbc.gridy++;
         panel.add(useDevoxxGenieMdInPromptCheckbox, gbc);
-        
+
         gbc.gridy++;
         JEditorPane explanationPane = new JEditorPane(
                 "text/html",
                 "<html><body style='margin: 5px'>When enabled, the content of DEVOXXGENIE.md will be included in the prompt sent to the AI, "
-                + "providing it with context about your project structure and important files.</body></html>"
+                        + "providing it with context about your project structure and important files.</body></html>"
         );
         explanationPane.setEditable(false);
         explanationPane.setBackground(null);
         explanationPane.setBorder(null);
         panel.add(explanationPane, gbc);
-        
-        // Add a button to manually create DEVOXXGENIE.md
+
         gbc.gridy++;
         gbc.weighty = 0.0;
         gbc.fill = GridBagConstraints.NONE;
         gbc.anchor = GridBagConstraints.WEST;
         panel.add(createDevoxxGenieMdButton, gbc);
-        
-        // Reset to default settings
+
         gbc.anchor = GridBagConstraints.CENTER;
         gbc.fill = GridBagConstraints.HORIZONTAL;
-        
-        // Add event listener to enable/disable tree options based on checkbox state
+
         createDevoxxGenieMdCheckbox.addChangeListener(e -> {
             boolean enabled = createDevoxxGenieMdCheckbox.isSelected();
             includeProjectTreeCheckbox.setEnabled(enabled);
@@ -198,20 +129,16 @@ public class PromptSettingsComponent extends AbstractSettingsComponent {
             useDevoxxGenieMdInPromptCheckbox.setEnabled(enabled);
             createDevoxxGenieMdButton.setEnabled(enabled);
         });
-        
-        includeProjectTreeCheckbox.addChangeListener(e -> {
-            projectTreeDepthSpinner.setEnabled(createDevoxxGenieMdCheckbox.isSelected() && 
-                                              includeProjectTreeCheckbox.isSelected());
-        });
-        
-        // Initialize component states
+
+        includeProjectTreeCheckbox.addChangeListener(e ->
+                projectTreeDepthSpinner.setEnabled(createDevoxxGenieMdCheckbox.isSelected() && includeProjectTreeCheckbox.isSelected())
+        );
+
         includeProjectTreeCheckbox.setEnabled(createDevoxxGenieMdCheckbox.isSelected());
-        projectTreeDepthSpinner.setEnabled(createDevoxxGenieMdCheckbox.isSelected() && 
-                                        includeProjectTreeCheckbox.isSelected());
+        projectTreeDepthSpinner.setEnabled(createDevoxxGenieMdCheckbox.isSelected() && includeProjectTreeCheckbox.isSelected());
         useDevoxxGenieMdInPromptCheckbox.setEnabled(createDevoxxGenieMdCheckbox.isSelected());
         createDevoxxGenieMdButton.setEnabled(createDevoxxGenieMdCheckbox.isSelected());
 
-        // Add keyboard shortcuts section
         addSection(panel, gbc, "Configure keyboard submit shortcut");
 
         gbc.gridy++;
@@ -225,8 +152,7 @@ public class PromptSettingsComponent extends AbstractSettingsComponent {
         } else {
             panel.add(createShortcutPanel("Linux", stateService.getSubmitShortcutLinux(), true), gbc);
         }
-        
-        // Add keyboard shortcuts section for newline
+
         addSection(panel, gbc, "Configure keyboard newline shortcut");
 
         gbc.gridy++;
@@ -257,7 +183,6 @@ public class PromptSettingsComponent extends AbstractSettingsComponent {
 
     private @NotNull JPanel createShortcutPanel(String os, String initialShortcut, boolean isSubmitShortcut) {
         KeyboardShortcutPanel shortcutPanel = new KeyboardShortcutPanel(project, os, initialShortcut, shortcut -> {
-            // Update the appropriate shortcut based on OS
             if (isSubmitShortcut) {
                 if ("Mac".equalsIgnoreCase(os)) {
                     setSubmitShortcutMac(shortcut);
@@ -279,7 +204,6 @@ public class PromptSettingsComponent extends AbstractSettingsComponent {
             }
         });
 
-        // Set initial values from state service
         if (isSubmitShortcut) {
             if ("Mac".equalsIgnoreCase(os)) {
                 submitShortcutMac = shortcutPanel.getCurrentShortcut();
@@ -300,134 +224,16 @@ public class PromptSettingsComponent extends AbstractSettingsComponent {
 
         return shortcutPanel;
     }
-    
-    private @NotNull JPanel createShortcutPanel(String os, String initialShortcut) {
-        return createShortcutPanel(os, initialShortcut, true);
-    }
-    
+
     private @NotNull JPanel createNewlineShortcutPanel(String os, String initialShortcut) {
         return createShortcutPanel(os, initialShortcut, false);
-    }
-    
-    private void notifyNewlineShortcutChanged(String shortcut) {
-        project.getMessageBus()
-                .syncPublisher(AppTopics.NEWLINE_SHORTCUT_CHANGED_TOPIC)
-                .onNewlineShortcutChanged(shortcut);
-    }
-
-    private void setupCustomPromptsTable() {
-        customPromptsTable.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
-        customPromptsTable.setStriped(true);
-        customPromptsTable.getColumnModel().getColumn(0).setPreferredWidth(50);
-        customPromptsTable.getColumnModel().getColumn(1).setPreferredWidth(550);
-
-        // Add double-click listener
-        customPromptsTable.addMouseListener(new MouseAdapter() {
-            @Override
-            public void mouseClicked(MouseEvent e) {
-                if (e.getClickCount() == 2) {
-                    editCustomPrompt();
-                }
-            }
-        });
-
-        customPromptsTable.getColumnModel().getColumn(PROMPT_COLUMN).setCellRenderer(new DefaultTableCellRenderer() {
-            @Override
-            public Component getTableCellRendererComponent(JTable table, Object value, boolean isSelected, boolean hasFocus, int row, int column) {
-                JTextArea textArea = new JTextArea((String) value);
-                textArea.setWrapStyleWord(true);
-                textArea.setLineWrap(true);
-                if (isSelected) {
-                    textArea.setBackground(table.getSelectionBackground());
-                    textArea.setForeground(table.getSelectionForeground());
-                } else {
-                    textArea.setBackground(table.getBackground());
-                    textArea.setForeground(table.getForeground());
-                }
-                return textArea;
-            }
-        });
-    }
-
-    private void addCustomPrompt() {
-        CustomPromptDialog dialog = new CustomPromptDialog(project);
-        if (dialog.showAndGet()) {
-            String newName = dialog.getCommandName();
-            String newPrompt = dialog.getPrompt();
-
-            customPromptsTableModel.addRow(new Object[]{newName, newPrompt});
-            int newRowIndex = customPromptsTableModel.getRowCount() - 1;
-            customPromptsTable.setRowSelectionInterval(newRowIndex, newRowIndex);
-            customPromptsTable.scrollRectToVisible(customPromptsTable.getCellRect(newRowIndex, 0, true));
-
-            project
-                .getMessageBus()
-                .syncPublisher(AppTopics.CUSTOM_PROMPT_CHANGED_TOPIC)
-                .onCustomPromptsChanged();
-        }
-    }
-
-    private void editCustomPrompt() {
-        int selectedRow = customPromptsTable.getSelectedRow();
-        if (selectedRow != -1) {
-            String commandName = (String) customPromptsTableModel.getValueAt(selectedRow, 0);
-            String prompt = (String) customPromptsTableModel.getValueAt(selectedRow, PROMPT_COLUMN);
-
-            CustomPromptDialog dialog = new CustomPromptDialog(project, commandName, prompt);
-            if (dialog.showAndGet()) {
-                String newName = dialog.getCommandName();
-                String newPrompt = dialog.getPrompt();
-
-                customPromptsTableModel.setValueAt(newName, selectedRow, 0);
-                customPromptsTableModel.setValueAt(newPrompt, selectedRow, PROMPT_COLUMN);
-
-                project
-                        .getMessageBus()
-                        .syncPublisher(AppTopics.CUSTOM_PROMPT_CHANGED_TOPIC)
-                        .onCustomPromptsChanged();
-            }
-        }
-    }
-
-
-    private void removeCustomPrompt() {
-        int selectedRow = customPromptsTable.getSelectedRow();
-        if (selectedRow != -1) {
-            customPromptsTableModel.removeRow(selectedRow);
-            project
-                .getMessageBus()
-                .syncPublisher(AppTopics.CUSTOM_PROMPT_CHANGED_TOPIC)
-                .onCustomPromptsChanged();
-        }
-    }
-
-    private void restoreDefaultPrompts() {
-        setCustomPrompts(settings.getDefaultPrompts());
-    }
-
-    public List<CustomPrompt> getCustomPrompts() {
-        int NAME_COLUMN = 0;
-        List<CustomPrompt> prompts = new ArrayList<>();
-        for (int i = 0; i < customPromptsTableModel.getRowCount(); i++) {
-            String name = (String) customPromptsTableModel.getValueAt(i, NAME_COLUMN);
-            String prompt = (String) customPromptsTableModel.getValueAt(i, PROMPT_COLUMN);
-            prompts.add(new CustomPrompt(name.toLowerCase(), prompt));
-        }
-        return prompts;
-    }
-
-    public void setCustomPrompts(@NotNull List<CustomPrompt> customPrompts) {
-        customPromptsTableModel.setRowCount(0);
-        for (CustomPrompt prompt : customPrompts) {
-            customPromptsTableModel.addRow(new Object[]{prompt.getName(), prompt.getPrompt()});
-        }
     }
 
     private void addPromptArea(@NotNull JPanel panel,
                                @NotNull GridBagConstraints gbc,
                                @NotNull JTextArea textArea) {
         gbc.gridy++;
-        panel.add(new JLabel("System prompt"), gbc);
+        panel.add(new JLabel("System instruction"), gbc);
 
         gbc.gridy++;
         textArea.setRows(5);
@@ -443,44 +249,32 @@ public class PromptSettingsComponent extends AbstractSettingsComponent {
                 .syncPublisher(AppTopics.SHORTCUT_CHANGED_TOPIC)
                 .onShortcutChanged(shortcut);
     }
-    
-    /**
-     * Creates the DEVOXXGENIE.md file in the project root directory
-     * The method executes in a background task to avoid blocking the EDT
-     */
+
+    private void notifyNewlineShortcutChanged(String shortcut) {
+        project.getMessageBus()
+                .syncPublisher(AppTopics.NEWLINE_SHORTCUT_CHANGED_TOPIC)
+                .onNewlineShortcutChanged(shortcut);
+    }
+
     private void createDevoxxGenieMdFile() {
-        // Disable the button to prevent multiple clicks
         createDevoxxGenieMdButton.setEnabled(false);
-        
-        // Use ProgressManager to run in a background task
+
         ProgressManager.getInstance().run(new Task.Backgroundable(project, "Generating DEVOXXGENIE.md", false) {
             @Override
             public void run(@NotNull ProgressIndicator indicator) {
                 try {
                     indicator.setText("Generating DEVOXXGENIE.md file...");
-                    
-                    // TODO: Implement actual file generation logic here
-                    // This would include analyzing the project structure and generating the content
+
                     boolean includeTree = includeProjectTreeCheckbox.isSelected();
                     int treeDepth = (Integer) projectTreeDepthSpinner.getValue();
-                    
-                    // Get the project base path
-                    String projectPath = project.getBasePath();
 
-                    if (projectPath != null) {
-
-                    }
                     DevoxxGenieGenerator devoxxGenieGenerator =
                             new DevoxxGenieGenerator(project, includeTree, treeDepth, indicator);
                     devoxxGenieGenerator.generate();
-
-                    if (includeTree) {
-                    }
                 } finally {
-                    // Re-enable the button on the EDT when done
-                    ApplicationManager.getApplication().invokeLater(() -> {
-                        createDevoxxGenieMdButton.setEnabled(createDevoxxGenieMdCheckbox.isSelected());
-                    });
+                    ApplicationManager.getApplication().invokeLater(() ->
+                            createDevoxxGenieMdButton.setEnabled(createDevoxxGenieMdCheckbox.isSelected())
+                    );
                 }
             }
         });

--- a/src/main/java/com/devoxx/genie/ui/settings/prompt/PromptSettingsConfigurable.java
+++ b/src/main/java/com/devoxx/genie/ui/settings/prompt/PromptSettingsConfigurable.java
@@ -30,22 +30,12 @@ public class PromptSettingsConfigurable implements Configurable {
         return promptSettingsComponent.createPanel();
     }
 
-    /**
-     * Get the display name
-     *
-     * @return the display name
-     */
     @Nls
     @Override
     public String getDisplayName() {
         return "Prompts";
     }
 
-    /**
-     * Check if the settings have been modified
-     *
-     * @return true if the settings have been modified
-     */
     @Override
     public boolean isModified() {
         DevoxxGenieStateService settings = DevoxxGenieStateService.getInstance();
@@ -54,19 +44,15 @@ public class PromptSettingsConfigurable implements Configurable {
 
         isModified |= !StringUtil.equals(promptSettingsComponent.getSystemPromptField().getText(), settings.getSystemPrompt());
 
-        isModified |= !settings.getCustomPrompts().equals(promptSettingsComponent.getCustomPrompts());
-        
-        // Check DEVOXXGENIE.md generation options
         isModified |= settings.getCreateDevoxxGenieMd() != promptSettingsComponent.getCreateDevoxxGenieMdCheckbox().isSelected();
         isModified |= settings.getIncludeProjectTree() != promptSettingsComponent.getIncludeProjectTreeCheckbox().isSelected();
         isModified |= !Objects.equals(settings.getProjectTreeDepth(), promptSettingsComponent.getProjectTreeDepthSpinner().getValue());
         isModified |= settings.getUseDevoxxGenieMdInPrompt() != promptSettingsComponent.getUseDevoxxGenieMdInPromptCheckbox().isSelected();
 
-        // Check shortcuts
         isModified |= !settings.getSubmitShortcutWindows().equals(promptSettingsComponent.getSubmitShortcutWindows());
         isModified |= !settings.getSubmitShortcutMac().equals(promptSettingsComponent.getSubmitShortcutMac());
         isModified |= !settings.getSubmitShortcutLinux().equals(promptSettingsComponent.getSubmitShortcutLinux());
-        
+
         isModified |= !settings.getNewlineShortcutWindows().equals(promptSettingsComponent.getNewlineShortcutWindows());
         isModified |= !settings.getNewlineShortcutMac().equals(promptSettingsComponent.getNewlineShortcutMac());
         isModified |= !settings.getNewlineShortcutLinux().equals(promptSettingsComponent.getNewlineShortcutLinux());
@@ -74,24 +60,17 @@ public class PromptSettingsConfigurable implements Configurable {
         return isModified;
     }
 
-    /**
-     * Apply the changes to the settings
-     */
     @Override
     public void apply() {
         DevoxxGenieStateService settings = DevoxxGenieStateService.getInstance();
         updateTextAreaIfModified(promptSettingsComponent.getSystemPromptField(), settings.getSystemPrompt(), settings::setSystemPrompt);
 
-        settings.setCustomPrompts(promptSettingsComponent.getCustomPrompts());
-        
-        // Apply DEVOXXGENIE.md generation options
         settings.setCreateDevoxxGenieMd(promptSettingsComponent.getCreateDevoxxGenieMdCheckbox().isSelected());
         settings.setIncludeProjectTree(promptSettingsComponent.getIncludeProjectTreeCheckbox().isSelected());
         settings.setProjectTreeDepth((Integer) promptSettingsComponent.getProjectTreeDepthSpinner().getValue());
         settings.setUseDevoxxGenieMdInPrompt(promptSettingsComponent.getUseDevoxxGenieMdInPromptCheckbox().isSelected());
 
-        // Apply submit shortcuts and notify changes
-        String newShortcut = null;
+        String newShortcut;
         if (SystemInfo.isWindows) {
             settings.setSubmitShortcutWindows(promptSettingsComponent.getSubmitShortcutWindows());
             newShortcut = promptSettingsComponent.getSubmitShortcutWindows();
@@ -103,15 +82,13 @@ public class PromptSettingsConfigurable implements Configurable {
             newShortcut = promptSettingsComponent.getSubmitShortcutLinux();
         }
 
-        // Notify shortcut change
         if (newShortcut != null) {
             project.getMessageBus()
                     .syncPublisher(AppTopics.SHORTCUT_CHANGED_TOPIC)
                     .onShortcutChanged(newShortcut);
         }
-        
-        // Apply newline shortcuts and notify changes
-        String newNewlineShortcut = null;
+
+        String newNewlineShortcut;
         if (SystemInfo.isWindows) {
             settings.setNewlineShortcutWindows(promptSettingsComponent.getNewlineShortcutWindows());
             newNewlineShortcut = promptSettingsComponent.getNewlineShortcutWindows();
@@ -123,35 +100,23 @@ public class PromptSettingsConfigurable implements Configurable {
             newNewlineShortcut = promptSettingsComponent.getNewlineShortcutLinux();
         }
 
-        // Notify newline shortcut change
         if (newNewlineShortcut != null) {
             project.getMessageBus()
                     .syncPublisher(AppTopics.NEWLINE_SHORTCUT_CHANGED_TOPIC)
                     .onNewlineShortcutChanged(newNewlineShortcut);
         }
-
-        project.getMessageBus()
-                .syncPublisher(AppTopics.CUSTOM_PROMPT_CHANGED_TOPIC)
-                .onCustomPromptsChanged();
     }
 
-    /**
-     * Reset the text area to the default value
-     */
     @Override
     public void reset() {
         DevoxxGenieStateService settings = DevoxxGenieStateService.getInstance();
         promptSettingsComponent.getSystemPromptField().setText(settings.getSystemPrompt());
 
-        promptSettingsComponent.setCustomPrompts(settings.getCustomPrompts());
-        
-        // Reset DEVOXXGENIE.md generation options
         promptSettingsComponent.getCreateDevoxxGenieMdCheckbox().setSelected(settings.getCreateDevoxxGenieMd());
         promptSettingsComponent.getIncludeProjectTreeCheckbox().setSelected(settings.getIncludeProjectTree());
         promptSettingsComponent.getProjectTreeDepthSpinner().setValue(settings.getProjectTreeDepth());
         promptSettingsComponent.getUseDevoxxGenieMdInPromptCheckbox().setSelected(settings.getUseDevoxxGenieMdInPrompt());
-        
-        // Reset UI state based on checkbox selections
+
         boolean createMdEnabled = settings.getCreateDevoxxGenieMd();
         promptSettingsComponent.getIncludeProjectTreeCheckbox().setEnabled(createMdEnabled);
         promptSettingsComponent.getProjectTreeDepthSpinner().setEnabled(createMdEnabled && settings.getIncludeProjectTree());
@@ -161,15 +126,11 @@ public class PromptSettingsConfigurable implements Configurable {
         promptSettingsComponent.setSubmitShortcutWindows(settings.getSubmitShortcutWindows());
         promptSettingsComponent.setSubmitShortcutMac(settings.getSubmitShortcutMac());
         promptSettingsComponent.setSubmitShortcutLinux(settings.getSubmitShortcutLinux());
+        promptSettingsComponent.setNewlineShortcutWindows(settings.getNewlineShortcutWindows());
+        promptSettingsComponent.setNewlineShortcutMac(settings.getNewlineShortcutMac());
+        promptSettingsComponent.setNewlineShortcutLinux(settings.getNewlineShortcutLinux());
     }
 
-    /**
-     * Update the text area if the value has changed
-     *
-     * @param textArea     the text area
-     * @param currentValue the current value
-     * @param updateAction the update action
-     */
     public void updateTextAreaIfModified(@NotNull JTextArea textArea,
                                          Object currentValue,
                                          Consumer<String> updateAction) {

--- a/src/main/java/com/devoxx/genie/ui/settings/skill/SkillSettingsComponent.java
+++ b/src/main/java/com/devoxx/genie/ui/settings/skill/SkillSettingsComponent.java
@@ -1,0 +1,195 @@
+package com.devoxx.genie.ui.settings.skill;
+
+import com.devoxx.genie.model.CustomPrompt;
+import com.devoxx.genie.ui.dialog.CustomPromptDialog;
+import com.devoxx.genie.ui.settings.AbstractSettingsComponent;
+import com.devoxx.genie.ui.settings.DevoxxGenieStateService;
+import com.devoxx.genie.ui.topic.AppTopics;
+import com.intellij.openapi.project.Project;
+import com.intellij.ui.components.JBScrollPane;
+import com.intellij.ui.table.JBTable;
+import com.intellij.util.ui.JBUI;
+import org.jetbrains.annotations.NotNull;
+
+import javax.swing.*;
+import javax.swing.table.DefaultTableCellRenderer;
+import javax.swing.table.DefaultTableModel;
+import java.awt.*;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.devoxx.genie.ui.component.button.ButtonFactory.createActionButton;
+import static com.devoxx.genie.ui.util.DevoxxGenieIconsUtil.PlusIcon;
+import static com.devoxx.genie.ui.util.DevoxxGenieIconsUtil.RefreshIcon;
+import static com.devoxx.genie.ui.util.DevoxxGenieIconsUtil.TrashIcon;
+
+public class SkillSettingsComponent extends AbstractSettingsComponent {
+
+    private static final int COMMAND_COLUMN = 0;
+    private static final int SKILL_COLUMN = 1;
+
+    private final DevoxxGenieStateService settings;
+    private final Project project;
+
+    private final DefaultTableModel customPromptsTableModel = new DefaultTableModel(new String[]{"Command", "Skill"}, 0);
+
+    private final JBTable customPromptsTable = new JBTable(customPromptsTableModel) {
+        @Override
+        public boolean isCellEditable(int row, int column) {
+            return false;
+        }
+    };
+
+    public SkillSettingsComponent(Project project) {
+        this.project = project;
+        this.settings = DevoxxGenieStateService.getInstance();
+
+        setupCustomPromptsTable();
+        setCustomPrompts(settings.getCustomPrompts());
+    }
+
+    @Override
+    public JPanel createPanel() {
+        panel.setLayout(new GridBagLayout());
+        GridBagConstraints gbc = new GridBagConstraints();
+        gbc.gridx = 0;
+        gbc.gridy = 0;
+        gbc.gridwidth = 1;
+        gbc.fill = GridBagConstraints.HORIZONTAL;
+        gbc.weightx = 1.0;
+        gbc.insets = JBUI.insets(5);
+
+        addSection(panel, gbc, "Skills");
+
+        gbc.gridy++;
+        gbc.weighty = 0.0;
+        gbc.fill = GridBagConstraints.HORIZONTAL;
+        panel.add(new JEditorPane(
+                        "text/html",
+                        "<html><body>"
+                                + "Create custom user skills callable with the <code>/</code> prefix.<br/>"
+                                + "Use <code>$ARGUMENT</code> in the skill text to inject everything typed after the command.<br/>"
+                                + "Example: <code>/ralph-runners create a PRD.json for my project</code><br/>"
+                                + "Skill text: <code>You are a product manager. Task: $ARGUMENT</code>"
+                                + "</body></html>"),
+                gbc);
+
+        JPanel buttonPanel = new JPanel(new FlowLayout(FlowLayout.LEFT));
+        buttonPanel.add(createActionButton("Add", PlusIcon, "Add custom skill", e -> addCustomPrompt()));
+        buttonPanel.add(createActionButton("Remove", TrashIcon, "Remove custom skill", e -> removeCustomPrompt()));
+        buttonPanel.add(createActionButton("Restore", RefreshIcon, "Restore custom skills", e -> restoreDefaultPrompts()));
+
+        gbc.gridy++;
+        gbc.weighty = 0.0;
+        gbc.fill = GridBagConstraints.HORIZONTAL;
+        panel.add(buttonPanel, gbc);
+
+        JBScrollPane tableScrollPane = new JBScrollPane(customPromptsTable);
+        tableScrollPane.setPreferredSize(new Dimension(-1, 300));
+        gbc.gridy++;
+        gbc.weighty = 1.0;
+        gbc.fill = GridBagConstraints.BOTH;
+        panel.add(tableScrollPane, gbc);
+
+        return panel;
+    }
+
+    public List<CustomPrompt> getCustomPrompts() {
+        List<CustomPrompt> prompts = new ArrayList<>();
+        for (int i = 0; i < customPromptsTableModel.getRowCount(); i++) {
+            String name = (String) customPromptsTableModel.getValueAt(i, COMMAND_COLUMN);
+            String prompt = (String) customPromptsTableModel.getValueAt(i, SKILL_COLUMN);
+            prompts.add(new CustomPrompt(name.toLowerCase(), prompt));
+        }
+        return prompts;
+    }
+
+    public void setCustomPrompts(@NotNull List<CustomPrompt> customPrompts) {
+        customPromptsTableModel.setRowCount(0);
+        for (CustomPrompt prompt : customPrompts) {
+            customPromptsTableModel.addRow(new Object[]{prompt.getName(), prompt.getPrompt()});
+        }
+    }
+
+    private void setupCustomPromptsTable() {
+        customPromptsTable.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
+        customPromptsTable.setStriped(true);
+        customPromptsTable.getColumnModel().getColumn(COMMAND_COLUMN).setPreferredWidth(120);
+        customPromptsTable.getColumnModel().getColumn(SKILL_COLUMN).setPreferredWidth(480);
+
+        customPromptsTable.addMouseListener(new MouseAdapter() {
+            @Override
+            public void mouseClicked(MouseEvent e) {
+                if (e.getClickCount() == 2) {
+                    editCustomPrompt();
+                }
+            }
+        });
+
+        customPromptsTable.getColumnModel().getColumn(SKILL_COLUMN).setCellRenderer(new DefaultTableCellRenderer() {
+            @Override
+            public Component getTableCellRendererComponent(JTable table, Object value, boolean isSelected, boolean hasFocus, int row, int column) {
+                JTextArea textArea = new JTextArea((String) value);
+                textArea.setWrapStyleWord(true);
+                textArea.setLineWrap(true);
+                if (isSelected) {
+                    textArea.setBackground(table.getSelectionBackground());
+                    textArea.setForeground(table.getSelectionForeground());
+                } else {
+                    textArea.setBackground(table.getBackground());
+                    textArea.setForeground(table.getForeground());
+                }
+                return textArea;
+            }
+        });
+    }
+
+    private void addCustomPrompt() {
+        CustomPromptDialog dialog = new CustomPromptDialog(project);
+        if (dialog.showAndGet()) {
+            customPromptsTableModel.addRow(new Object[]{dialog.getCommandName(), dialog.getPrompt()});
+            int newRowIndex = customPromptsTableModel.getRowCount() - 1;
+            customPromptsTable.setRowSelectionInterval(newRowIndex, newRowIndex);
+            customPromptsTable.scrollRectToVisible(customPromptsTable.getCellRect(newRowIndex, 0, true));
+            publishCustomPromptChange();
+        }
+    }
+
+    private void editCustomPrompt() {
+        int selectedRow = customPromptsTable.getSelectedRow();
+        if (selectedRow == -1) {
+            return;
+        }
+
+        String commandName = (String) customPromptsTableModel.getValueAt(selectedRow, COMMAND_COLUMN);
+        String prompt = (String) customPromptsTableModel.getValueAt(selectedRow, SKILL_COLUMN);
+
+        CustomPromptDialog dialog = new CustomPromptDialog(project, commandName, prompt);
+        if (dialog.showAndGet()) {
+            customPromptsTableModel.setValueAt(dialog.getCommandName(), selectedRow, COMMAND_COLUMN);
+            customPromptsTableModel.setValueAt(dialog.getPrompt(), selectedRow, SKILL_COLUMN);
+            publishCustomPromptChange();
+        }
+    }
+
+    private void removeCustomPrompt() {
+        int selectedRow = customPromptsTable.getSelectedRow();
+        if (selectedRow != -1) {
+            customPromptsTableModel.removeRow(selectedRow);
+            publishCustomPromptChange();
+        }
+    }
+
+    private void restoreDefaultPrompts() {
+        setCustomPrompts(settings.getDefaultPrompts());
+        publishCustomPromptChange();
+    }
+
+    private void publishCustomPromptChange() {
+        project.getMessageBus()
+                .syncPublisher(AppTopics.CUSTOM_PROMPT_CHANGED_TOPIC)
+                .onCustomPromptsChanged();
+    }
+}

--- a/src/main/java/com/devoxx/genie/ui/settings/skill/SkillSettingsConfigurable.java
+++ b/src/main/java/com/devoxx/genie/ui/settings/skill/SkillSettingsConfigurable.java
@@ -1,0 +1,55 @@
+package com.devoxx.genie.ui.settings.skill;
+
+import com.devoxx.genie.ui.settings.DevoxxGenieStateService;
+import com.devoxx.genie.ui.topic.AppTopics;
+import com.intellij.openapi.options.Configurable;
+import com.intellij.openapi.project.Project;
+import org.jetbrains.annotations.Nls;
+import org.jetbrains.annotations.Nullable;
+
+import javax.swing.*;
+
+public class SkillSettingsConfigurable implements Configurable {
+
+    private final Project project;
+    private final SkillSettingsComponent skillSettingsComponent;
+
+    public SkillSettingsConfigurable(Project project) {
+        this.project = project;
+        this.skillSettingsComponent = new SkillSettingsComponent(project);
+    }
+
+    @Nls
+    @Override
+    public String getDisplayName() {
+        return "Skills";
+    }
+
+    @Nullable
+    @Override
+    public JComponent createComponent() {
+        return skillSettingsComponent.createPanel();
+    }
+
+    @Override
+    public boolean isModified() {
+        DevoxxGenieStateService settings = DevoxxGenieStateService.getInstance();
+        return !settings.getCustomPrompts().equals(skillSettingsComponent.getCustomPrompts());
+    }
+
+    @Override
+    public void apply() {
+        DevoxxGenieStateService settings = DevoxxGenieStateService.getInstance();
+        settings.setCustomPrompts(skillSettingsComponent.getCustomPrompts());
+
+        project.getMessageBus()
+                .syncPublisher(AppTopics.CUSTOM_PROMPT_CHANGED_TOPIC)
+                .onCustomPromptsChanged();
+    }
+
+    @Override
+    public void reset() {
+        DevoxxGenieStateService settings = DevoxxGenieStateService.getInstance();
+        skillSettingsComponent.setCustomPrompts(settings.getCustomPrompts());
+    }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -29,7 +29,7 @@
             <LI>Install the plugin</LI>
             <LI>Make sure you have Ollama, LMStudio or GPT4All running</LI>
             <LI>Optional: Add API Keys for Cloud based LLM providers</LI>
-            <LI>Optional: Update the command prompts in the Settings</LI>
+            <LI>Optional: Update the command skills in the Settings</LI>
             <LI>Start using the plugin</LI>
         </UL>
     ]]></description>
@@ -196,6 +196,11 @@
                              parentId="com.devoxx.genie.DevoxxGenie"
                              instance="com.devoxx.genie.ui.settings.prompt.PromptSettingsConfigurable"
                              displayName="Prompts"/>
+
+        <projectConfigurable id="com.devoxx.genie.SkillSettings"
+                             parentId="com.devoxx.genie.DevoxxGenie"
+                             instance="com.devoxx.genie.ui.settings.skill.SkillSettingsConfigurable"
+                             displayName="Skills"/>
 
         <projectConfigurable id="com.devoxx.genie.mcpsettings"
                              parentId="com.devoxx.genie.DevoxxGenie"

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -1,7 +1,7 @@
 welcome.title=Welcome to Devoxx Genie
 welcome.description=The Devoxx Genie plugin allows you to interact with Local & Cloud Large Language Models (LLMs). The remote LLM's do require an API key in the Settings page
 welcome.instructions=Start by selecting a language model provider. Select some code, or add some files, type your prompt, and click submit button. Discover and install MCP servers from the MCP Marketplace in Settings!
-welcome.tip=You can modify the endpoints for different LLM providers and the default command prompts in the plugin settings.
+welcome.tip=You can modify the endpoints for different LLM providers and the default command skills in the plugin settings.
 welcome.enjoy=Enjoy!
 
 prompt.placeholder=Type prompt or /help

--- a/src/main/resources/messages_fr_FR.properties
+++ b/src/main/resources/messages_fr_FR.properties
@@ -1,7 +1,7 @@
 welcome.title=Bienvenue dans Devoxx Genie
 welcome.description=Le plugin Devoxx Genie vous permet d'interagir avec des modèles de langage de grande taille (LLM) même sans connexion Internet.
 welcome.instructions=Commencez par sélectionner un fournisseur de modèle de langage. Sélectionnez du code, tapez votre invite et cliquez sur le bouton de soumission. Découvrez et installez des serveurs MCP depuis le Marketplace MCP dans les Paramètres!
-welcome.tip=Vous pouvez modifier les points de terminaison des différents fournisseurs de LLM et les invites de commande par défaut dans les paramètres du plugin.
+welcome.tip=Vous pouvez modifier les points de terminaison des différents fournisseurs de LLM et les skills de commande par défaut dans les paramètres du plugin.
 welcome.enjoy=Amusez-vous!
 
 prompt.placeholder=Tapez votre invite ou /help

--- a/src/main/resources/webview/html/welcome.html
+++ b/src/main/resources/webview/html/welcome.html
@@ -20,8 +20,8 @@
         <li><span class="feature-emoji">🧠</span><span class="feature-name">Project Scanner:</span> Add source code (full project or by package) to prompt context (or clipboard) when using Anthropic, OpenAI or Gemini.</li>
     </ul>
     
-    <h2>Utility Commands:</h2>
-    <p class="subtext">You can update the prompts for each utility command or add custom ones in the settings page.</p>
+    <h2>Your Skills:</h2>
+    <p class="subtext">You can update the skills for each utility command or add custom ones in the settings page.</p>
     <ul>
         ${customPromptCommands}
     </ul>


### PR DESCRIPTION
## Summary
- split settings into two dialogs:
  - **Prompts**: System instruction, DEVOXXGENIE.md options, keyboard shortcuts
  - **Skills**: custom user-defined skills only
- add custom skill argument templating via `$ARGUMENT`
  - example: `/ralph-runners create a PRD.json for my project`
  - template: `You are a product manager. Task: $ARGUMENT`
- fix prompt rendering order so the user message shows the resolved skill prompt instead of raw `/command`
- migrate legacy HTTP/SSE MCP usage to `StreamableHttpMcpTransport`
- update welcome/settings wording for Skills and MCP marketplace

## Validation
- `JAVA_HOME=$(/usr/libexec/java_home -v 21) ./gradlew -q compileJava`
- `JAVA_HOME=$(/usr/libexec/java_home -v 21) ./gradlew -q compileJava test --tests com.devoxx.genie.service.prompt.command.CustomPromptCommandTest`
