### PR TITLE
fix: replace deprecated JsonNode.fields() with properties()

### DIFF
--- a/src/main/java/com/devoxx/genie/service/acp/protocol/AcpClient.java
+++ b/src/main/java/com/devoxx/genie/service/acp/protocol/AcpClient.java
@@ -422,7 +422,7 @@ public class AcpClient implements AutoCloseable {
             }
         }
         // Try one level deep (e.g. "toolCall": { "name": "..." })
-        var fields = node.fields();
+        var fields = node.properties();
         while (fields.hasNext()) {
             var entry = fields.next();
             if (entry.getValue().isObject()) {
@@ -462,7 +462,7 @@ public class AcpClient implements AutoCloseable {
 
     /** Helper method to search for text in nested nodes. */
     private static String findTextInNestedNode(JsonNode node, String... candidates) {
-        var fields = node.fields();
+        var fields = node.properties();
         while (fields.hasNext()) {
             var entry = fields.next();
             if (entry.getValue().isObject()) {


### PR DESCRIPTION
Replace deprecated JsonNode.fields() method with the modern JsonNode.properties() method in AcpClient class to fix API deprecation warnings.

### Changes
- Updated findTextField() method to use properties() instead of fields()
- Updated findTextInNestedNode() method to use properties() instead of fields()

Fixes #926

Generated with [Claude Code](https://claude.ai/code)