### PR TITLE
fix: replace deprecated Project.getBaseDir() with ProjectUtil.guessPr…

### DIFF
--- a/src/main/java/com/devoxx/genie/service/analyzer/DevoxxGenieGenerator.java
+++ b/src/main/java/com/devoxx/genie/service/analyzer/DevoxxGenieGenerator.java
@@ -10,6 +10,7 @@ import com.intellij.openapi.application.ReadAction;
 import com.intellij.openapi.application.WriteAction;
 import com.intellij.openapi.progress.ProgressIndicator;
 import com.intellij.openapi.project.Project;
+import com.intellij.openapi.project.ProjectUtil;
 import com.intellij.openapi.vfs.VirtualFile;
 import lombok.extern.slf4j.Slf4j;
 import org.jetbrains.annotations.NotNull;
@@ -50,7 +51,7 @@ public class DevoxxGenieGenerator {
                                 ProgressIndicator indicator) {
         this.project = project;
         this.includeTree = includeTree;
-        this.baseDir = project.getBaseDir();
+        this.baseDir = ProjectUtil.guessProjectDir(project);
         this.indicator = indicator;
         
         // Initialize components

--- a/src/main/java/com/devoxx/genie/service/analyzer/languages/cpp/CppProjectScannerExtension.java
+++ b/src/main/java/com/devoxx/genie/service/analyzer/languages/cpp/CppProjectScannerExtension.java
@@ -2,6 +2,7 @@ package com.devoxx.genie.service.analyzer.languages.cpp;
 
 import com.devoxx.genie.service.analyzer.ProjectAnalyzerExtension;
 import com.intellij.openapi.project.Project;
+import com.intellij.openapi.project.ProjectUtil;
 import com.intellij.openapi.vfs.VfsUtil;
 import com.intellij.openapi.vfs.VirtualFile;
 import org.jetbrains.annotations.NotNull;
@@ -25,7 +26,7 @@ public class CppProjectScannerExtension implements ProjectAnalyzerExtension {
         }
 
         // Get project base directory
-        VirtualFile baseDir = project.getBaseDir();
+        VirtualFile baseDir = ProjectUtil.guessProjectDir(project);
         if (baseDir == null) {
             return;
         }

--- a/src/main/java/com/devoxx/genie/service/analyzer/languages/go/GoProjectScannerExtension.java
+++ b/src/main/java/com/devoxx/genie/service/analyzer/languages/go/GoProjectScannerExtension.java
@@ -2,6 +2,7 @@ package com.devoxx.genie.service.analyzer.languages.go;
 
 import com.devoxx.genie.service.analyzer.ProjectAnalyzerExtension;
 import com.intellij.openapi.project.Project;
+import com.intellij.openapi.project.ProjectUtil;
 import com.intellij.openapi.vfs.VfsUtil;
 import com.intellij.openapi.vfs.VirtualFile;
 import org.jetbrains.annotations.NotNull;
@@ -25,7 +26,7 @@ public class GoProjectScannerExtension implements ProjectAnalyzerExtension {
         }
 
         // Get project base directory
-        VirtualFile baseDir = project.getBaseDir();
+        VirtualFile baseDir = ProjectUtil.guessProjectDir(project);
         if (baseDir == null) {
             return;
         }

--- a/src/main/java/com/devoxx/genie/service/analyzer/languages/javascript/JavaScriptProjectScannerExtension.java
+++ b/src/main/java/com/devoxx/genie/service/analyzer/languages/javascript/JavaScriptProjectScannerExtension.java
@@ -2,6 +2,7 @@ package com.devoxx.genie.service.analyzer.languages.javascript;
 
 import com.devoxx.genie.service.analyzer.ProjectAnalyzerExtension;
 import com.intellij.openapi.project.Project;
+import com.intellij.openapi.project.ProjectUtil;
 import com.intellij.openapi.vfs.VfsUtil;
 import com.intellij.openapi.vfs.VirtualFile;
 import org.jetbrains.annotations.NotNull;
@@ -27,7 +28,7 @@ public class JavaScriptProjectScannerExtension implements ProjectAnalyzerExtensi
         }
 
         // Get project base directory
-        VirtualFile baseDir = project.getBaseDir();
+        VirtualFile baseDir = ProjectUtil.guessProjectDir(project);
         if (baseDir == null) {
             return;
         }

--- a/src/main/java/com/devoxx/genie/service/analyzer/languages/kotlin/KotlinProjectScannerExtension.java
+++ b/src/main/java/com/devoxx/genie/service/analyzer/languages/kotlin/KotlinProjectScannerExtension.java
@@ -2,6 +2,7 @@ package com.devoxx.genie.service.analyzer.languages.kotlin;
 
 import com.devoxx.genie.service.analyzer.ProjectAnalyzerExtension;
 import com.intellij.openapi.project.Project;
+import com.intellij.openapi.project.ProjectUtil;
 import com.intellij.openapi.vfs.VfsUtil;
 import com.intellij.openapi.vfs.VirtualFile;
 import org.jetbrains.annotations.NotNull;
@@ -25,7 +26,7 @@ public class KotlinProjectScannerExtension implements ProjectAnalyzerExtension {
         }
 
         // Get project base directory
-        VirtualFile baseDir = project.getBaseDir();
+        VirtualFile baseDir = ProjectUtil.guessProjectDir(project);
         if (baseDir == null) {
             return;
         }

--- a/src/main/java/com/devoxx/genie/service/analyzer/languages/php/PhpProjectScannerExtension.java
+++ b/src/main/java/com/devoxx/genie/service/analyzer/languages/php/PhpProjectScannerExtension.java
@@ -2,6 +2,7 @@ package com.devoxx.genie.service.analyzer.languages.php;
 
 import com.devoxx.genie.service.analyzer.ProjectAnalyzerExtension;
 import com.intellij.openapi.project.Project;
+import com.intellij.openapi.project.ProjectUtil;
 import com.intellij.openapi.vfs.VfsUtil;
 import com.intellij.openapi.vfs.VirtualFile;
 import org.jetbrains.annotations.NotNull;
@@ -25,7 +26,7 @@ public class PhpProjectScannerExtension implements ProjectAnalyzerExtension {
         }
 
         // Get project base directory
-        VirtualFile baseDir = project.getBaseDir();
+        VirtualFile baseDir = ProjectUtil.guessProjectDir(project);
         if (baseDir == null) {
             return;
         }

--- a/src/main/java/com/devoxx/genie/service/analyzer/languages/python/PythonProjectScannerExtension.java
+++ b/src/main/java/com/devoxx/genie/service/analyzer/languages/python/PythonProjectScannerExtension.java
@@ -2,6 +2,7 @@ package com.devoxx.genie.service.analyzer.languages.python;
 
 import com.devoxx.genie.service.analyzer.ProjectAnalyzerExtension;
 import com.intellij.openapi.project.Project;
+import com.intellij.openapi.project.ProjectUtil;
 import com.intellij.openapi.vfs.VfsUtil;
 import com.intellij.openapi.vfs.VirtualFile;
 import org.jetbrains.annotations.NotNull;
@@ -25,7 +26,7 @@ public class PythonProjectScannerExtension implements ProjectAnalyzerExtension {
         }
 
         // Get project base directory
-        VirtualFile baseDir = project.getBaseDir();
+        VirtualFile baseDir = ProjectUtil.guessProjectDir(project);
         if (baseDir == null) {
             return;
         }

--- a/src/main/java/com/devoxx/genie/service/analyzer/languages/rust/RustProjectScannerExtension.java
+++ b/src/main/java/com/devoxx/genie/service/analyzer/languages/rust/RustProjectScannerExtension.java
@@ -2,6 +2,7 @@ package com.devoxx.genie.service.analyzer.languages.rust;
 
 import com.devoxx.genie.service.analyzer.ProjectAnalyzerExtension;
 import com.intellij.openapi.project.Project;
+import com.intellij.openapi.project.ProjectUtil;
 import com.intellij.openapi.vfs.VfsUtil;
 import com.intellij.openapi.vfs.VirtualFile;
 import org.jetbrains.annotations.NotNull;
@@ -26,7 +27,7 @@ public class RustProjectScannerExtension implements ProjectAnalyzerExtension {
         }
 
         // Get project base directory
-        VirtualFile baseDir = project.getBaseDir();
+        VirtualFile baseDir = ProjectUtil.guessProjectDir(project);
         if (baseDir == null) {
             return;
         }

--- a/src/test/java/com/devoxx/genie/service/analyzer/ProjectAnalyzerExtensionTest.java
+++ b/src/test/java/com/devoxx/genie/service/analyzer/ProjectAnalyzerExtensionTest.java
@@ -1,0 +1,258 @@
+package com.devoxx.genie.service.analyzer;
+
+import com.devoxx.genie.service.analyzer.languages.cpp.CppProjectScannerExtension;
+import com.devoxx.genie.service.analyzer.languages.go.GoProjectScannerExtension;
+import com.devoxx.genie.service.analyzer.languages.javascript.JavaScriptProjectScannerExtension;
+import com.devoxx.genie.service.analyzer.languages.kotlin.KotlinProjectScannerExtension;
+import com.devoxx.genie.service.analyzer.languages.php.PhpProjectScannerExtension;
+import com.devoxx.genie.service.analyzer.languages.python.PythonProjectScannerExtension;
+import com.devoxx.genie.service.analyzer.languages.rust.RustProjectScannerExtension;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.project.ProjectUtil;
+import com.intellij.openapi.vfs.VirtualFile;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Tests that all ProjectAnalyzerExtension implementations use
+ * ProjectUtil.guessProjectDir(project) instead of the deprecated project.getBaseDir().
+ */
+class ProjectAnalyzerExtensionTest {
+
+    private Project mockProject;
+    private VirtualFile mockBaseDir;
+
+    @BeforeEach
+    void setUp() {
+        mockProject = mock(Project.class);
+        mockBaseDir = mock(VirtualFile.class);
+        when(mockBaseDir.isDirectory()).thenReturn(true);
+        when(mockBaseDir.getPath()).thenReturn("/project");
+        when(mockBaseDir.getName()).thenReturn("project");
+    }
+
+    @Test
+    void cppExtension_usesProjectUtilGuessProjectDir() {
+        CppProjectScannerExtension extension = new CppProjectScannerExtension();
+        Map<String, Object> projectInfo = createProjectInfoWithLanguage("C/C++");
+
+        try (MockedStatic<ProjectUtil> projectUtilMock = mockStatic(ProjectUtil.class)) {
+            projectUtilMock.when(() -> ProjectUtil.guessProjectDir(mockProject)).thenReturn(mockBaseDir);
+
+            extension.enhanceProjectInfo(mockProject, projectInfo);
+
+            projectUtilMock.verify(() -> ProjectUtil.guessProjectDir(mockProject));
+        }
+    }
+
+    @Test
+    void cppExtension_handlesNullProjectDir() {
+        CppProjectScannerExtension extension = new CppProjectScannerExtension();
+        Map<String, Object> projectInfo = createProjectInfoWithLanguage("C/C++");
+
+        try (MockedStatic<ProjectUtil> projectUtilMock = mockStatic(ProjectUtil.class)) {
+            projectUtilMock.when(() -> ProjectUtil.guessProjectDir(mockProject)).thenReturn(null);
+
+            extension.enhanceProjectInfo(mockProject, projectInfo);
+
+            // Should return early without adding cpp info
+            assertNull(projectInfo.get("cpp"));
+        }
+    }
+
+    @Test
+    void cppExtension_skipsNonCppProject() {
+        CppProjectScannerExtension extension = new CppProjectScannerExtension();
+        Map<String, Object> projectInfo = createProjectInfoWithLanguage("Java");
+
+        try (MockedStatic<ProjectUtil> projectUtilMock = mockStatic(ProjectUtil.class)) {
+            extension.enhanceProjectInfo(mockProject, projectInfo);
+
+            // Should not even call guessProjectDir for non-C++ projects
+            projectUtilMock.verify(() -> ProjectUtil.guessProjectDir(mockProject), never());
+        }
+    }
+
+    @Test
+    void goExtension_usesProjectUtilGuessProjectDir() {
+        GoProjectScannerExtension extension = new GoProjectScannerExtension();
+        Map<String, Object> projectInfo = createProjectInfoWithLanguage("Go");
+
+        try (MockedStatic<ProjectUtil> projectUtilMock = mockStatic(ProjectUtil.class)) {
+            projectUtilMock.when(() -> ProjectUtil.guessProjectDir(mockProject)).thenReturn(mockBaseDir);
+
+            extension.enhanceProjectInfo(mockProject, projectInfo);
+
+            projectUtilMock.verify(() -> ProjectUtil.guessProjectDir(mockProject));
+        }
+    }
+
+    @Test
+    void goExtension_handlesNullProjectDir() {
+        GoProjectScannerExtension extension = new GoProjectScannerExtension();
+        Map<String, Object> projectInfo = createProjectInfoWithLanguage("Go");
+
+        try (MockedStatic<ProjectUtil> projectUtilMock = mockStatic(ProjectUtil.class)) {
+            projectUtilMock.when(() -> ProjectUtil.guessProjectDir(mockProject)).thenReturn(null);
+
+            extension.enhanceProjectInfo(mockProject, projectInfo);
+
+            assertNull(projectInfo.get("go"));
+        }
+    }
+
+    @Test
+    void jsExtension_usesProjectUtilGuessProjectDir() {
+        JavaScriptProjectScannerExtension extension = new JavaScriptProjectScannerExtension();
+        Map<String, Object> projectInfo = createProjectInfoWithLanguage("JavaScript");
+
+        try (MockedStatic<ProjectUtil> projectUtilMock = mockStatic(ProjectUtil.class)) {
+            projectUtilMock.when(() -> ProjectUtil.guessProjectDir(mockProject)).thenReturn(mockBaseDir);
+
+            extension.enhanceProjectInfo(mockProject, projectInfo);
+
+            projectUtilMock.verify(() -> ProjectUtil.guessProjectDir(mockProject));
+        }
+    }
+
+    @Test
+    void jsExtension_handlesNullProjectDir() {
+        JavaScriptProjectScannerExtension extension = new JavaScriptProjectScannerExtension();
+        Map<String, Object> projectInfo = createProjectInfoWithLanguage("JavaScript");
+
+        try (MockedStatic<ProjectUtil> projectUtilMock = mockStatic(ProjectUtil.class)) {
+            projectUtilMock.when(() -> ProjectUtil.guessProjectDir(mockProject)).thenReturn(null);
+
+            extension.enhanceProjectInfo(mockProject, projectInfo);
+
+            assertNull(projectInfo.get("javascript"));
+        }
+    }
+
+    @Test
+    void kotlinExtension_usesProjectUtilGuessProjectDir() {
+        KotlinProjectScannerExtension extension = new KotlinProjectScannerExtension();
+        Map<String, Object> projectInfo = createProjectInfoWithLanguage("Kotlin");
+
+        try (MockedStatic<ProjectUtil> projectUtilMock = mockStatic(ProjectUtil.class)) {
+            projectUtilMock.when(() -> ProjectUtil.guessProjectDir(mockProject)).thenReturn(mockBaseDir);
+
+            extension.enhanceProjectInfo(mockProject, projectInfo);
+
+            projectUtilMock.verify(() -> ProjectUtil.guessProjectDir(mockProject));
+        }
+    }
+
+    @Test
+    void kotlinExtension_handlesNullProjectDir() {
+        KotlinProjectScannerExtension extension = new KotlinProjectScannerExtension();
+        Map<String, Object> projectInfo = createProjectInfoWithLanguage("Kotlin");
+
+        try (MockedStatic<ProjectUtil> projectUtilMock = mockStatic(ProjectUtil.class)) {
+            projectUtilMock.when(() -> ProjectUtil.guessProjectDir(mockProject)).thenReturn(null);
+
+            extension.enhanceProjectInfo(mockProject, projectInfo);
+
+            assertNull(projectInfo.get("kotlin"));
+        }
+    }
+
+    @Test
+    void phpExtension_usesProjectUtilGuessProjectDir() {
+        PhpProjectScannerExtension extension = new PhpProjectScannerExtension();
+        Map<String, Object> projectInfo = createProjectInfoWithLanguage("PHP");
+
+        try (MockedStatic<ProjectUtil> projectUtilMock = mockStatic(ProjectUtil.class)) {
+            projectUtilMock.when(() -> ProjectUtil.guessProjectDir(mockProject)).thenReturn(mockBaseDir);
+
+            extension.enhanceProjectInfo(mockProject, projectInfo);
+
+            projectUtilMock.verify(() -> ProjectUtil.guessProjectDir(mockProject));
+        }
+    }
+
+    @Test
+    void phpExtension_handlesNullProjectDir() {
+        PhpProjectScannerExtension extension = new PhpProjectScannerExtension();
+        Map<String, Object> projectInfo = createProjectInfoWithLanguage("PHP");
+
+        try (MockedStatic<ProjectUtil> projectUtilMock = mockStatic(ProjectUtil.class)) {
+            projectUtilMock.when(() -> ProjectUtil.guessProjectDir(mockProject)).thenReturn(null);
+
+            extension.enhanceProjectInfo(mockProject, projectInfo);
+
+            assertNull(projectInfo.get("php"));
+        }
+    }
+
+    @Test
+    void pythonExtension_usesProjectUtilGuessProjectDir() {
+        PythonProjectScannerExtension extension = new PythonProjectScannerExtension();
+        Map<String, Object> projectInfo = createProjectInfoWithLanguage("Python");
+
+        try (MockedStatic<ProjectUtil> projectUtilMock = mockStatic(ProjectUtil.class)) {
+            projectUtilMock.when(() -> ProjectUtil.guessProjectDir(mockProject)).thenReturn(mockBaseDir);
+
+            extension.enhanceProjectInfo(mockProject, projectInfo);
+
+            projectUtilMock.verify(() -> ProjectUtil.guessProjectDir(mockProject));
+        }
+    }
+
+    @Test
+    void pythonExtension_handlesNullProjectDir() {
+        PythonProjectScannerExtension extension = new PythonProjectScannerExtension();
+        Map<String, Object> projectInfo = createProjectInfoWithLanguage("Python");
+
+        try (MockedStatic<ProjectUtil> projectUtilMock = mockStatic(ProjectUtil.class)) {
+            projectUtilMock.when(() -> ProjectUtil.guessProjectDir(mockProject)).thenReturn(null);
+
+            extension.enhanceProjectInfo(mockProject, projectInfo);
+
+            assertNull(projectInfo.get("python"));
+        }
+    }
+
+    @Test
+    void rustExtension_usesProjectUtilGuessProjectDir() {
+        RustProjectScannerExtension extension = new RustProjectScannerExtension();
+        Map<String, Object> projectInfo = createProjectInfoWithLanguage("Rust");
+
+        try (MockedStatic<ProjectUtil> projectUtilMock = mockStatic(ProjectUtil.class)) {
+            projectUtilMock.when(() -> ProjectUtil.guessProjectDir(mockProject)).thenReturn(mockBaseDir);
+
+            extension.enhanceProjectInfo(mockProject, projectInfo);
+
+            projectUtilMock.verify(() -> ProjectUtil.guessProjectDir(mockProject));
+        }
+    }
+
+    @Test
+    void rustExtension_handlesNullProjectDir() {
+        RustProjectScannerExtension extension = new RustProjectScannerExtension();
+        Map<String, Object> projectInfo = createProjectInfoWithLanguage("Rust");
+
+        try (MockedStatic<ProjectUtil> projectUtilMock = mockStatic(ProjectUtil.class)) {
+            projectUtilMock.when(() -> ProjectUtil.guessProjectDir(mockProject)).thenReturn(null);
+
+            extension.enhanceProjectInfo(mockProject, projectInfo);
+
+            assertNull(projectInfo.get("rust"));
+        }
+    }
+
+    private Map<String, Object> createProjectInfoWithLanguage(String language) {
+        Map<String, Object> projectInfo = new HashMap<>();
+        Map<String, Object> languages = new HashMap<>();
+        languages.put(language, 10);
+        projectInfo.put("languages", languages);
+        return projectInfo;
+    }
+}


### PR DESCRIPTION
…ojectDir()

Project.getBaseDir() is deprecated in the IntelliJ Platform API. Replace all 8 occurrences across analyzer extensions and DevoxxGenieGenerator with the recommended ProjectUtil.guessProjectDir(project) alternative. Add tests verifying correct usage and null-safety for all scanner extensions.