### PR TITLE
feat: make Token Cost settings read-only and refresh from models.json

### DIFF
--- a/src/main/java/com/devoxx/genie/ui/settings/costsettings/LanguageModelCostSettingsComponent.java
+++ b/src/main/java/com/devoxx/genie/ui/settings/costsettings/LanguageModelCostSettingsComponent.java
@@ -1,6 +1,7 @@
 package com.devoxx.genie.ui.settings.costsettings;
 
 import com.devoxx.genie.service.models.LLMModelRegistryService;
+import com.devoxx.genie.service.models.ModelConfigService;
 import com.devoxx.genie.ui.settings.AbstractSettingsComponent;
 import com.intellij.ui.components.JBScrollPane;
 import com.intellij.ui.table.JBTable;
@@ -78,6 +79,9 @@ public class LanguageModelCostSettingsComponent extends AbstractSettingsComponen
         setCustomRenderers();
         loadCurrentCosts();
 
+        // Trigger a remote config refresh so newly added models in models.json appear
+        ModelConfigService.getInstance().forceRefresh(this::loadCurrentCosts);
+
         JPanel optionsPanel = new JPanel(new FlowLayout(FlowLayout.LEFT));
         optionsPanel.add(showCalcTokensButtonCheckBox);
         optionsPanel.add(showAddFileButtonCheckBox);
@@ -143,9 +147,7 @@ public class LanguageModelCostSettingsComponent extends AbstractSettingsComponen
 
         @Override
         public boolean isCellEditable(int row, int column) {
-            return column == ColumnName.INPUT_COST.ordinal() ||
-                column == ColumnName.OUTPUT_COST.ordinal() ||
-                column == ColumnName.CONTEXT_WINDOW.ordinal();
+            return false;
         }
     }
 }


### PR DESCRIPTION
## Summary
- Make the Token Cost settings table fully read-only since model costs are now driven by the remote `models.json`
- Trigger a background refresh of `models.json` when opening the settings page so newly added models (e.g. Gemini 3.1 Pro Preview) appear immediately
- Previously, the table had editable cost/context columns but edits were never persisted — this removes the misleading editability

Depends on #943

## Test plan
- [ ] Open Settings > LLM Costs, verify table is not editable
- [ ] Verify all models from `models.json` appear in the table (including Gemini 3.1 Pro Preview)
- [ ] Verify table sorts correctly by provider/model/cost columns

🤖 Generated with [Claude Code](https://claude.com/claude-code)