### PR TITLE
feat: externalize welcome text with remote fetching & analytics

### DIFF
--- a/docusaurus/static/api/welcome.json
+++ b/docusaurus/static/api/welcome.json
@@ -1,0 +1,28 @@
+{
+  "schemaVersion": 1,
+  "lastUpdated": "2026-02-07",
+  "title": "Welcome to Devoxx Genie",
+  "description": "The Devoxx Genie plugin allows you to interact with Local & Cloud Large Language Models (LLMs). The remote LLM's do require an API key in the Settings page",
+  "instructions": "Start by selecting a language model provider. Select some code, or add some files, type your prompt, and click submit button. Discover and install MCP servers from the MCP Marketplace in Settings!",
+  "features": [
+    { "emoji": "\uD83D\uDECD\uFE0F", "name": "MCP Marketplace", "description": "Discover and install MCP servers directly from Settings." },
+    { "emoji": "\uD83D\uDCC2", "name": "@ Opens Files Popup", "description": "Type @ in your prompt to open the file selection dialog." },
+    { "emoji": "\uD83C\uDFA8", "name": "Appearance", "description": "Change the conversation appearances" },
+    { "emoji": "\uD83D\uDD25", "name": "MCP Support", "description": "You can now add MCP servers!" },
+    { "emoji": "\uD83D\uDDC4\uFE0F", "name": "DEVOXXGENIE.md", "description": "Generate project info for extra system instructions" },
+    { "emoji": "\uD83C\uDFB9", "name": "Define submit shortcode", "description": "You can now define the keyboard shortcode to submit a prompt in settings." },
+    { "emoji": "\uD83D\uDCF8", "name": "DnD images", "description": "You can now DnD images with multimodal LLM's." },
+    { "emoji": "\uD83E\uDDD0", "name": "RAG Support", "description": "Retrieval-Augmented Generation (RAG) support for automatically incorporating project context into your prompts." },
+    { "emoji": "\u274C", "name": ".gitignore", "description": "Exclude files and directories based on .gitignore file" },
+    { "emoji": "\uD83D\uDC40", "name": "Chat History", "description": "All chats are saved and can be restored or removed" },
+    { "emoji": "\uD83E\uDDE0", "name": "Project Scanner", "description": "Add source code (full project or by package) to prompt context (or clipboard) when using Anthropic, OpenAI or Gemini." }
+  ],
+  "announcements": [],
+  "tip": "You can modify the endpoints for different LLM providers and the default command skills in the plugin settings.",
+  "enjoy": "Enjoy!",
+  "socialLinks": [
+    { "platform": "Bluesky", "url": "https://bsky.app/profile/devoxxgenie.bsky.social", "label": "@DevoxxGenie.bsky.social" }
+  ],
+  "reviewUrl": "https://plugins.jetbrains.com/plugin/24169-devoxxgenie/reviews?noRedirect=true",
+  "trackingPixelUrl": "https://dry-voice-8e11.devoxx.workers.dev/"
+}

--- a/src/main/java/com/devoxx/genie/model/welcome/WelcomeAnnouncement.java
+++ b/src/main/java/com/devoxx/genie/model/welcome/WelcomeAnnouncement.java
@@ -1,0 +1,9 @@
+package com.devoxx.genie.model.welcome;
+
+import lombok.Data;
+
+@Data
+public class WelcomeAnnouncement {
+    private String type; // info, warning, success
+    private String message;
+}

--- a/src/main/java/com/devoxx/genie/model/welcome/WelcomeContent.java
+++ b/src/main/java/com/devoxx/genie/model/welcome/WelcomeContent.java
@@ -1,0 +1,21 @@
+package com.devoxx.genie.model.welcome;
+
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class WelcomeContent {
+    private int schemaVersion;
+    private String lastUpdated;
+    private String title;
+    private String description;
+    private String instructions;
+    private List<WelcomeFeature> features;
+    private List<WelcomeAnnouncement> announcements;
+    private String tip;
+    private String enjoy;
+    private List<WelcomeSocialLink> socialLinks;
+    private String reviewUrl;
+    private String trackingPixelUrl;
+}

--- a/src/main/java/com/devoxx/genie/model/welcome/WelcomeFeature.java
+++ b/src/main/java/com/devoxx/genie/model/welcome/WelcomeFeature.java
@@ -1,0 +1,10 @@
+package com.devoxx.genie.model.welcome;
+
+import lombok.Data;
+
+@Data
+public class WelcomeFeature {
+    private String emoji;
+    private String name;
+    private String description;
+}

--- a/src/main/java/com/devoxx/genie/model/welcome/WelcomeSocialLink.java
+++ b/src/main/java/com/devoxx/genie/model/welcome/WelcomeSocialLink.java
@@ -1,0 +1,10 @@
+package com.devoxx.genie.model.welcome;
+
+import lombok.Data;
+
+@Data
+public class WelcomeSocialLink {
+    private String platform;
+    private String url;
+    private String label;
+}

--- a/src/main/java/com/devoxx/genie/service/welcome/WelcomeContentService.java
+++ b/src/main/java/com/devoxx/genie/service/welcome/WelcomeContentService.java
@@ -1,0 +1,160 @@
+package com.devoxx.genie.service.welcome;
+
+import com.devoxx.genie.model.welcome.WelcomeContent;
+import com.devoxx.genie.service.PropertiesService;
+import com.devoxx.genie.ui.settings.DevoxxGenieStateService;
+import com.devoxx.genie.util.HttpClientProvider;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.intellij.openapi.application.ApplicationManager;
+import lombok.extern.slf4j.Slf4j;
+import okhttp3.HttpUrl;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+
+@Slf4j
+public class WelcomeContentService {
+
+    private static final String WELCOME_JSON_URL = "https://genie.devoxx.com/api/welcome.json";
+    private static final long CACHE_TTL_MS = TimeUnit.HOURS.toMillis(24);
+    private static final int SUPPORTED_SCHEMA_VERSION = 1;
+
+    private final OkHttpClient client = HttpClientProvider.getClient();
+    private final Gson gson = new GsonBuilder().create();
+
+    private volatile WelcomeContent cachedContent;
+
+    @NotNull
+    public static WelcomeContentService getInstance() {
+        return ApplicationManager.getApplication().getService(WelcomeContentService.class);
+    }
+
+    /**
+     * Returns cached welcome content immediately and triggers a background refresh if stale.
+     * On first call with no cache, returns null (local fallback should be used).
+     *
+     * @return cached WelcomeContent, or null if no cache is available yet
+     */
+    @Nullable
+    public WelcomeContent getWelcomeContent() {
+        if (cachedContent != null) {
+            triggerBackgroundRefreshIfStale();
+            return cachedContent;
+        }
+
+        // Try to restore from persistent cache
+        WelcomeContent restored = restoreFromPersistentCache();
+        if (restored != null) {
+            cachedContent = restored;
+            triggerBackgroundRefreshIfStale();
+            return cachedContent;
+        }
+
+        // No cache at all — trigger background fetch for next time, return null for local fallback
+        triggerBackgroundFetch();
+        return null;
+    }
+
+    private void triggerBackgroundRefreshIfStale() {
+        DevoxxGenieStateService state = DevoxxGenieStateService.getInstance();
+        long lastFetch = state.getWelcomeContentLastFetchTimestamp();
+        String cachedVersion = state.getWelcomeContentPluginVersion();
+        String currentVersion = getPluginVersion();
+
+        boolean isStale = (System.currentTimeMillis() - lastFetch) > CACHE_TTL_MS;
+        boolean isVersionChanged = !currentVersion.equals(cachedVersion);
+
+        if (isStale || isVersionChanged) {
+            triggerBackgroundFetch();
+        }
+    }
+
+    private void triggerBackgroundFetch() {
+        ApplicationManager.getApplication().executeOnPooledThread(this::fetchAndCache);
+    }
+
+    private void fetchAndCache() {
+        try {
+            String pluginVersion = getPluginVersion();
+            String os = System.getProperty("os.name", "unknown");
+
+            HttpUrl.Builder urlBuilder = Objects.requireNonNull(HttpUrl.parse(WELCOME_JSON_URL)).newBuilder();
+            urlBuilder.addQueryParameter("v", pluginVersion);
+            urlBuilder.addQueryParameter("os", os);
+
+            Request request = new Request.Builder()
+                    .url(urlBuilder.build())
+                    .build();
+
+            try (Response response = client.newCall(request).execute()) {
+                if (!response.isSuccessful() || response.body() == null) {
+                    log.warn("Failed to fetch welcome content: HTTP {}", response.code());
+                    return;
+                }
+
+                String json = response.body().string();
+                WelcomeContent content = gson.fromJson(json, WelcomeContent.class);
+
+                if (content == null) {
+                    log.warn("Failed to parse welcome content JSON");
+                    return;
+                }
+
+                // Schema version check — ignore incompatible content
+                if (content.getSchemaVersion() > SUPPORTED_SCHEMA_VERSION) {
+                    log.info("Remote welcome content has unsupported schema version {}, using local fallback",
+                            content.getSchemaVersion());
+                    return;
+                }
+
+                // Update in-memory cache
+                cachedContent = content;
+
+                // Persist to state service
+                DevoxxGenieStateService state = DevoxxGenieStateService.getInstance();
+                state.setWelcomeContentCachedJson(json);
+                state.setWelcomeContentLastFetchTimestamp(System.currentTimeMillis());
+                state.setWelcomeContentPluginVersion(pluginVersion);
+
+                log.info("Successfully fetched and cached welcome content (schema v{})", content.getSchemaVersion());
+            }
+        } catch (Exception e) {
+            log.warn("Failed to fetch welcome content: {}", e.getMessage());
+        }
+    }
+
+    @Nullable
+    private WelcomeContent restoreFromPersistentCache() {
+        try {
+            DevoxxGenieStateService state = DevoxxGenieStateService.getInstance();
+            String cachedJson = state.getWelcomeContentCachedJson();
+
+            if (cachedJson == null || cachedJson.isEmpty()) {
+                return null;
+            }
+
+            WelcomeContent content = gson.fromJson(cachedJson, WelcomeContent.class);
+            if (content != null && content.getSchemaVersion() <= SUPPORTED_SCHEMA_VERSION) {
+                return content;
+            }
+        } catch (Exception e) {
+            log.warn("Failed to restore welcome content from persistent cache: {}", e.getMessage());
+        }
+        return null;
+    }
+
+    @NotNull
+    private String getPluginVersion() {
+        try {
+            return PropertiesService.getInstance().getVersion();
+        } catch (Exception e) {
+            return "unknown";
+        }
+    }
+}

--- a/src/main/java/com/devoxx/genie/ui/settings/DevoxxGenieStateService.java
+++ b/src/main/java/com/devoxx/genie/ui/settings/DevoxxGenieStateService.java
@@ -199,6 +199,11 @@ public final class DevoxxGenieStateService implements PersistentStateComponent<D
     private Boolean mcpApprovalRequired = true;
     private Integer mcpApprovalTimeout = MCP_APPROVAL_TIMEOUT;
 
+    // Welcome content cache
+    private String welcomeContentCachedJson = "";
+    private long welcomeContentLastFetchTimestamp = 0L;
+    private String welcomeContentPluginVersion = "";
+
     // Appearance settings
     private Double lineHeight = 1.6;  // Default line height multiplier
     private Integer messagePadding = 10;  // Padding inside messages in px

--- a/src/main/java/com/devoxx/genie/ui/webview/handler/WebViewMessageRenderer.java
+++ b/src/main/java/com/devoxx/genie/ui/webview/handler/WebViewMessageRenderer.java
@@ -1,6 +1,8 @@
 package com.devoxx.genie.ui.webview.handler;
 
 import com.devoxx.genie.model.request.ChatMessageContext;
+import com.devoxx.genie.model.welcome.WelcomeContent;
+import com.devoxx.genie.service.welcome.WelcomeContentService;
 import com.devoxx.genie.ui.webview.WebServer;
 import com.devoxx.genie.ui.webview.template.ChatMessageTemplate;
 import com.devoxx.genie.ui.webview.template.WelcomeTemplate;
@@ -65,8 +67,9 @@ public class WebViewMessageRenderer {
             return;
         }
 
-        // Use the WelcomeTemplate to generate HTML
-        WelcomeTemplate welcomeTemplate = new WelcomeTemplate(webServer, resourceBundle);
+        // Use the WelcomeTemplate to generate HTML, with remote content if available
+        WelcomeContent remoteContent = WelcomeContentService.getInstance().getWelcomeContent();
+        WelcomeTemplate welcomeTemplate = new WelcomeTemplate(webServer, resourceBundle, remoteContent);
         String welcomeContent = welcomeTemplate.generate();
 
         // Only inject welcome content if no chat messages are already present (defense-in-depth).

--- a/src/main/java/com/devoxx/genie/ui/webview/template/WelcomeTemplate.java
+++ b/src/main/java/com/devoxx/genie/ui/webview/template/WelcomeTemplate.java
@@ -1,51 +1,207 @@
 package com.devoxx.genie.ui.webview.template;
 
+import com.devoxx.genie.model.welcome.WelcomeAnnouncement;
+import com.devoxx.genie.model.welcome.WelcomeContent;
+import com.devoxx.genie.model.welcome.WelcomeFeature;
+import com.devoxx.genie.model.welcome.WelcomeSocialLink;
+import com.devoxx.genie.service.PropertiesService;
 import com.devoxx.genie.ui.util.HelpUtil;
 import com.devoxx.genie.ui.webview.WebServer;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
 import java.util.ResourceBundle;
 
 /**
  * Template for generating the welcome panel HTML content.
+ * Supports both remote content (from WelcomeContentService) and local fallback (from ResourceBundle).
  */
 public class WelcomeTemplate extends HtmlTemplate {
 
-    private final ResourceBundle resourceBundle;
+    private static final String DEFAULT_REVIEW_URL =
+            "https://plugins.jetbrains.com/plugin/24169-devoxxgenie/reviews?noRedirect=true";
 
-    /**
-     * Constructor with WebServer and ResourceBundle dependencies.
-     *
-     * @param webServer The web server instance for resource URLs
-     * @param resourceBundle The resource bundle for i18n
-     */
+    private final ResourceBundle resourceBundle;
+    private final WelcomeContent remoteContent;
+
     public WelcomeTemplate(WebServer webServer, ResourceBundle resourceBundle) {
+        this(webServer, resourceBundle, null);
+    }
+
+    public WelcomeTemplate(WebServer webServer, ResourceBundle resourceBundle, @Nullable WelcomeContent remoteContent) {
         super(webServer);
         this.resourceBundle = resourceBundle;
+        this.remoteContent = remoteContent;
     }
 
     @Override
     public @NotNull String generate() {
-        // Load the HTML template from the resources
         String htmlTemplate = ResourceLoader.loadResource("webview/html/welcome.html");
-        
-        // Get the localized strings from the resource bundle
+        String customPromptCommands = HelpUtil.getCustomPromptCommandsForWebView();
+
+        if (remoteContent != null) {
+            return generateFromRemoteContent(htmlTemplate, customPromptCommands);
+        }
+        return generateFromResourceBundle(htmlTemplate, customPromptCommands);
+    }
+
+    @NotNull
+    private String generateFromRemoteContent(@NotNull String htmlTemplate, @NotNull String customPromptCommands) {
+        String title = escapeHtml(remoteContent.getTitle());
+        String description = escapeHtml(remoteContent.getDescription());
+        String instructions = escapeHtml(remoteContent.getInstructions());
+        String tip = escapeHtml(remoteContent.getTip());
+        String enjoy = escapeHtml(remoteContent.getEnjoy());
+        String featuresHtml = buildFeaturesHtml(remoteContent.getFeatures());
+        String announcementsHtml = buildAnnouncementsHtml(remoteContent.getAnnouncements());
+        String socialLinksHtml = buildSocialLinksHtml(remoteContent.getSocialLinks());
+        String reviewUrl = getReviewUrl(remoteContent.getReviewUrl());
+        String trackingPixelHtml = buildTrackingPixelHtml(remoteContent.getTrackingPixelUrl());
+
+        return htmlTemplate
+                .replace("${title}", title)
+                .replace("${description}", description)
+                .replace("${instructions}", instructions)
+                .replace("${tip}", tip)
+                .replace("${enjoy}", enjoy)
+                .replace("${features}", featuresHtml)
+                .replace("${announcements}", announcementsHtml)
+                .replace("${socialLinks}", socialLinksHtml)
+                .replace("${reviewUrl}", reviewUrl)
+                .replace("${trackingPixel}", trackingPixelHtml)
+                .replace("${customPromptCommands}", customPromptCommands);
+    }
+
+    @NotNull
+    private String generateFromResourceBundle(@NotNull String htmlTemplate, @NotNull String customPromptCommands) {
         String title = resourceBundle.getString("welcome.title");
         String description = resourceBundle.getString("welcome.description");
         String instructions = resourceBundle.getString("welcome.instructions");
         String tip = resourceBundle.getString("welcome.tip");
         String enjoy = resourceBundle.getString("welcome.enjoy");
-        
-        // Get the custom prompts for utility commands
-        String customPromptCommands = HelpUtil.getCustomPromptCommandsForWebView();
-        
-        // Replace the placeholder variables in the template
+
         return htmlTemplate
-            .replace("${title}", title)
-            .replace("${description}", description)
-            .replace("${instructions}", instructions)
-            .replace("${tip}", tip)
-            .replace("${enjoy}", enjoy)
-            .replace("${customPromptCommands}", customPromptCommands);
+                .replace("${title}", title)
+                .replace("${description}", description)
+                .replace("${instructions}", instructions)
+                .replace("${tip}", tip)
+                .replace("${enjoy}", enjoy)
+                .replace("${features}", getDefaultFeaturesHtml())
+                .replace("${announcements}", "")
+                .replace("${socialLinks}", getDefaultSocialLinksHtml())
+                .replace("${reviewUrl}", DEFAULT_REVIEW_URL)
+                .replace("${trackingPixel}", "")
+                .replace("${customPromptCommands}", customPromptCommands);
+    }
+
+    @NotNull
+    private String buildFeaturesHtml(@Nullable List<WelcomeFeature> features) {
+        if (features == null || features.isEmpty()) {
+            return getDefaultFeaturesHtml();
+        }
+        StringBuilder sb = new StringBuilder();
+        for (WelcomeFeature feature : features) {
+            sb.append("<li><span class=\"feature-emoji\">")
+                    .append(escapeHtml(feature.getEmoji()))
+                    .append("</span><span class=\"feature-name\">")
+                    .append(escapeHtml(feature.getName()))
+                    .append(":</span> ")
+                    .append(escapeHtml(feature.getDescription()))
+                    .append("</li>\n");
+        }
+        return sb.toString();
+    }
+
+    @NotNull
+    private String buildAnnouncementsHtml(@Nullable List<WelcomeAnnouncement> announcements) {
+        if (announcements == null || announcements.isEmpty()) {
+            return "";
+        }
+        StringBuilder sb = new StringBuilder();
+        for (WelcomeAnnouncement announcement : announcements) {
+            String type = announcement.getType() != null ? announcement.getType() : "info";
+            sb.append("<div class=\"announcement announcement-")
+                    .append(escapeHtml(type))
+                    .append("\">")
+                    .append(escapeHtml(announcement.getMessage()))
+                    .append("</div>\n");
+        }
+        return sb.toString();
+    }
+
+    @NotNull
+    private String buildSocialLinksHtml(@Nullable List<WelcomeSocialLink> socialLinks) {
+        if (socialLinks == null || socialLinks.isEmpty()) {
+            return getDefaultSocialLinksHtml();
+        }
+        StringBuilder sb = new StringBuilder();
+        for (WelcomeSocialLink link : socialLinks) {
+            sb.append("<p>Follow us on ")
+                    .append(escapeHtml(link.getPlatform()))
+                    .append(" : <a href=\"")
+                    .append(escapeHtml(link.getUrl()))
+                    .append("\">")
+                    .append(escapeHtml(link.getLabel()))
+                    .append("</a></p>\n");
+        }
+        return sb.toString();
+    }
+
+    @NotNull
+    private String buildTrackingPixelHtml(@Nullable String trackingPixelUrl) {
+        if (trackingPixelUrl == null || trackingPixelUrl.isEmpty()) {
+            return "";
+        }
+        // Only allow HTTPS URLs for security
+        if (!trackingPixelUrl.startsWith("https://")) {
+            return "";
+        }
+        String separator = trackingPixelUrl.contains("?") ? "&" : "?";
+        String version = getPluginVersion();
+        String os = URLEncoder.encode(System.getProperty("os.name", "unknown"), StandardCharsets.UTF_8);
+        String fullUrl = trackingPixelUrl + separator + "v=" + version + "&os=" + os;
+        return "<img src=\"" + escapeHtml(fullUrl) + "\" width=\"1\" height=\"1\" style=\"display:none\" alt=\"\">";
+    }
+
+    @NotNull
+    private String getPluginVersion() {
+        try {
+            return PropertiesService.getInstance().getVersion();
+        } catch (Exception e) {
+            return "unknown";
+        }
+    }
+
+    @NotNull
+    private String getReviewUrl(@Nullable String reviewUrl) {
+        if (reviewUrl == null || reviewUrl.isEmpty()) {
+            return DEFAULT_REVIEW_URL;
+        }
+        return escapeHtml(reviewUrl);
+    }
+
+    @NotNull
+    private String getDefaultFeaturesHtml() {
+        return """
+                <li><span class="feature-emoji">🛍️</span><span class="feature-name">MCP Marketplace:</span> Discover and install MCP servers directly from Settings.</li>
+                <li><span class="feature-emoji">📂</span><span class="feature-name">@ Opens Files Popup:</span> Type <code>@</code> in your prompt to open the file selection dialog.</li>
+                <li><span class="feature-emoji">🎨</span><span class="feature-name">Appearance:</span> Change the conversation appearances</li>
+                <li><span class="feature-emoji">🔥</span><span class="feature-name">MCP Support:</span> You can now add MCP servers!</li>
+                <li><span class="feature-emoji">🗄️</span><span class="feature-name">DEVOXXGENIE.md:</span> Generate project info for extra system instructions</li>
+                <li><span class="feature-emoji">🎹</span><span class="feature-name">Define submit shortcode:</span> You can now define the keyboard shortcode to submit a prompt in settings.</li>
+                <li><span class="feature-emoji">📸</span><span class="feature-name">DnD images:</span> You can now DnD images with multimodal LLM's.</li>
+                <li><span class="feature-emoji">🧐</span><span class="feature-name">RAG Support:</span> Retrieval-Augmented Generation (RAG) support for automatically incorporating project context into your prompts.</li>
+                <li><span class="feature-emoji">❌</span><span class="feature-name">.gitignore:</span> Exclude files and directories based on .gitignore file</li>
+                <li><span class="feature-emoji">👀</span><span class="feature-name">Chat History:</span> All chats are saved and can be restored or removed</li>
+                <li><span class="feature-emoji">🧠</span><span class="feature-name">Project Scanner:</span> Add source code (full project or by package) to prompt context (or clipboard) when using Anthropic, OpenAI or Gemini.</li>
+                """;
+    }
+
+    @NotNull
+    private String getDefaultSocialLinksHtml() {
+        return "<p>Follow us on Bluesky : <a href=\"https://bsky.app/profile/devoxxgenie.bsky.social\">@DevoxxGenie.bsky.social</a></p>";
     }
 }

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -297,6 +297,7 @@
         <applicationService serviceImplementation="com.devoxx.genie.chatmodel.local.jan.JanModelService"/>
         <applicationService serviceImplementation="com.devoxx.genie.service.mcp.MCPExecutionService"/>
         <applicationService serviceImplementation="com.devoxx.genie.service.mcp.MCPRegistryService"/>
+        <applicationService serviceImplementation="com.devoxx.genie.service.welcome.WelcomeContentService"/>
         <applicationService serviceImplementation="com.devoxx.genie.service.chromadb.ChromaDockerService"/>
         <applicationService serviceImplementation="com.devoxx.genie.service.rag.ProjectIndexerService"/>
         <!-- New service for WebView implementation -->

--- a/src/main/resources/webview/html/welcome.html
+++ b/src/main/resources/webview/html/welcome.html
@@ -1,32 +1,23 @@
 <div class="container">
     <h2>${title}</h2>
-    <p>Follow us on Bluesky : <a href="https://bsky.app/profile/devoxxgenie.bsky.social">@DevoxGenie.bsky.social</a></p>
+    ${socialLinks}
     <p>${description}</p>
     <p>${instructions}</p>
-    
+    ${announcements}
     <h2>Features 🚀</h2>
     <p class="subtext">Configure features in the settings page.</p>
     <ul>
-        <li><span class="feature-emoji">🛍️</span><span class="feature-name">MCP Marketplace:</span> Discover and install MCP servers directly from Settings.</li>
-        <li><span class="feature-emoji">📂</span><span class="feature-name">@ Opens Files Popup:</span> Type <code>@</code> in your prompt to open the file selection dialog.</li>
-        <li><span class="feature-emoji">🎨</span><span class="feature-name">Appearance:</span> Change the conversation appearances</li>
-        <li><span class="feature-emoji">🔥</span><span class="feature-name">MCP Support:</span> You can now add MCP servers!</li>
-        <li><span class="feature-emoji">🗄️</span><span class="feature-name">DEVOXXGENIE.md:</span> Generate project info for extra system instructions</li>
-        <li><span class="feature-emoji">🎹</span><span class="feature-name">Define submit shortcode:</span> You can now define the keyboard shortcode to submit a prompt in settings.</li>
-        <li><span class="feature-emoji">📸</span><span class="feature-name">DnD images:</span> You can now DnD images with multimodal LLM's.</li>
-        <li><span class="feature-emoji">🧐</span><span class="feature-name">RAG Support:</span> Retrieval-Augmented Generation (RAG) support for automatically incorporating project context into your prompts.</li>
-        <li><span class="feature-emoji">❌</span><span class="feature-name">.gitignore:</span> Exclude files and directories based on .gitignore file</li>
-        <li><span class="feature-emoji">👀</span><span class="feature-name">Chat History:</span> All chats are saved and can be restored or removed</li>
-        <li><span class="feature-emoji">🧠</span><span class="feature-name">Project Scanner:</span> Add source code (full project or by package) to prompt context (or clipboard) when using Anthropic, OpenAI or Gemini.</li>
+        ${features}
     </ul>
-    
+
     <h2>Your Skills:</h2>
     <p class="subtext">You can update the skills for each utility command or add custom ones in the settings page.</p>
     <ul>
         ${customPromptCommands}
     </ul>
-    
+
     <p>${tip}</p>
     <p>${enjoy}</p>
-    <p class="subtext">BTW If you like this plugin please give us a <a href="https://plugins.jetbrains.com/plugin/24169-devoxxgenie/reviews?noRedirect=true">review</a> ❤️</p>
+    <p class="subtext">BTW If you like this plugin please give us a <a href="${reviewUrl}">review</a> ❤️</p>
+    ${trackingPixel}
 </div>

--- a/src/test/java/com/devoxx/genie/service/welcome/WelcomeContentServiceTest.java
+++ b/src/test/java/com/devoxx/genie/service/welcome/WelcomeContentServiceTest.java
@@ -1,0 +1,180 @@
+package com.devoxx.genie.service.welcome;
+
+import com.devoxx.genie.model.welcome.WelcomeContent;
+import com.devoxx.genie.service.PropertiesService;
+import com.devoxx.genie.ui.settings.DevoxxGenieStateService;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.intellij.openapi.application.Application;
+import com.intellij.openapi.application.ApplicationManager;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class WelcomeContentServiceTest {
+
+    private final Gson gson = new GsonBuilder().create();
+
+    @Mock
+    private DevoxxGenieStateService stateService;
+
+    @Mock
+    private PropertiesService propertiesService;
+
+    @Mock
+    private Application application;
+
+    private MockedStatic<ApplicationManager> appManagerStatic;
+    private MockedStatic<DevoxxGenieStateService> stateServiceStatic;
+    private MockedStatic<PropertiesService> propertiesServiceStatic;
+
+    @BeforeEach
+    void setUp() {
+        appManagerStatic = mockStatic(ApplicationManager.class);
+        appManagerStatic.when(ApplicationManager::getApplication).thenReturn(application);
+
+        stateServiceStatic = mockStatic(DevoxxGenieStateService.class);
+        stateServiceStatic.when(DevoxxGenieStateService::getInstance).thenReturn(stateService);
+
+        propertiesServiceStatic = mockStatic(PropertiesService.class);
+        propertiesServiceStatic.when(PropertiesService::getInstance).thenReturn(propertiesService);
+
+        when(propertiesService.getVersion()).thenReturn("0.9.2");
+        when(stateService.getWelcomeContentCachedJson()).thenReturn("");
+        when(stateService.getWelcomeContentLastFetchTimestamp()).thenReturn(0L);
+        when(stateService.getWelcomeContentPluginVersion()).thenReturn("");
+    }
+
+    @AfterEach
+    void tearDown() {
+        appManagerStatic.close();
+        stateServiceStatic.close();
+        propertiesServiceStatic.close();
+    }
+
+    @Test
+    void getWelcomeContent_returnsNullWhenNoCacheExists() {
+        WelcomeContentService service = new WelcomeContentService();
+
+        WelcomeContent result = service.getWelcomeContent();
+
+        assertNull(result, "Should return null when no cache exists");
+    }
+
+    @Test
+    void getWelcomeContent_restoresFromPersistentCache() {
+        String cachedJson = createSampleWelcomeJson(1);
+        when(stateService.getWelcomeContentCachedJson()).thenReturn(cachedJson);
+        when(stateService.getWelcomeContentLastFetchTimestamp()).thenReturn(System.currentTimeMillis());
+        when(stateService.getWelcomeContentPluginVersion()).thenReturn("0.9.2");
+
+        WelcomeContentService service = new WelcomeContentService();
+
+        WelcomeContent result = service.getWelcomeContent();
+
+        assertNotNull(result);
+        assertEquals("Welcome to Devoxx Genie", result.getTitle());
+        assertEquals(1, result.getSchemaVersion());
+    }
+
+    @Test
+    void getWelcomeContent_ignoresUnsupportedSchemaVersion() {
+        String cachedJson = createSampleWelcomeJson(999);
+        when(stateService.getWelcomeContentCachedJson()).thenReturn(cachedJson);
+
+        WelcomeContentService service = new WelcomeContentService();
+
+        WelcomeContent result = service.getWelcomeContent();
+
+        assertNull(result, "Should return null for unsupported schema version");
+    }
+
+    @Test
+    void getWelcomeContent_returnsCachedContentOnSubsequentCalls() {
+        String cachedJson = createSampleWelcomeJson(1);
+        when(stateService.getWelcomeContentCachedJson()).thenReturn(cachedJson);
+        when(stateService.getWelcomeContentLastFetchTimestamp()).thenReturn(System.currentTimeMillis());
+        when(stateService.getWelcomeContentPluginVersion()).thenReturn("0.9.2");
+
+        WelcomeContentService service = new WelcomeContentService();
+
+        WelcomeContent first = service.getWelcomeContent();
+        WelcomeContent second = service.getWelcomeContent();
+
+        assertNotNull(first);
+        assertSame(first, second, "Should return same cached instance");
+    }
+
+    @Test
+    void parsesWelcomeJsonCorrectly() {
+        String json = createFullSampleWelcomeJson();
+        WelcomeContent content = gson.fromJson(json, WelcomeContent.class);
+
+        assertNotNull(content);
+        assertEquals(1, content.getSchemaVersion());
+        assertEquals("Welcome to Devoxx Genie", content.getTitle());
+        assertNotNull(content.getFeatures());
+        assertEquals(2, content.getFeatures().size());
+        assertEquals("MCP Marketplace", content.getFeatures().get(0).getName());
+        assertNotNull(content.getSocialLinks());
+        assertEquals(1, content.getSocialLinks().size());
+        assertEquals("Bluesky", content.getSocialLinks().get(0).getPlatform());
+        assertEquals("Enjoy!", content.getEnjoy());
+        assertNotNull(content.getAnnouncements());
+        assertTrue(content.getAnnouncements().isEmpty());
+    }
+
+    private String createSampleWelcomeJson(int schemaVersion) {
+        return """
+                {
+                  "schemaVersion": %d,
+                  "lastUpdated": "2026-02-07",
+                  "title": "Welcome to Devoxx Genie",
+                  "description": "Test description",
+                  "instructions": "Test instructions",
+                  "features": [],
+                  "announcements": [],
+                  "tip": "Test tip",
+                  "enjoy": "Enjoy!",
+                  "socialLinks": [],
+                  "reviewUrl": "",
+                  "trackingPixelUrl": ""
+                }
+                """.formatted(schemaVersion);
+    }
+
+    private String createFullSampleWelcomeJson() {
+        return """
+                {
+                  "schemaVersion": 1,
+                  "lastUpdated": "2026-02-07",
+                  "title": "Welcome to Devoxx Genie",
+                  "description": "The Devoxx Genie plugin allows you to interact with LLMs.",
+                  "instructions": "Start by selecting a language model provider.",
+                  "features": [
+                    { "emoji": "\uD83D\uDECD\uFE0F", "name": "MCP Marketplace", "description": "Discover and install MCP servers." },
+                    { "emoji": "\uD83D\uDCC2", "name": "@ Opens Files Popup", "description": "Type @ to open file selection." }
+                  ],
+                  "announcements": [],
+                  "tip": "You can modify the endpoints in settings.",
+                  "enjoy": "Enjoy!",
+                  "socialLinks": [
+                    { "platform": "Bluesky", "url": "https://bsky.app/profile/devoxxgenie.bsky.social", "label": "@DevoxxGenie.bsky.social" }
+                  ],
+                  "reviewUrl": "https://plugins.jetbrains.com/plugin/24169-devoxxgenie/reviews?noRedirect=true",
+                  "trackingPixelUrl": ""
+                }
+                """;
+    }
+}

--- a/src/test/java/com/devoxx/genie/ui/webview/template/WelcomeTemplateTest.java
+++ b/src/test/java/com/devoxx/genie/ui/webview/template/WelcomeTemplateTest.java
@@ -1,0 +1,237 @@
+package com.devoxx.genie.ui.webview.template;
+
+import com.devoxx.genie.model.CustomPrompt;
+import com.devoxx.genie.model.welcome.*;
+import com.devoxx.genie.service.PropertiesService;
+import com.devoxx.genie.ui.settings.DevoxxGenieStateService;
+import com.devoxx.genie.ui.webview.WebServer;
+import com.intellij.openapi.application.Application;
+import com.intellij.openapi.application.ApplicationManager;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.ResourceBundle;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class WelcomeTemplateTest {
+
+    @Mock
+    private WebServer webServer;
+
+    @Mock
+    private ResourceBundle resourceBundle;
+
+    @Mock
+    private DevoxxGenieStateService stateService;
+
+    @Mock
+    private PropertiesService propertiesService;
+
+    @Mock
+    private Application application;
+
+    private MockedStatic<ApplicationManager> appManagerStatic;
+    private MockedStatic<DevoxxGenieStateService> stateServiceStatic;
+    private MockedStatic<PropertiesService> propertiesServiceStatic;
+
+    @BeforeEach
+    void setUp() {
+        appManagerStatic = mockStatic(ApplicationManager.class);
+        appManagerStatic.when(ApplicationManager::getApplication).thenReturn(application);
+
+        stateServiceStatic = mockStatic(DevoxxGenieStateService.class);
+        stateServiceStatic.when(DevoxxGenieStateService::getInstance).thenReturn(stateService);
+
+        propertiesServiceStatic = mockStatic(PropertiesService.class);
+        propertiesServiceStatic.when(PropertiesService::getInstance).thenReturn(propertiesService);
+        when(propertiesService.getVersion()).thenReturn("0.9.2");
+
+        // Setup custom prompts for HelpUtil
+        List<CustomPrompt> customPrompts = new ArrayList<>();
+        customPrompts.add(new CustomPrompt("test", "Run unit tests"));
+        when(stateService.getCustomPrompts()).thenReturn(customPrompts);
+
+        // Setup resource bundle
+        when(resourceBundle.getString("welcome.title")).thenReturn("Welcome to DevoxxGenie");
+        when(resourceBundle.getString("welcome.description")).thenReturn("Test description");
+        when(resourceBundle.getString("welcome.instructions")).thenReturn("Test instructions");
+        when(resourceBundle.getString("welcome.tip")).thenReturn("Test tip");
+        when(resourceBundle.getString("welcome.enjoy")).thenReturn("Enjoy!");
+    }
+
+    @AfterEach
+    void tearDown() {
+        appManagerStatic.close();
+        stateServiceStatic.close();
+        propertiesServiceStatic.close();
+    }
+
+    @Test
+    void generate_withNullRemoteContent_usesLocalFallback() {
+        WelcomeTemplate template = new WelcomeTemplate(webServer, resourceBundle, null);
+
+        String html = template.generate();
+
+        assertNotNull(html);
+        assertTrue(html.contains("Welcome to DevoxxGenie"));
+        assertTrue(html.contains("Test description"));
+        assertTrue(html.contains("MCP Marketplace"));
+        assertTrue(html.contains("devoxxgenie.bsky.social"));
+        assertTrue(html.contains("plugins.jetbrains.com"));
+        assertFalse(html.contains("${"), "No unresolved placeholders should remain");
+    }
+
+    @Test
+    void generate_withRemoteContent_usesRemoteData() {
+        WelcomeContent content = createRemoteContent();
+
+        WelcomeTemplate template = new WelcomeTemplate(webServer, resourceBundle, content);
+
+        String html = template.generate();
+
+        assertNotNull(html);
+        assertTrue(html.contains("Remote Welcome Title"));
+        assertTrue(html.contains("Remote description"));
+        assertTrue(html.contains("Cool Feature"));
+        assertTrue(html.contains("https://example.com/reviews"));
+        assertFalse(html.contains("${"), "No unresolved placeholders should remain");
+    }
+
+    @Test
+    void generate_withAnnouncements_rendersAnnouncementDivs() {
+        WelcomeContent content = createRemoteContent();
+        WelcomeAnnouncement announcement = new WelcomeAnnouncement();
+        announcement.setType("info");
+        announcement.setMessage("New version available!");
+        content.setAnnouncements(List.of(announcement));
+
+        WelcomeTemplate template = new WelcomeTemplate(webServer, resourceBundle, content);
+
+        String html = template.generate();
+
+        assertTrue(html.contains("announcement-info"));
+        assertTrue(html.contains("New version available!"));
+    }
+
+    @Test
+    void generate_withTrackingPixel_rendersImgTag() {
+        WelcomeContent content = createRemoteContent();
+        content.setTrackingPixelUrl("https://analytics.example.com/pixel.gif");
+
+        WelcomeTemplate template = new WelcomeTemplate(webServer, resourceBundle, content);
+
+        String html = template.generate();
+
+        assertTrue(html.contains("https://analytics.example.com/pixel.gif?v=0.9.2&amp;os="));
+        assertTrue(html.contains("width=\"1\""));
+        assertTrue(html.contains("height=\"1\""));
+    }
+
+    @Test
+    void generate_withHttpTrackingPixel_doesNotRender() {
+        WelcomeContent content = createRemoteContent();
+        content.setTrackingPixelUrl("http://insecure.example.com/pixel.gif");
+
+        WelcomeTemplate template = new WelcomeTemplate(webServer, resourceBundle, content);
+
+        String html = template.generate();
+
+        assertFalse(html.contains("insecure.example.com"), "HTTP tracking pixels should not be rendered");
+    }
+
+    @Test
+    void generate_withEmptyTrackingPixel_rendersNothing() {
+        WelcomeContent content = createRemoteContent();
+        content.setTrackingPixelUrl("");
+
+        WelcomeTemplate template = new WelcomeTemplate(webServer, resourceBundle, content);
+
+        String html = template.generate();
+
+        assertFalse(html.contains("<img"), "Empty tracking pixel should not produce an img tag");
+    }
+
+    @Test
+    void generate_escapesHtmlInRemoteContent() {
+        WelcomeContent content = createRemoteContent();
+        content.setTitle("Welcome <script>alert('xss')</script>");
+
+        WelcomeTemplate template = new WelcomeTemplate(webServer, resourceBundle, content);
+
+        String html = template.generate();
+
+        assertFalse(html.contains("<script>"), "Script tags should be escaped");
+        assertTrue(html.contains("&lt;script&gt;"));
+    }
+
+    @Test
+    void generate_withSocialLinks_rendersLinks() {
+        WelcomeContent content = createRemoteContent();
+        WelcomeSocialLink link = new WelcomeSocialLink();
+        link.setPlatform("Twitter");
+        link.setUrl("https://twitter.com/devoxxgenie");
+        link.setLabel("@DevoxxGenie");
+        content.setSocialLinks(List.of(link));
+
+        WelcomeTemplate template = new WelcomeTemplate(webServer, resourceBundle, content);
+
+        String html = template.generate();
+
+        assertTrue(html.contains("Twitter"));
+        assertTrue(html.contains("https://twitter.com/devoxxgenie"));
+        assertTrue(html.contains("@DevoxxGenie"));
+    }
+
+    @Test
+    void generate_withNoConstructorArgs_usesLocalFallback() {
+        WelcomeTemplate template = new WelcomeTemplate(webServer, resourceBundle);
+
+        String html = template.generate();
+
+        assertNotNull(html);
+        assertTrue(html.contains("Welcome to DevoxxGenie"));
+    }
+
+    private WelcomeContent createRemoteContent() {
+        WelcomeContent content = new WelcomeContent();
+        content.setSchemaVersion(1);
+        content.setLastUpdated("2026-02-07");
+        content.setTitle("Remote Welcome Title");
+        content.setDescription("Remote description");
+        content.setInstructions("Remote instructions");
+        content.setTip("Remote tip");
+        content.setEnjoy("Have fun!");
+
+        WelcomeFeature feature = new WelcomeFeature();
+        feature.setEmoji("🔥");
+        feature.setName("Cool Feature");
+        feature.setDescription("A cool feature description");
+        content.setFeatures(List.of(feature));
+
+        content.setAnnouncements(List.of());
+
+        WelcomeSocialLink socialLink = new WelcomeSocialLink();
+        socialLink.setPlatform("Bluesky");
+        socialLink.setUrl("https://bsky.app/profile/devoxxgenie.bsky.social");
+        socialLink.setLabel("@DevoxxGenie.bsky.social");
+        content.setSocialLinks(List.of(socialLink));
+
+        content.setReviewUrl("https://example.com/reviews");
+        content.setTrackingPixelUrl("");
+
+        return content;
+    }
+}


### PR DESCRIPTION
## Summary
- **Remote welcome content**: Plugin fetches welcome text from `genie.devoxx.com/api/welcome.json` with 24h cache TTL, allowing content updates (announcements, features, social links) without a plugin release
- **Analytics tracking pixel**: Renders a 1x1 `<img>` tag from a configurable URL (Cloudflare Worker → GA4 Measurement Protocol), capturing plugin version, OS, and geo location
- **Graceful fallback**: Returns cached/local content immediately on first display; background fetch updates cache for next startup. Schema versioning ignores incompatible remote content

## New Files
- `model/welcome/` — `WelcomeContent`, `WelcomeFeature`, `WelcomeAnnouncement`, `WelcomeSocialLink` POJOs
- `service/welcome/WelcomeContentService` — fetch + in-memory/persistent cache + background refresh
- `docusaurus/static/api/welcome.json` — static JSON for GitHub Pages
- `WelcomeContentServiceTest` (5 tests) + `WelcomeTemplateTest` (9 tests)

## Modified Files
- `DevoxxGenieStateService` — 3 persistent cache fields
- `welcome.html` — dynamic placeholders for features, announcements, social links, review URL, tracking pixel
- `WelcomeTemplate` — remote content rendering with HTML escaping + local fallback
- `WebViewMessageRenderer` — 2-line integration with `WelcomeContentService`
- `plugin.xml` — service registration

## Test plan
- [x] `./gradlew buildPlugin` — builds successfully
- [x] 14/14 unit tests pass (`WelcomeContentServiceTest` + `WelcomeTemplateTest`)
- [ ] Manual test (online): Run IDE → verify remote content loads on second startup
- [ ] Manual test (offline): Disconnect network → clear cache → verify local fallback
- [ ] Manual test (announcements): Edit welcome.json → verify announcement appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)