### PR TITLE
fix: replace deprecated URL(String) constructor with URI

### DIFF
--- a/src/main/java/com/devoxx/genie/ui/webview/handler/WebViewExternalLinkHandler.java
+++ b/src/main/java/com/devoxx/genie/ui/webview/handler/WebViewExternalLinkHandler.java
@@ -9,8 +9,8 @@ import org.cef.handler.CefRequestHandlerAdapter;
 import org.cef.network.CefRequest;
 import org.jetbrains.annotations.NotNull;
 
-import java.net.MalformedURLException;
-import java.net.URL;
+import java.net.URI;
+import java.net.URISyntaxException;
 
 /**
  * Handler for managing external links in the webview.
@@ -95,13 +95,14 @@ public class WebViewExternalLinkHandler extends CefRequestHandlerAdapter {
      */
     private boolean isExternalUrl(@NotNull String url) {
         try {
-            URL parsedUrl = new URL(url);
-            String protocol = parsedUrl.getProtocol().toLowerCase();
-            
+            URI uri = new URI(url);
+            String scheme = uri.getScheme();
+
             // Consider HTTP and HTTPS URLs as external if they're not from our internal server
-            return ("http".equals(protocol) || "https".equals(protocol)) && 
+            return scheme != null &&
+                   ("http".equalsIgnoreCase(scheme) || "https".equalsIgnoreCase(scheme)) &&
                    !url.startsWith(internalServerUrl);
-        } catch (MalformedURLException e) {
+        } catch (URISyntaxException e) {
             log.debug("Malformed URL, treating as internal: {}", url);
             return false;
         }


### PR DESCRIPTION
## Summary
- Replace deprecated `URL(String)` constructor (deprecated since JDK 20) with `java.net.URI` in `WebViewExternalLinkHandler.isExternalUrl()`
- Resolves plugin verifier warning: *Deprecated constructor `URL.<init>(String)` is invoked in `WebViewExternalLinkHandler.isExternalUrl(String)`*

## Test plan
- [ ] Verify external links in the webview still open in the system browser
- [ ] Verify internal links (localhost server, data:, about:) still load in the webview
- [ ] Verify malformed URLs are treated as internal (no exceptions thrown)

🤖 Generated with [Claude Code](https://claude.com/claude-code)