### PR TITLE
fix(ci): fix lychee link checker configuration errors

### DIFF
--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -29,8 +29,8 @@ jobs:
             './docusaurus/docs/**/*.md'
             './docusaurus/blog/**/*.md'
           fail: true
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          failIfEmpty: false
+          token: ${{ secrets.GITHUB_TOKEN }}
 
   check-live-site:
     name: Check live site via sitemap
@@ -49,9 +49,9 @@ jobs:
             --no-progress
             https://genie.devoxx.com/sitemap.xml
           fail: false
+          failIfEmpty: false
           output: lychee-report.md
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Create issue on broken links
         if: steps.lychee.outputs.exit_code != 0

--- a/.lychee.toml
+++ b/.lychee.toml
@@ -26,6 +26,4 @@ exclude = [
   "^mailto:",
 ]
 
-# Use GitHub token for github.com links to avoid rate limiting
-[github]
-token = "${GITHUB_TOKEN}"
+# GitHub token is passed via GITHUB_TOKEN env var (set by lychee-action)


### PR DESCRIPTION
The lychee workflow was failing with "No links were found" (exit code 2)
due to an invalid [github] TOML section in .lychee.toml. Lychee has no
[github] table — the token is read from the GITHUB_TOKEN env var which
the action sets automatically.

Changes:
- Remove invalid [github] section from .lychee.toml (root cause of
  config parse error / exit code 2)
- Set failIfEmpty: false to prevent false failures when scanning files
  with no external links (defaults to true in lychee-action v2)
- Pass GitHub token via the action's token input parameter instead of
  env var (v2 convention)

https://claude.ai/code/session_01LtZjLiiuwY65sZU5gqgGat