### PR TITLE
fix: conversation history doesn't restore old chats (#946)

### DIFF
--- a/src/main/java/com/devoxx/genie/ui/panel/conversation/ConversationHistoryManager.java
+++ b/src/main/java/com/devoxx/genie/ui/panel/conversation/ConversationHistoryManager.java
@@ -67,6 +67,9 @@ public class ConversationHistoryManager {
                 .setMinSize(new Dimension(500, 400))
                 .createPopup();
 
+        // Allow the history panel to dismiss the popup on selection
+        historyPanel.setPopup(historyPopup);
+
         // Calculate the position for the popup
         int x = referenceButton.getX() + referenceButton.getWidth() - 500;
         int y = referenceButton.getY() + referenceButton.getHeight();
@@ -129,10 +132,7 @@ public class ConversationHistoryManager {
 
             log.debug("Starting to process {} messages for conversation restoration", messages.size());
 
-        // Clear any existing DOM content first to prevent duplicate messages
-        messageRenderer.clearWithoutWelcome();
-        
-        // Process all messages
+        // Process all messages (caller already cleared the DOM via clearWithoutWelcome)
         int messageIndex = 0;
 
         // If the first message is an AI message, handle it specially

--- a/src/main/java/com/devoxx/genie/ui/panel/conversation/MessageRenderer.java
+++ b/src/main/java/com/devoxx/genie/ui/panel/conversation/MessageRenderer.java
@@ -8,7 +8,6 @@ import com.intellij.openapi.project.Project;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.util.messages.MessageBusConnection;
 import com.devoxx.genie.ui.topic.AppTopics;
-import com.devoxx.genie.util.ThreadUtils;
 import lombok.extern.slf4j.Slf4j;
 import org.jetbrains.annotations.NotNull;
 
@@ -140,11 +139,10 @@ public class MessageRenderer implements FileReferencesListener {
      * This is used after restoring a conversation.
      */
     public void scrollToTop() {
-        // Small delay before scrolling to ensure all message rendering is complete
+        // Use setTimeout in JS to delay scroll until rendering is complete, avoiding EDT blocking
         ApplicationManager.getApplication().invokeLater(() -> {
-            ThreadUtils.sleep(300);
-            webViewController.executeJavaScript("window.scrollTo(0, 0);");
-            log.debug("Scrolled conversation to top");
+            webViewController.executeJavaScript("setTimeout(function() { window.scrollTo(0, 0); }, 300);");
+            log.debug("Scheduled scroll-to-top");
         });
     }
 
@@ -161,9 +159,6 @@ public class MessageRenderer implements FileReferencesListener {
                 log.error("Error adding chat message: {}", e.getMessage(), e);
             }
         });
-        
-        // Small delay to ensure proper rendering between messages
-        ThreadUtils.sleep(75);
     }
     
     /**
@@ -179,9 +174,6 @@ public class MessageRenderer implements FileReferencesListener {
                 log.error("Error adding user message: {}", e.getMessage(), e);
             }
         });
-        
-        // Small delay to ensure proper rendering
-        ThreadUtils.sleep(50);
     }
 
     /**

--- a/src/main/java/com/devoxx/genie/ui/panel/conversationhistory/ConversationHistoryPanel.java
+++ b/src/main/java/com/devoxx/genie/ui/panel/conversationhistory/ConversationHistoryPanel.java
@@ -9,6 +9,7 @@ import com.devoxx.genie.ui.util.NotificationUtil;
 import com.intellij.icons.AllIcons;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.ui.Messages;
+import com.intellij.openapi.ui.popup.JBPopup;
 import com.intellij.ui.JBColor;
 import com.intellij.ui.components.JBScrollPane;
 import com.intellij.ui.table.JBTable;
@@ -35,6 +36,7 @@ public class ConversationHistoryPanel extends JPanel implements ConversationSele
     private final ConversationStorageService storageService;
     private final ConversationTableModel tableModel;
     private final Project project;
+    private JBPopup activePopup;
 
     public ConversationHistoryPanel(Project project) {
         this.project = project;
@@ -78,6 +80,10 @@ public class ConversationHistoryPanel extends JPanel implements ConversationSele
                     updateChatMemory(conversation);
                     // Notify listener
                     onConversationSelected(conversation);
+                    // Dismiss the popup so the restored conversation is visible
+                    if (activePopup != null && !activePopup.isDisposed()) {
+                        activePopup.cancel();
+                    }
                 }
             }
         });
@@ -129,6 +135,10 @@ public class ConversationHistoryPanel extends JPanel implements ConversationSele
         add(createActionButton("Delete All", TrashIcon, e -> showDeleteAllConfirmationDialog()), BorderLayout.SOUTH);
 
         loadConversations();
+    }
+
+    public void setPopup(JBPopup popup) {
+        this.activePopup = popup;
     }
 
     public void loadConversations() {


### PR DESCRIPTION
## Summary
- **Close popup on conversation selection**: The `JBPopup` was a local variable with no way to dismiss it from the click handler — the restored conversation was hidden behind the popup. Added a `setPopup()` method and dismiss it after selection.
- **Remove EDT blocking during restoration**: `ThreadUtils.sleep(75/50/300)` calls on the EDT froze the UI while restoring messages. Removed all three sleep calls; replaced `scrollToTop()` with a JS-side `setTimeout` to avoid blocking.
- **Remove redundant clear call**: `processConversationMessages()` called `clearWithoutWelcome()` but the caller (`ConversationManager.onConversationSelected()`) already does this.

Fixes #946

## Test plan
- [ ] Open plugin, have a chat conversation
- [ ] Open Conversation History popup and click an old chat
- [ ] Verify popup closes immediately after selection
- [ ] Verify the old conversation messages are restored and visible
- [ ] Verify no UI freeze during restoration with many messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)