### PR TITLE
fix(lmstudio): resolve API URL mismatch and context length detection (#809)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 - Show resolved custom skill prompt in the user message bubble instead of raw `/command`
 - Migrate legacy HTTP/SSE MCP transport usage to `StreamableHttpMcpTransport` (removes deprecated-for-removal API usage)
+- Issue #809: Fix LM Studio API URL compatibility - changed default from `http://localhost:1234/api/v1/` to `http://localhost:1234/v1/` to match OpenAI-compatible chat completions endpoint, while preserving rich metadata endpoint access for context length detection
+- Issue #809: Fix LM Studio context length detection so model metadata no longer defaults to 8K when larger context values are available
+- Issue #809: Add optional LM Studio fallback context setting in the GUI when model metadata does not expose context length
 
 ## [0.9.1]
 

--- a/src/main/java/com/devoxx/genie/chatmodel/local/lmstudio/LMStudioChatModelFactory.java
+++ b/src/main/java/com/devoxx/genie/chatmodel/local/lmstudio/LMStudioChatModelFactory.java
@@ -44,13 +44,15 @@ public class LMStudioChatModelFactory extends LocalChatModelFactory {
     @Override
     protected LanguageModel buildLanguageModel(Object model) {
         LMStudioModelEntryDTO lmStudioModel = (LMStudioModelEntryDTO) model;
+        Integer configuredFallbackContextLength = DevoxxGenieStateService.getInstance().getLmStudioFallbackContextLength();
+        int fallbackContextLength = configuredFallbackContextLength != null ? configuredFallbackContextLength : DEFAULT_CONTEXT_LENGTH;
         return LanguageModel.builder()
                 .provider(modelProvider)
-                .modelName(lmStudioModel.getId())
-                .displayName(lmStudioModel.getId())
+                .modelName(lmStudioModel.resolveModelName())
+                .displayName(lmStudioModel.resolveDisplayName())
                 .inputCost(0)
                 .outputCost(0)
-                .inputMaxTokens(lmStudioModel.getMax_context_length()!=null?lmStudioModel.getMax_context_length():DEFAULT_CONTEXT_LENGTH)
+                .inputMaxTokens(lmStudioModel.resolveContextLengthOrDefault(fallbackContextLength))
                 .apiKeyUsed(false)
                 .build();
     }

--- a/src/main/java/com/devoxx/genie/chatmodel/local/lmstudio/LMStudioModelService.java
+++ b/src/main/java/com/devoxx/genie/chatmodel/local/lmstudio/LMStudioModelService.java
@@ -3,10 +3,12 @@ package com.devoxx.genie.chatmodel.local.lmstudio;
 import com.devoxx.genie.chatmodel.local.LocalLLMProvider;
 import com.devoxx.genie.chatmodel.local.LocalLLMProviderUtil;
 import com.devoxx.genie.model.lmstudio.LMStudioModelEntryDTO;
+import com.devoxx.genie.ui.settings.DevoxxGenieStateService;
 import com.intellij.openapi.application.ApplicationManager;
 import org.jetbrains.annotations.NotNull;
 
 import java.io.IOException;
+import java.net.URI;
 
 public class LMStudioModelService implements LocalLLMProvider {
 
@@ -17,7 +19,45 @@ public class LMStudioModelService implements LocalLLMProvider {
 
     @Override
     public LMStudioModelEntryDTO[] getModels() throws IOException {
+        // LMStudio has separate API endpoints:
+        // - /api/v1/models : Rich metadata (max_context_length, display_name, loaded_instances)
+        // - /api/v1/chat   : Native LM Studio chat endpoint (recommended in LM Studio 0.4.0+)
+        // - /v1/models     : OpenAI-compatible model list (basic metadata only)
+        // - /v1/chat/completions : OpenAI-compatible chat (used by Langchain4J)
+        //
+        // The chat base URL is set to /v1/ for Langchain4J's OpenAI-compatible client,
+        // but we always use /api/v1/models for model listing to get rich metadata.
+
+        String baseUrl = DevoxxGenieStateService.getInstance().getLmstudioModelUrl();
+        String modelsUrl = buildModelsUrl(baseUrl);
+
         return LocalLLMProviderUtil
-                .getModels("lmStudioModelUrl", "models", LMStudioModelEntryDTO[].class);
+                .getModelsFromUrl(modelsUrl, LMStudioModelEntryDTO[].class);
+    }
+
+    /**
+     * Builds the full URL for the LM Studio rich models endpoint.
+     * Always targets /api/v1/models regardless of the configured chat base URL path.
+     *
+     * @param baseUrl The configured LMStudio base URL (e.g., http://localhost:1234/v1/)
+     * @return The full models endpoint URL (e.g., http://localhost:1234/api/v1/models)
+     */
+    protected String buildModelsUrl(String baseUrl) {
+        if (baseUrl == null || baseUrl.isBlank()) {
+            return "http://localhost:1234/api/v1/models";
+        }
+
+        try {
+            URI uri = URI.create(baseUrl);
+            String scheme = uri.getScheme() != null ? uri.getScheme() : "http";
+            String authority = uri.getAuthority();
+            if (authority == null) {
+                return baseUrl + (baseUrl.endsWith("/") ? "" : "/") + "api/v1/models";
+            }
+            return scheme + "://" + authority + "/api/v1/models";
+        } catch (IllegalArgumentException e) {
+            // Fallback: strip path and append /api/v1/models
+            return baseUrl + (baseUrl.endsWith("/") ? "" : "/") + "api/v1/models";
+        }
     }
 }

--- a/src/main/java/com/devoxx/genie/model/lmstudio/LMStudioModelEntryDTO.java
+++ b/src/main/java/com/devoxx/genie/model/lmstudio/LMStudioModelEntryDTO.java
@@ -1,13 +1,69 @@
 package com.devoxx.genie.model.lmstudio;
 
+import com.google.gson.annotations.SerializedName;
 import lombok.Getter;
 import lombok.Setter;
+
+import java.util.Arrays;
 
 @Setter
 @Getter
 public class LMStudioModelEntryDTO {
+    @SerializedName(value = "id", alternate = {"key"})
     private String id;
+    @SerializedName("display_name")
+    private String displayName;
     private String object;
     private String owned_by;
+
+    @SerializedName(value = "max_context_length", alternate = {"maxContextLength"})
     private Integer max_context_length;
+    private Integer context_length;
+    private LoadedInstance[] loaded_instances;
+
+    public String resolveModelName() {
+        return id;
+    }
+
+    public String resolveDisplayName() {
+        return displayName != null ? displayName : id;
+    }
+
+    public Integer resolveContextLength() {
+        if (max_context_length != null) {
+            return max_context_length;
+        }
+
+        if (context_length != null) {
+            return context_length;
+        }
+
+        if (loaded_instances == null) {
+            return null;
+        }
+
+        return Arrays.stream(loaded_instances)
+                .map(LoadedInstance::getConfig)
+                .filter(config -> config != null && config.getContext_length() != null)
+                .map(Config::getContext_length)
+                .findFirst()
+                .orElse(null);
+    }
+
+    public int resolveContextLengthOrDefault(int defaultValue) {
+        Integer resolvedContextLength = resolveContextLength();
+        return resolvedContextLength != null ? resolvedContextLength : defaultValue;
+    }
+
+    @Setter
+    @Getter
+    public static class LoadedInstance {
+        private Config config;
+    }
+
+    @Setter
+    @Getter
+    public static class Config {
+        private Integer context_length;
+    }
 }

--- a/src/main/java/com/devoxx/genie/ui/settings/DevoxxGenieStateService.java
+++ b/src/main/java/com/devoxx/genie/ui/settings/DevoxxGenieStateService.java
@@ -78,6 +78,7 @@ public final class DevoxxGenieStateService implements PersistentStateComponent<D
     // Local LLM URL fields
     private String ollamaModelUrl = OLLAMA_MODEL_URL;
     private String lmstudioModelUrl = LMSTUDIO_MODEL_URL;
+    private Integer lmStudioFallbackContextLength;
     private String gpt4allModelUrl = GPT4ALL_MODEL_URL;
     private String janModelUrl = JAN_MODEL_URL;
     private String llamaCPPUrl = LLAMA_CPP_MODEL_URL;

--- a/src/main/java/com/devoxx/genie/ui/settings/llm/LLMProvidersComponent.java
+++ b/src/main/java/com/devoxx/genie/ui/settings/llm/LLMProvidersComponent.java
@@ -2,6 +2,8 @@ package com.devoxx.genie.ui.settings.llm;
 
 import com.devoxx.genie.service.PropertiesService;
 import com.devoxx.genie.ui.settings.AbstractSettingsComponent;
+import com.intellij.ide.ui.UINumericRange;
+import com.intellij.ui.JBIntSpinner;
 import com.intellij.ui.JBColor;
 import com.intellij.util.ui.JBUI;
 import lombok.Getter;
@@ -21,6 +23,16 @@ public class LLMProvidersComponent extends AbstractSettingsComponent {
     private final JTextField ollamaModelUrlField = new JTextField(stateService.getOllamaModelUrl());
     @Getter
     private final JTextField lmStudioModelUrlField = new JTextField(stateService.getLmstudioModelUrl());
+    @Getter
+    private final JCheckBox lmStudioFallbackContextEnabledCheckBox = new JCheckBox("", stateService.getLmStudioFallbackContextLength() != null);
+    @Getter
+    private final JBIntSpinner lmStudioFallbackContextField = new JBIntSpinner(
+            new UINumericRange(
+                    stateService.getLmStudioFallbackContextLength() != null ? stateService.getLmStudioFallbackContextLength() : 8000,
+                    1,
+                    2_000_000
+            )
+    );
     @Getter
     private final JTextField gpt4AllModelUrlField = new JTextField(stateService.getGpt4allModelUrl());
     @Getter
@@ -143,7 +155,9 @@ public class LLMProvidersComponent extends AbstractSettingsComponent {
         addProviderSettingRow(panel, gbc, "LMStudio URL", lmStudioEnabledCheckBox,
                 createTextWithLinkButton(lmStudioModelUrlField, "https://lmstudio.ai/"));
         // Add hint text for LMStudio URL
-        addHintText(panel, gbc, "Use \"http://localhost:1234/api/v0\" to get the correct window context");
+        addHintText(panel, gbc, "Base URL for OpenAI-compatible chat; model metadata is always fetched from /api/v1/models");
+        addProviderSettingRow(panel, gbc, "LMStudio Fallback Context", lmStudioFallbackContextEnabledCheckBox, lmStudioFallbackContextField);
+        addHintText(panel, gbc, "Used only when LMStudio model metadata does not expose context length");
         addProviderSettingRow(panel, gbc, "GPT4All URL", gpt4AllEnabledCheckBox,
                 createTextWithLinkButton(gpt4AllModelUrlField, "https://gpt4all.io/"));
         addProviderSettingRow(panel, gbc, "Jan URL", janEnabledCheckBox,
@@ -209,6 +223,7 @@ public class LLMProvidersComponent extends AbstractSettingsComponent {
         // Add new listeners for enable/disable checkboxes
         ollamaEnabledCheckBox.addItemListener(e -> updateUrlFieldState(ollamaEnabledCheckBox, ollamaModelUrlField));
         lmStudioEnabledCheckBox.addItemListener(e -> updateUrlFieldState(lmStudioEnabledCheckBox, lmStudioModelUrlField));
+        lmStudioFallbackContextEnabledCheckBox.addItemListener(e -> updateUrlFieldState(lmStudioFallbackContextEnabledCheckBox, lmStudioFallbackContextField));
         gpt4AllEnabledCheckBox.addItemListener(e -> updateUrlFieldState(gpt4AllEnabledCheckBox, gpt4AllModelUrlField));
         janEnabledCheckBox.addItemListener(e -> updateUrlFieldState(janEnabledCheckBox, janModelUrlField));
         llamaCPPEnabledCheckBox.addItemListener(e -> updateUrlFieldState(llamaCPPEnabledCheckBox, llamaCPPModelUrlField));
@@ -227,6 +242,8 @@ public class LLMProvidersComponent extends AbstractSettingsComponent {
         openRouterEnabledCheckBox.addItemListener(e -> updateUrlFieldState(openRouterEnabledCheckBox, openRouterApiKeyField));
         grokEnabledCheckBox.addItemListener(e -> updateUrlFieldState(grokEnabledCheckBox, grokApiKeyField));
         enableAzureOpenAICheckBox.addItemListener(e -> updateUrlFieldState(enableAzureOpenAICheckBox, azureOpenAIEndpointField));
+
+        updateUrlFieldState(lmStudioFallbackContextEnabledCheckBox, lmStudioFallbackContextField);
     }
 
     private void addAzureOpenAIPanel(JPanel panel, GridBagConstraints gbc) {

--- a/src/main/java/com/devoxx/genie/ui/settings/llm/LLMProvidersConfigurable.java
+++ b/src/main/java/com/devoxx/genie/ui/settings/llm/LLMProvidersConfigurable.java
@@ -69,6 +69,11 @@ public class LLMProvidersConfigurable implements Configurable {
 
         isModified |= isFieldModified(llmSettingsComponent.getOllamaModelUrlField(), stateService.getOllamaModelUrl());
         isModified |= isFieldModified(llmSettingsComponent.getLmStudioModelUrlField(), stateService.getLmstudioModelUrl());
+        isModified |= (stateService.getLmStudioFallbackContextLength() != null) != llmSettingsComponent.getLmStudioFallbackContextEnabledCheckBox().isSelected();
+        if (llmSettingsComponent.getLmStudioFallbackContextEnabledCheckBox().isSelected()) {
+            Integer savedFallback = stateService.getLmStudioFallbackContextLength();
+            isModified |= savedFallback == null || !savedFallback.equals(llmSettingsComponent.getLmStudioFallbackContextField().getNumber());
+        }
         isModified |= isFieldModified(llmSettingsComponent.getGpt4AllModelUrlField(), stateService.getGpt4allModelUrl());
         isModified |= isFieldModified(llmSettingsComponent.getJanModelUrlField(), stateService.getJanModelUrl());
 
@@ -127,6 +132,11 @@ public class LLMProvidersConfigurable implements Configurable {
 
         settings.setOllamaModelUrl(llmSettingsComponent.getOllamaModelUrlField().getText());
         settings.setLmstudioModelUrl(llmSettingsComponent.getLmStudioModelUrlField().getText());
+        settings.setLmStudioFallbackContextLength(
+                llmSettingsComponent.getLmStudioFallbackContextEnabledCheckBox().isSelected()
+                        ? llmSettingsComponent.getLmStudioFallbackContextField().getNumber()
+                        : null
+        );
         settings.setGpt4allModelUrl(llmSettingsComponent.getGpt4AllModelUrlField().getText());
         settings.setJanModelUrl(llmSettingsComponent.getJanModelUrlField().getText());
         settings.setLlamaCPPUrl(llmSettingsComponent.getLlamaCPPModelUrlField().getText());
@@ -215,6 +225,11 @@ public class LLMProvidersConfigurable implements Configurable {
 
         llmSettingsComponent.getOllamaModelUrlField().setText(settings.getOllamaModelUrl());
         llmSettingsComponent.getLmStudioModelUrlField().setText(settings.getLmstudioModelUrl());
+        llmSettingsComponent.getLmStudioFallbackContextEnabledCheckBox().setSelected(settings.getLmStudioFallbackContextLength() != null);
+        llmSettingsComponent.getLmStudioFallbackContextField().setNumber(
+                settings.getLmStudioFallbackContextLength() != null ? settings.getLmStudioFallbackContextLength() : 8000
+        );
+        llmSettingsComponent.getLmStudioFallbackContextField().setEnabled(settings.getLmStudioFallbackContextLength() != null);
         llmSettingsComponent.getGpt4AllModelUrlField().setText(settings.getGpt4allModelUrl());
         llmSettingsComponent.getJanModelUrlField().setText(settings.getJanModelUrl());
         llmSettingsComponent.getLlamaCPPModelUrlField().setText(settings.getLlamaCPPUrl());

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -43,6 +43,8 @@
             <LI>Show resolved custom skill prompt in user message instead of raw /command</LI>
             <LI>Migrate legacy HTTP/SSE MCP transport usage to StreamableHttpMcpTransport</LI>
             <LI>Update welcome wording to Skills terminology and highlight MCP Marketplace first</LI>
+            <LI>Issue #809: Fix LM Studio context length detection to use model metadata instead of defaulting to 8K</LI>
+            <LI>Issue #809: Add optional LM Studio fallback context setting in the GUI</LI>
         </UL>
         <h2>v0.9.1</h2>
         <UL>

--- a/src/test/java/com/devoxx/genie/chatmodel/local/lmstudio/LMStudioChatModelFactoryTest.java
+++ b/src/test/java/com/devoxx/genie/chatmodel/local/lmstudio/LMStudioChatModelFactoryTest.java
@@ -1,18 +1,24 @@
 package com.devoxx.genie.chatmodel.local.lmstudio;
 
 import com.devoxx.genie.model.CustomChatModel;
+import com.devoxx.genie.model.LanguageModel;
+import com.devoxx.genie.model.lmstudio.LMStudioModelEntryDTO;
 import com.devoxx.genie.ui.settings.DevoxxGenieStateService;
+import com.google.gson.Gson;
 import dev.langchain4j.model.chat.ChatModel;
 
 import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
+import java.lang.reflect.Method;
+
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 class LMStudioChatModelFactoryTest {
+    private final Gson gson = new Gson();
 
     @Test
     void testCreateChatModel() {
@@ -20,7 +26,7 @@ class LMStudioChatModelFactoryTest {
             // Setup the mock for SettingsState
             DevoxxGenieStateService mockSettingsState = mock(DevoxxGenieStateService.class);
             when(DevoxxGenieStateService.getInstance()).thenReturn(mockSettingsState);
-            when(mockSettingsState.getLmstudioModelUrl()).thenReturn("http://localhost:8080");
+            when(mockSettingsState.getLmstudioModelUrl()).thenReturn("http://localhost:1234/v1/");
 
             // Instance of the class containing the method to be tested
             LMStudioChatModelFactory factory = new LMStudioChatModelFactory();
@@ -32,6 +38,51 @@ class LMStudioChatModelFactoryTest {
             // Call the method
             ChatModel result = factory.createChatModel(customChatModel);
             assertThat(result).isNotNull();
+        }
+    }
+
+    @Test
+    void buildLanguageModel_usesConfiguredFallbackContextLengthWhenModelContextIsMissing() throws Exception {
+        try (MockedStatic<DevoxxGenieStateService> mockedSettings = Mockito.mockStatic(DevoxxGenieStateService.class)) {
+            DevoxxGenieStateService mockSettingsState = mock(DevoxxGenieStateService.class);
+            when(DevoxxGenieStateService.getInstance()).thenReturn(mockSettingsState);
+            when(mockSettingsState.getLmStudioFallbackContextLength()).thenReturn(131072);
+
+            LMStudioChatModelFactory factory = new LMStudioChatModelFactory();
+            LMStudioModelEntryDTO modelEntryDTO = new LMStudioModelEntryDTO();
+            modelEntryDTO.setId("test-model");
+
+            Method buildLanguageModel = LMStudioChatModelFactory.class.getDeclaredMethod("buildLanguageModel", Object.class);
+            buildLanguageModel.setAccessible(true);
+            LanguageModel languageModel = (LanguageModel) buildLanguageModel.invoke(factory, modelEntryDTO);
+
+            assertThat(languageModel.getInputMaxTokens()).isEqualTo(131072);
+        }
+    }
+
+    @Test
+    void buildLanguageModel_supportsApiV1ModelsResponseShape() throws Exception {
+        try (MockedStatic<DevoxxGenieStateService> mockedSettings = Mockito.mockStatic(DevoxxGenieStateService.class)) {
+            DevoxxGenieStateService mockSettingsState = mock(DevoxxGenieStateService.class);
+            when(DevoxxGenieStateService.getInstance()).thenReturn(mockSettingsState);
+            when(mockSettingsState.getLmStudioFallbackContextLength()).thenReturn(null);
+
+            LMStudioChatModelFactory factory = new LMStudioChatModelFactory();
+            LMStudioModelEntryDTO modelEntryDTO = gson.fromJson("""
+                    {
+                      "key": "text-embedding-nomic-embed-text-v1.5",
+                      "display_name": "Nomic Embed Text v1.5",
+                      "max_context_length": 2048
+                    }
+                    """, LMStudioModelEntryDTO.class);
+
+            Method buildLanguageModel = LMStudioChatModelFactory.class.getDeclaredMethod("buildLanguageModel", Object.class);
+            buildLanguageModel.setAccessible(true);
+            LanguageModel languageModel = (LanguageModel) buildLanguageModel.invoke(factory, modelEntryDTO);
+
+            assertThat(languageModel.getModelName()).isEqualTo("text-embedding-nomic-embed-text-v1.5");
+            assertThat(languageModel.getDisplayName()).isEqualTo("Nomic Embed Text v1.5");
+            assertThat(languageModel.getInputMaxTokens()).isEqualTo(2048);
         }
     }
 }

--- a/src/test/java/com/devoxx/genie/chatmodel/local/lmstudio/LMStudioModelServiceTest.java
+++ b/src/test/java/com/devoxx/genie/chatmodel/local/lmstudio/LMStudioModelServiceTest.java
@@ -1,0 +1,77 @@
+package com.devoxx.genie.chatmodel.local.lmstudio;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class LMStudioModelServiceTest {
+
+    private static class TestableModelService extends LMStudioModelService {
+        public String testBuildModelsUrl(String baseUrl) {
+            return buildModelsUrl(baseUrl);
+        }
+    }
+
+    @Test
+    void buildModelsUrl_withV1BaseUrl_returnsApiV1ModelsUrl() {
+        TestableModelService service = new TestableModelService();
+        String url = service.testBuildModelsUrl("http://localhost:1234/v1/");
+        assertThat(url).isEqualTo("http://localhost:1234/api/v1/models");
+    }
+
+    @Test
+    void buildModelsUrl_withApiV1BaseUrl_returnsApiV1ModelsUrl() {
+        TestableModelService service = new TestableModelService();
+        String url = service.testBuildModelsUrl("http://localhost:1234/api/v1/");
+        assertThat(url).isEqualTo("http://localhost:1234/api/v1/models");
+    }
+
+    @Test
+    void buildModelsUrl_withNullBaseUrl_returnsDefaultUrl() {
+        TestableModelService service = new TestableModelService();
+        String url = service.testBuildModelsUrl(null);
+        assertThat(url).isEqualTo("http://localhost:1234/api/v1/models");
+    }
+
+    @Test
+    void buildModelsUrl_withBlankBaseUrl_returnsDefaultUrl() {
+        TestableModelService service = new TestableModelService();
+        String url = service.testBuildModelsUrl("  ");
+        assertThat(url).isEqualTo("http://localhost:1234/api/v1/models");
+    }
+
+    @Test
+    void buildModelsUrl_withCustomPort_preservesHostAndPort() {
+        TestableModelService service = new TestableModelService();
+        String url = service.testBuildModelsUrl("http://localhost:5678/v1/");
+        assertThat(url).isEqualTo("http://localhost:5678/api/v1/models");
+    }
+
+    @Test
+    void buildModelsUrl_withCustomHost_preservesHost() {
+        TestableModelService service = new TestableModelService();
+        String url = service.testBuildModelsUrl("http://myserver:1234/v1/");
+        assertThat(url).isEqualTo("http://myserver:1234/api/v1/models");
+    }
+
+    @Test
+    void buildModelsUrl_withoutTrailingSlash_stillWorks() {
+        TestableModelService service = new TestableModelService();
+        String url = service.testBuildModelsUrl("http://localhost:1234/v1");
+        assertThat(url).isEqualTo("http://localhost:1234/api/v1/models");
+    }
+
+    @Test
+    void buildModelsUrl_withRootPath_extractsHostCorrectly() {
+        TestableModelService service = new TestableModelService();
+        String url = service.testBuildModelsUrl("http://localhost:1234/");
+        assertThat(url).isEqualTo("http://localhost:1234/api/v1/models");
+    }
+
+    @Test
+    void buildModelsUrl_withHttps_preservesScheme() {
+        TestableModelService service = new TestableModelService();
+        String url = service.testBuildModelsUrl("https://lmstudio.example.com:1234/v1/");
+        assertThat(url).isEqualTo("https://lmstudio.example.com:1234/api/v1/models");
+    }
+}

--- a/src/test/java/com/devoxx/genie/model/lmstudio/LMStudioModelEntryDTOTest.java
+++ b/src/test/java/com/devoxx/genie/model/lmstudio/LMStudioModelEntryDTOTest.java
@@ -1,0 +1,136 @@
+package com.devoxx.genie.model.lmstudio;
+
+import com.google.gson.Gson;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class LMStudioModelEntryDTOTest {
+
+    private final Gson gson = new Gson();
+
+    @Test
+    void resolveContextLength_usesMaxContextLengthWhenPresent() {
+        LMStudioModelEntryDTO model = gson.fromJson("""
+                {
+                  "id": "mistralai/devstral-small-2-2512",
+                  "max_context_length": 393216
+                }
+                """, LMStudioModelEntryDTO.class);
+
+        assertThat(model.resolveContextLength()).isEqualTo(393216);
+    }
+
+    @Test
+    void resolveContextLength_usesLoadedInstanceContextLengthAsFallback() {
+        LMStudioModelEntryDTO model = gson.fromJson("""
+                {
+                  "id": "mistralai/devstral-small-2-2512",
+                  "loaded_instances": [
+                    {
+                      "id": "mistralai/devstral-small-2-2512",
+                      "config": {
+                        "context_length": 393216
+                      }
+                    }
+                  ]
+                }
+                """, LMStudioModelEntryDTO.class);
+
+        assertThat(model.resolveContextLength()).isEqualTo(393216);
+    }
+
+    @Test
+    void resolveContextLength_supportsCamelCaseAlternativeField() {
+        LMStudioModelEntryDTO model = gson.fromJson("""
+                {
+                  "id": "example/model",
+                  "maxContextLength": 131072
+                }
+                """, LMStudioModelEntryDTO.class);
+
+        assertThat(model.resolveContextLength()).isEqualTo(131072);
+    }
+
+    @Test
+    void resolveContextLengthOrDefault_returnsDefaultWhenNoContextLengthFound() {
+        LMStudioModelEntryDTO model = gson.fromJson("""
+                {
+                  "id": "example/model"
+                }
+                """, LMStudioModelEntryDTO.class);
+
+        assertThat(model.resolveContextLengthOrDefault(8000)).isEqualTo(8000);
+    }
+
+    @Test
+    void resolveModelName_supportsApiV1ModelsKeyField() {
+        LMStudioModelEntryDTO model = gson.fromJson("""
+                {
+                  "key": "text-embedding-nomic-embed-text-v1.5"
+                }
+                """, LMStudioModelEntryDTO.class);
+
+        assertThat(model.resolveModelName()).isEqualTo("text-embedding-nomic-embed-text-v1.5");
+    }
+
+    @Test
+    void resolveDisplayName_prefersDisplayNameFromApiV1Models() {
+        LMStudioModelEntryDTO model = gson.fromJson("""
+                {
+                  "key": "text-embedding-nomic-embed-text-v1.5",
+                  "display_name": "Nomic Embed Text v1.5"
+                }
+                """, LMStudioModelEntryDTO.class);
+
+        assertThat(model.resolveDisplayName()).isEqualTo("Nomic Embed Text v1.5");
+    }
+
+    /**
+     * Regression test for <a href="https://github.com/devoxx/DevoxxGenieIDEAPlugin/issues/809">#809</a>:
+     * Parses the exact JSON from the issue to verify context length is not stuck at 8K default.
+     */
+    @Test
+    void issue809_fullApiV1ModelsResponse_parsesContextLengthCorrectly() {
+        LMStudioModelEntryDTO model = gson.fromJson("""
+                {
+                  "type": "llm",
+                  "publisher": "mistralai",
+                  "key": "mistralai/devstral-small-2-2512",
+                  "display_name": "Devstral Small 2 2512",
+                  "architecture": "mistral3",
+                  "quantization": {
+                    "name": "4bit",
+                    "bits_per_weight": 4
+                  },
+                  "size_bytes": 14120998772,
+                  "params_string": "24B",
+                  "loaded_instances": [
+                    {
+                      "id": "mistralai/devstral-small-2-2512",
+                      "config": {
+                        "context_length": 393216
+                      }
+                    }
+                  ],
+                  "max_context_length": 393216,
+                  "format": "mlx",
+                  "capabilities": {
+                    "vision": true,
+                    "trained_for_tool_use": true
+                  },
+                  "description": null,
+                  "variants": [
+                    "mistralai/devstral-small-2-2512@4bit"
+                  ],
+                  "selected_variant": "mistralai/devstral-small-2-2512@4bit"
+                }
+                """, LMStudioModelEntryDTO.class);
+
+        // Issue #809: context length should NOT default to 8000
+        assertThat(model.resolveModelName()).isEqualTo("mistralai/devstral-small-2-2512");
+        assertThat(model.resolveDisplayName()).isEqualTo("Devstral Small 2 2512");
+        assertThat(model.resolveContextLength()).isEqualTo(393216);
+        assertThat(model.resolveContextLengthOrDefault(8000)).isEqualTo(393216);
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #809 — LM Studio context length always defaulted to 8K tokens, and chat completions failed due to an API URL mismatch.

**Root cause:** LM Studio uses separate URL prefixes for different APIs:
- `/api/v1/*` — Native LM Studio API (rich model metadata, native chat)
- `/v1/*` — OpenAI-compatible endpoints (`/v1/chat/completions`)

DevoxxGenie used `/api/v1/` as the base URL for everything. Since Langchain4J appends `/chat/completions`, this called `/api/v1/chat/completions` which doesn't exist, breaking chat entirely.

**Changes:**
- Change default base URL from `/api/v1/` to `/v1/` for OpenAI-compatible chat
- `LMStudioModelService.buildModelsUrl()` extracts host:port from the configured URL and always targets `/api/v1/models` for rich metadata
- `LocalLLMProviderUtil` gains `getModelsFromUrl()` for direct URL access when the models endpoint differs from the chat base URL
- `LMStudioModelEntryDTO` enhanced with multi-level context length resolution: `max_context_length` → `context_length` → `loaded_instances[].config.context_length`
- Added configurable fallback context length setting in Settings → LLM Providers
- Updated settings hint text to reflect new URL structure

## Test plan

- [x] `LMStudioModelEntryDTOTest` — 7 tests including regression test with exact JSON from issue #809 (verifies 393216 context length parsed instead of 8K default)
- [x] `LMStudioModelServiceTest` — 9 tests for URL construction (custom host/port, HTTPS, trailing slash variations, backward compatibility)
- [x] `LMStudioChatModelFactoryTest` — 3 tests for model creation and fallback context length
- [ ] Manual: Start LM Studio, verify models list with context lengths in Settings → LLM Providers
- [ ] Manual: Send a chat prompt and verify response works (no more "Unexpected endpoint" error)

🤖 Generated with [Claude Code](https://claude.com/claude-code)