### PR TITLE
fix: use for-each loop for JsonNode.properties() Set iteration

### DIFF
--- a/src/main/java/com/devoxx/genie/service/acp/protocol/AcpClient.java
+++ b/src/main/java/com/devoxx/genie/service/acp/protocol/AcpClient.java
@@ -422,9 +422,7 @@ public class AcpClient implements AutoCloseable {
             }
         }
         // Try one level deep (e.g. "toolCall": { "name": "..." })
-        var fields = node.properties();
-        while (fields.hasNext()) {
-            var entry = fields.next();
+        for (var entry : node.properties()) {
             if (entry.getValue().isObject()) {
                 for (String name : new String[]{"toolName", "name", "tool_name"}) {
                     JsonNode child = entry.getValue().get(name);
@@ -462,9 +460,7 @@ public class AcpClient implements AutoCloseable {
 
     /** Helper method to search for text in nested nodes. */
     private static String findTextInNestedNode(JsonNode node, String... candidates) {
-        var fields = node.properties();
-        while (fields.hasNext()) {
-            var entry = fields.next();
+        for (var entry : node.properties()) {
             if (entry.getValue().isObject()) {
                 String result = findTextInNode(entry.getValue(), candidates);
                 if (result != null) {


### PR DESCRIPTION
## Summary
- Fixes compilation failure in `AcpClient.java` caused by calling `hasNext()`/`next()` on a `Set` instead of an `Iterator`
- Commit `acd2f4d` replaced `JsonNode.fields()` with `properties()` but didn't update the iteration pattern — `properties()` returns a `Set<Entry>`, not an `Iterator`
- Replaced `while`/`hasNext`/`next` loops with for-each loops in `findTextField()` and `findTextInNestedNode()`

## Test plan
- [x] Project compiles successfully with `./gradlew buildPlugin`

🤖 Generated with [Claude Code](https://claude.com/claude-code)