### PR TITLE
fix: catch NoClassDefFoundError for CompilerTopics in non-Java IDEs

### DIFF
--- a/src/main/java/com/devoxx/genie/service/PostStartupActivity.java
+++ b/src/main/java/com/devoxx/genie/service/PostStartupActivity.java
@@ -66,28 +66,30 @@ public class PostStartupActivity implements ProjectActivity {
      * Listeners are tied to the project lifecycle and disposed when the project closes.
      */
     private void registerEventAutomationListeners(@NotNull Project project) {
+        MessageBusConnection connection = project.getMessageBus().connect();
+
+        // File editor events (FILE_OPENED)
+        connection.subscribe(FileEditorManagerListener.FILE_EDITOR_MANAGER,
+                new FileEventListener(project));
+
+        // File save events (FILE_SAVED) — application-level topic
+        connection.subscribe(FileDocumentManagerListener.TOPIC,
+                new FileSaveListener());
+
+        // Build/compilation events (BUILD_FAILED, BUILD_SUCCEEDED)
+        // CompilerTopics is only available in IDEs with compiler support (e.g. IntelliJ IDEA),
+        // not in PhpStorm, WebStorm, etc.
         try {
-            MessageBusConnection connection = project.getMessageBus().connect();
-
-            // File editor events (FILE_OPENED)
-            connection.subscribe(FileEditorManagerListener.FILE_EDITOR_MANAGER,
-                    new FileEventListener(project));
-
-            // File save events (FILE_SAVED) — application-level topic
-            connection.subscribe(FileDocumentManagerListener.TOPIC,
-                    new FileSaveListener());
-
-            // Build/compilation events (BUILD_FAILED, BUILD_SUCCEEDED)
             connection.subscribe(CompilerTopics.COMPILATION_STATUS,
                     new BuildCompilationListener(project));
-
-            // Process exit events (PROCESS_CRASHED)
-            connection.subscribe(ExecutionManager.EXECUTION_TOPIC,
-                    new ProcessExitListener());
-
-            log.debug("Registered event automation listeners for project: {}", project.getName());
-        } catch (Exception e) {
-            log.warn("Failed to register some event automation listeners (IDE may lack required APIs)", e);
+        } catch (NoClassDefFoundError e) {
+            log.debug("CompilerTopics not available in this IDE, skipping build compilation listener");
         }
+
+        // Process exit events (PROCESS_CRASHED)
+        connection.subscribe(ExecutionManager.EXECUTION_TOPIC,
+                new ProcessExitListener());
+
+        log.debug("Registered event automation listeners for project: {}", project.getName());
     }
 }


### PR DESCRIPTION
## Summary
- Fixes `NoClassDefFoundError` crash on startup in PhpStorm, WebStorm, and other non-Java JetBrains IDEs
- `CompilerTopics` is only available in IDEs with compiler support (IntelliJ IDEA, Android Studio) — the previous `catch(Exception)` didn't catch this since `NoClassDefFoundError` extends `Error`, not `Exception`
- Narrows the try-catch to only the `CompilerTopics` subscription so other event listeners (file editor, file save, process exit) always register regardless of IDE type

Fixes #990

## Test plan
- [ ] Install plugin in PhpStorm/WebStorm and verify no exception on startup
- [ ] Verify plugin still works in IntelliJ IDEA with build compilation events

🤖 Generated with [Claude Code](https://claude.com/claude-code)