### PR TITLE
fix: resolve plugin verifier warnings for experimental and deprecated…

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -160,6 +160,17 @@ tasks {
         }
     }
 
+    runPluginVerifier {
+        ideVersions.set(listOf(
+            "IC-2023.3.8",
+            "IC-2024.1.7",
+            "IC-2024.2.6",
+            "IC-2024.3.7",
+            "IC-2025.1.7",
+            "IC-2025.2.6.1"
+        ))
+    }
+
     signPlugin {
         certificateChain.set(System.getenv("CERTIFICATE_CHAIN"))
         privateKey.set(System.getenv("PRIVATE_KEY"))

--- a/src/main/java/com/devoxx/genie/ui/renderer/CodeBlockNodeRenderer.java
+++ b/src/main/java/com/devoxx/genie/ui/renderer/CodeBlockNodeRenderer.java
@@ -2,7 +2,6 @@ package com.devoxx.genie.ui.renderer;
 
 import com.devoxx.genie.ui.util.LanguageGuesser;
 import com.intellij.lang.Language;
-import com.intellij.lang.documentation.DocumentationSettings;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.editor.richcopy.HtmlSyntaxInfoUtil;
 import com.intellij.openapi.fileTypes.PlainTextLanguage;
@@ -35,6 +34,7 @@ import java.util.Set;
  * String html = renderer.render(node);
  */
 public class CodeBlockNodeRenderer implements NodeRenderer {
+    private static final float DEFAULT_HIGHLIGHTING_SATURATION = 1.0f;
     private final Project project;
     private final HtmlWriter htmlOutputWriter;
 
@@ -125,7 +125,7 @@ public class CodeBlockNodeRenderer implements NodeRenderer {
                             language,
                             codeSnippet,
                             false,
-                            DocumentationSettings.getHighlightingSaturation(true)
+                            DEFAULT_HIGHLIGHTING_SATURATION
                     )
             );
         } else {
@@ -135,10 +135,8 @@ public class CodeBlockNodeRenderer implements NodeRenderer {
     }
 
     private HighlightingMode determineHighlightingMode(boolean block) {
-        if (block && DocumentationSettings.isHighlightingOfCodeBlocksEnabled()) {
+        if (block) {
             return HighlightingMode.SEMANTIC_HIGHLIGHTING;
-        } else if (block) {
-            return HighlightingMode.NO_HIGHLIGHTING;
         } else {
             return HighlightingMode.INLINE_HIGHLIGHTING;
         }

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -311,6 +311,11 @@
         <postStartupActivity implementation="com.devoxx.genie.service.PostStartupActivity"/>
     </extensions>
 
+    <!-- Declare K2 Kotlin plugin mode compatibility (required since IntelliJ IDEA 2024.2.1) -->
+    <extensions defaultExtensionNs="org.jetbrains.kotlin">
+        <supportsKotlinPluginMode supportsK2="true"/>
+    </extensions>
+
     <actions>
 
         <action id="DevoxxGenie.AddSnippetAction"


### PR DESCRIPTION
… API usage

- Replace experimental DocumentationSettings API in CodeBlockNodeRenderer with a constant saturation value and always-enabled code block highlighting
- Add Kotlin K2 plugin mode declaration (supportsKotlinPluginMode) in plugin.xml, required since IntelliJ IDEA 2024.2.1
- Configure runPluginVerifier task with IDE versions 2023.3.8 through 2025.2.6.1 for local verification

Verified compatible across all 6 IDE versions with zero warnings.