### PR TITLE
fix(backlog): use task_prefix from config.yml without forcing uppercase

### DIFF
--- a/src/main/java/com/devoxx/genie/service/spec/BacklogConfigService.java
+++ b/src/main/java/com/devoxx/genie/service/spec/BacklogConfigService.java
@@ -79,9 +79,8 @@ public final class BacklogConfigService {
     public @NotNull String getNextTaskId() {
         String prefix = getConfig().getTaskPrefix();
         if (prefix == null || prefix.isEmpty()) {
-            prefix = "TASK";
+            prefix = "task";
         }
-        prefix = prefix.toUpperCase();
         int maxNum = Math.max(scanMaxId(getTasksDir()),
                 Math.max(scanMaxId(getCompletedDir()), scanMaxId(getArchiveTasksDir())));
         return prefix + "-" + (maxNum + 1);


### PR DESCRIPTION
## Summary

- `BacklogConfigService.getNextTaskId()` was hardcoding `"TASK"` as the fallback prefix and calling `.toUpperCase()`, which forced uppercase task IDs regardless of what was configured in `backlog/config.yml`
- The configured `task_prefix: "task"` (lowercase) was being silently ignored
- Fixed by removing `.toUpperCase()` and using `"task"` as the lowercase fallback

## Test plan

- [x] Create a backlog task via the ExternalTask endpoint (e.g. from SonarLint plugin) and verify the generated ID uses lowercase `task-N` format
- [x] Verify `backlog/config.yml` with `task_prefix: "task"` produces IDs like `task-1`, `task-2`, etc.
- [x] Verify that Backlog.md MCP can find tasks by ID after creation

🤖 Generated with [Claude Code](https://claude.com/claude-code)