### PR TITLE
fix: filter raw JSON from CLI Runner output, show only human-readable…

### DIFF
--- a/src/main/java/com/devoxx/genie/service/cli/CliTaskExecutorService.java
+++ b/src/main/java/com/devoxx/genie/service/cli/CliTaskExecutorService.java
@@ -381,9 +381,14 @@ public final class CliTaskExecutorService implements Disposable {
             log.info("CLI {} [{}] line {}: {}", streamName, taskId, lineCount,
                     line.length() > 200 ? line.substring(0, 200) + "..." : line);
         }
-        // Parse Claude stream-json events and forward to Activity Logs panel
+        // Parse Claude stream-json events and forward to Activity Logs panel.
+        // When a line is a stream-json event, suppress it from the console output
+        // to avoid showing raw JSON dumps to the user.
         if (parseClaudeStreamJson && line.startsWith("{")) {
             publishClaudeStreamJsonEvents(line);
+            if (isStdout) {
+                return; // Don't print parsed JSON events to console
+            }
         }
         // Prefix with task ID for parallel execution traceability
         final boolean isParallel = activeTasks.size() > 1;

--- a/src/main/java/com/devoxx/genie/service/cli/command/ClaudeCliCommand.java
+++ b/src/main/java/com/devoxx/genie/service/cli/command/ClaudeCliCommand.java
@@ -1,6 +1,8 @@
 package com.devoxx.genie.service.cli.command;
 
+import com.devoxx.genie.service.cli.ClaudeStreamJsonParser;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Claude Code CLI: prompt piped via stdin with -p flag.
@@ -21,5 +23,27 @@ public class ClaudeCliCommand extends AbstractCliCommand {
     @Override
     public @NotNull String defaultMcpConfigFlag() {
         return "--mcp-config";
+    }
+
+    /**
+     * Filter stream-json output lines so only human-readable text is shown in the chat panel.
+     * JSON event lines (system, assistant tool_use, user tool_result, etc.) are filtered out
+     * since they are already parsed by {@link ClaudeStreamJsonParser} and shown in Activity Logs.
+     * Only assistant text content is extracted and returned for display.
+     */
+    @Override
+    public @Nullable String filterResponseLine(@NotNull String line) {
+        String stripped = super.filterResponseLine(line);
+        if (stripped == null) {
+            return null;
+        }
+        // Non-JSON lines pass through (plain text output from non-stream-json mode)
+        if (!stripped.startsWith("{")) {
+            return stripped;
+        }
+        // Extract human-readable text; append extra newline so consecutive messages
+        // get paragraph separation (\n\n) when the accumulator adds its own \n.
+        String text = ClaudeStreamJsonParser.extractHumanReadableText(stripped);
+        return text != null ? text + "\n" : null;
     }
 }


### PR DESCRIPTION
… text

When using CLI Runners (e.g. Claude Code) with --verbose and --output-format stream-json, the user output panel displayed raw JSON dumps instead of readable content. Now ClaudeCliCommand.filterResponseLine() extracts only assistant text and result content from stream-json events, and CliTaskExecutorService suppresses parsed JSON from the Run console.

# Pull Request

## 📚 Documentation

Before submitting, please review our [Contributing Guide](https://genie.devoxx.com/docs/contributing).

## Description

<!-- Provide a clear description of your changes -->

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test addition/improvement

## Related Issue

<!-- Link to the issue this PR addresses -->
Fixes #
Closes #
Related to #

## Changes Made

<!-- List the specific changes made in this PR -->
-
-
-

## Testing

**How has this been tested?**

- [ ] Unit tests
- [ ] Integration tests
- [x] Manual testing in IntelliJ IDEA
- [ ] Tested with local LLM (Ollama/LMStudio/GPT4All)
- [ ] Tested with cloud LLM (OpenAI/Anthropic/Gemini)
- [ ] Tested with MCP servers
- [ ] Tested with RAG enabled

**Test Configuration:**
- IntelliJ IDEA version:
- JDK version:
- OS:

## Documentation

- [ ] I have updated the documentation at [genie.devoxx.com](https://genie.devoxx.com) if needed
- [ ] I have updated CLAUDE.md if architecture/patterns changed
- [ ] I have added/updated code comments for complex logic
- [ ] I have updated the README.md if needed

## Checklist

- [ ] My code follows the existing code style
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Screenshots/Videos (if applicable)

<!-- Add screenshots or videos demonstrating the changes, especially for UI changes -->

## Additional Notes

<!-- Any additional information that reviewers should know -->

## Breaking Changes

<!-- If this PR introduces breaking changes, describe them here and update the version accordingly -->

---

By submitting this pull request, I confirm that my contribution is made under the terms of the project's license.
