### PR TITLE
docs: add v0.9.8 changelog for automated test execution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@ so # Changelog
 
 All notable changes to this project will be documented in this file.
 
+## [0.9.8]
+
+### Added
+- Automated test execution: new `run_tests` agent tool that auto-detects build systems (Gradle, Maven, npm, Cargo, Go, Make), runs tests, and returns structured results to the LLM (#863)
+- Agent iterates on test failures: system prompt instructs the LLM to run tests after code changes and fix until they pass
+- Configurable test execution settings: enable/disable toggle, timeout (default 5 min), custom test command with `{target}` placeholder
+- Test output parsing for Gradle, Maven Surefire, and Jest with pass/fail counts and failed test names
+
+### Documentation
+- Add "Automated Test Execution" section to Agent Mode docs with build system table, configuration, and troubleshooting
+
 ## [0.9.7]
 
 ### Added

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -45,6 +45,12 @@
     ]]></description>
 
     <change-notes><![CDATA[
+        <h2>v0.9.8</h2>
+        <UL>
+            <LI>Automated test execution: new run_tests agent tool that auto-detects build systems (Gradle/Maven/npm/Cargo/Go/Make), runs tests, and returns structured results (#863)</LI>
+            <LI>Agent iterates on test failures: system prompt instructs the LLM to run tests after code changes and fix until they pass</LI>
+            <LI>Configurable test execution settings: timeout, custom test command with {target} placeholder</LI>
+        </UL>
         <h2>v0.9.7</h2>
         <UL>
             <LI>Spec Driven Development (SDD) feature with Backlog.md integration, Kanban board, and enhanced Spec Browser (#862)</LI>


### PR DESCRIPTION
## Summary

- Add v0.9.8 changelog entries for the `run_tests` agent tool feature (#863)
- Updates both `CHANGELOG.md` and `plugin.xml` change-notes

This was missed from the original PR merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)