### PR TITLE
chore(deps): bump gradle dependencies (AWS SDK, Compose 1.10.1, markdown renderer 0.39.2)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
     kotlin("jvm") version "2.3.10"
     kotlin("plugin.lombok") version "2.3.10"
     kotlin("plugin.compose") version "2.3.10"
-    id("org.jetbrains.compose") version "1.7.3"
+    id("org.jetbrains.compose") version "1.10.1"
     id("org.jetbrains.intellij.platform") version "2.11.0"
     jacoco
 }
@@ -109,7 +109,7 @@ dependencies {
 
     val lg4j_version = "1.11.0"
     val lg4j_beta_version = "1.11.0-beta19"
-    val awsSdkVersion = "2.41.34"
+    val awsSdkVersion = "2.42.1"
     val retrofitVersion = "3.0.0"
     val sqliteVersion = "3.51.2.0"
     val dockerJavaVersion = "3.7.0"
@@ -117,8 +117,8 @@ dependencies {
     val commonmarkVersion = "0.27.1"
     val jsoupVersion = "1.22.1"
     val nettyVersion = "4.2.10.Final"
-    val composeVersion = "1.7.3"
-    val markdownRendererVersion = "0.28.0"
+    val composeVersion = "1.10.1"
+    val markdownRendererVersion = "0.39.2"
     val logbackVersion = "1.5.32"
     val gitignoreReaderVersion = "1.14.1"
     val junitJupiterVersion = "6.1.0-M1"

--- a/src/main/kotlin/com/devoxx/genie/ui/compose/components/AiBubble.kt
+++ b/src/main/kotlin/com/devoxx/genie/ui/compose/components/AiBubble.kt
@@ -10,6 +10,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.TextLinkStyles
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
@@ -130,13 +132,9 @@ fun AiBubble(
 
             val mdColors = DefaultMarkdownColors(
                 text = textColor,
-                codeText = textColor,
-                inlineCodeText = DevoxxBlue,
-                linkText = DevoxxBlue,
                 codeBackground = codeBg,
                 inlineCodeBackground = codeBg,
                 dividerColor = secondaryColor,
-                tableText = textColor,
                 tableBackground = Color.Transparent,
             )
 
@@ -158,7 +156,8 @@ fun AiBubble(
                 ordered = baseStyle,
                 bullet = baseStyle,
                 list = baseStyle,
-                link = baseStyle.copy(color = DevoxxBlue),
+                textLink = TextLinkStyles(style = SpanStyle(color = DevoxxBlue)),
+                table = baseStyle,
             )
 
             SelectionContainer {

--- a/src/main/kotlin/com/devoxx/genie/ui/compose/components/UserBubble.kt
+++ b/src/main/kotlin/com/devoxx/genie/ui/compose/components/UserBubble.kt
@@ -8,6 +8,8 @@ import androidx.compose.foundation.text.selection.SelectionContainer
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.TextLinkStyles
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
@@ -41,13 +43,9 @@ fun UserBubble(
 
     val mdColors = DefaultMarkdownColors(
         text = textColor,
-        codeText = textColor,
-        inlineCodeText = DevoxxOrange,
-        linkText = DevoxxOrange,
         codeBackground = codeBg,
         inlineCodeBackground = codeBg,
         dividerColor = secondaryColor,
-        tableText = textColor,
         tableBackground = Color.Transparent,
     )
 
@@ -69,7 +67,8 @@ fun UserBubble(
         ordered = baseStyle,
         bullet = baseStyle,
         list = baseStyle,
-        link = baseStyle.copy(color = DevoxxOrange),
+        textLink = TextLinkStyles(style = SpanStyle(color = DevoxxOrange)),
+        table = baseStyle,
     )
 
     val codeFence: com.mikepenz.markdown.compose.components.MarkdownComponent = { model ->


### PR DESCRIPTION
## Summary

Dependabot dependency upgrades, rebased onto master with API compatibility fixes:

| Package | From | To |
| --- | --- | --- |
| `software.amazon.awssdk:bom` | 2.41.34 | 2.42.1 |
| `com.mikepenz:multiplatform-markdown-renderer-jvm` | 0.28.0 | 0.39.2 |
| `com.mikepenz:multiplatform-markdown-renderer-code-jvm` | 0.28.0 | 0.39.2 |
| `org.jetbrains.compose` (all modules) | 1.7.3 | 1.10.1 |

### Breaking API changes fixed

The `multiplatform-markdown-renderer` 0.39.2 removed several parameters from `DefaultMarkdownColors` and renamed `link` in `DefaultMarkdownTypography`:

- **`DefaultMarkdownColors`**: removed `codeText`, `inlineCodeText`, `linkText`, `tableText`
- **`DefaultMarkdownTypography`**: `link: TextStyle` → `textLink: TextLinkStyles`, added `table: TextStyle`

Both `AiBubble.kt` and `UserBubble.kt` have been updated accordingly.

## Test plan

- [x] Plugin builds successfully (`./gradlew buildPlugin`)
- [ ] Verify markdown rendering in AI/User chat bubbles works correctly
- [ ] Verify no runtime class conflicts with IntelliJ's bundled libraries

🤖 Generated with [Claude Code](https://claude.com/claude-code)