### PR TITLE
feat(welcome): blog feed on welcome screen + friendlier analytics copy

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -121,6 +121,92 @@ tasks.named("buildPlugin") {
     dependsOn("updateProperties")
 }
 
+val generatedBlogResourcesDir = layout.buildDirectory.dir("generated-resources/blog")
+
+sourceSets.named("main") {
+    resources.srcDir(generatedBlogResourcesDir)
+}
+
+tasks.register("generateBlogIndex") {
+    group = "build"
+    description = "Generates blog-posts.json from docusaurus/blog/*.md frontmatter"
+
+    val blogDir = file("docusaurus/blog")
+    val outputFile = generatedBlogResourcesDir.get().file("devoxxgenie/blog-posts.json").asFile
+
+    inputs.dir(blogDir)
+    outputs.file(outputFile)
+
+    doLast {
+        if (!blogDir.exists()) {
+            logger.warn("Blog directory not found: $blogDir — writing empty index")
+            outputFile.parentFile.mkdirs()
+            outputFile.writeText("[]")
+            return@doLast
+        }
+
+        // Very small YAML frontmatter parser — sufficient for our blog posts
+        fun parseFrontmatter(file: File): Map<String, String>? {
+            val lines = file.readLines()
+            if (lines.isEmpty() || lines[0].trim() != "---") return null
+            val end = lines.drop(1).indexOfFirst { it.trim() == "---" }
+            if (end < 0) return null
+            val map = mutableMapOf<String, String>()
+            for (line in lines.subList(1, end + 1)) {
+                val idx = line.indexOf(':')
+                if (idx <= 0) continue
+                val key = line.substring(0, idx).trim()
+                var value = line.substring(idx + 1).trim()
+                // Strip surrounding quotes
+                if ((value.startsWith("\"") && value.endsWith("\"") && value.length >= 2) ||
+                    (value.startsWith("'") && value.endsWith("'") && value.length >= 2)
+                ) {
+                    value = value.substring(1, value.length - 1)
+                }
+                map[key] = value
+            }
+            return map
+        }
+
+        fun jsonEscape(s: String): String = buildString {
+            for (c in s) when (c) {
+                '\\' -> append("\\\\")
+                '"' -> append("\\\"")
+                '\n' -> append("\\n")
+                '\r' -> append("\\r")
+                '\t' -> append("\\t")
+                else -> if (c.code < 0x20) append("\\u%04x".format(c.code)) else append(c)
+            }
+        }
+
+        data class Entry(val slug: String, val title: String, val date: String, val description: String)
+
+        val entries = blogDir.listFiles { f -> f.isFile && f.name.endsWith(".md") }
+            ?.mapNotNull { f ->
+                val fm = parseFrontmatter(f) ?: return@mapNotNull null
+                val slug = fm["slug"] ?: return@mapNotNull null
+                val title = fm["title"] ?: return@mapNotNull null
+                // Date: prefer explicit `date:` field, fall back to filename prefix yyyy-MM-dd
+                val date = fm["date"] ?: f.name.take(10)
+                val description = fm["description"] ?: ""
+                Entry(slug, title, date, description)
+            }
+            ?.sortedByDescending { it.date }
+            ?: emptyList()
+
+        outputFile.parentFile.mkdirs()
+        val json = entries.joinToString(prefix = "[\n", postfix = "\n]", separator = ",\n") { e ->
+            """  {"slug":"${jsonEscape(e.slug)}","title":"${jsonEscape(e.title)}","date":"${jsonEscape(e.date)}","description":"${jsonEscape(e.description)}"}"""
+        }
+        outputFile.writeText(json)
+        logger.lifecycle("Generated ${entries.size} blog entries → $outputFile")
+    }
+}
+
+tasks.named("processResources") {
+    dependsOn("generateBlogIndex")
+}
+
 dependencies {
     intellijPlatform {
         // Allow overriding IDE version via property: ./gradlew runIde -PideVersion=2025.1.7

--- a/src/main/java/com/devoxx/genie/service/analytics/AnalyticsConsentNotifier.java
+++ b/src/main/java/com/devoxx/genie/service/analytics/AnalyticsConsentNotifier.java
@@ -22,21 +22,23 @@ public final class AnalyticsConsentNotifier {
 
     private static final String NOTIFICATION_GROUP_ID = "com.devoxx.genie.notifications";
 
-    private static final String TITLE = "DevoxxGenie usage analytics";
+    private static final String TITLE = "Help shape DevoxxGenie";
+
+    private static final String ANALYTICS_SOURCE_URL =
+            "https://github.com/devoxx/DevoxxGenieIDEAPlugin/blob/master/" +
+                    "src/main/java/com/devoxx/genie/service/analytics/AnalyticsEventBuilder.java";
 
     private static final String CONTENT =
-            "<html>To guide which features and LLM providers we invest engineering effort in, " +
-                    "DevoxxGenie collects <b>anonymous</b> usage data when you run a prompt or change models:" +
-                    "<ul>" +
-                    "<li>Anonymous install ID, per-launch session ID, plugin version, IDE version</li>" +
-                    "<li>LLM provider name and model name</li>" +
-                    "<li>Which optional features are enabled (RAG, Agent, MCP, Web Search) and coarse counts</li>" +
-                    "<li>Which features are actually used during a prompt (feature identifiers only)</li>" +
-                    "</ul>" +
-                    "<b>We never send</b> prompt text, response text, file content, file paths, project names, " +
-                    "API keys, MCP server names/URLs/commands, user-defined prompt names, or anything " +
-                    "that could identify you. " +
-                    "You can change this any time in <i>Settings → DevoxxGenie → Analytics</i>." +
+            "<html>" +
+                    "We're a small open-source team, and <b>anonymous</b> usage data is the only way " +
+                    "we know which features are actually worth our time. " +
+                    "<b>No prompts, no code, no file paths, no API keys</b> — ever. " +
+                    "Just things like which LLM provider you picked and whether RAG is enabled." +
+                    "<br><br>" +
+                    "See exactly what we send: " +
+                    "<a href=\"" + ANALYTICS_SOURCE_URL + "\">AnalyticsEventBuilder.java</a>" +
+                    "<br><br>" +
+                    "You can turn this off any time in <i>Settings → DevoxxGenie → Analytics</i>." +
                     "</html>";
 
     private AnalyticsConsentNotifier() {
@@ -59,7 +61,7 @@ public final class AnalyticsConsentNotifier {
                     .getNotificationGroup(NOTIFICATION_GROUP_ID)
                     .createNotification(TITLE, CONTENT, NotificationType.INFORMATION);
 
-            notification.addAction(new AnAction("OK, Keep Enabled") {
+            notification.addAction(new AnAction("Sure, help out") {
                 @Override
                 public void actionPerformed(@NotNull AnActionEvent e) {
                     DevoxxGenieStateService.getInstance().setAnalyticsNoticeAcknowledged(true);

--- a/src/main/java/com/devoxx/genie/service/blog/BlogFeedService.java
+++ b/src/main/java/com/devoxx/genie/service/blog/BlogFeedService.java
@@ -1,0 +1,229 @@
+package com.devoxx.genie.service.blog;
+
+import com.devoxx.genie.util.HttpClientProvider;
+import com.google.gson.Gson;
+import com.intellij.ide.util.PropertiesComponent;
+import com.intellij.openapi.application.ApplicationManager;
+import lombok.extern.slf4j.Slf4j;
+import okhttp3.Request;
+import okhttp3.Response;
+import okhttp3.ResponseBody;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Consumer;
+
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.NodeList;
+
+/**
+ * Loads blog posts to surface on the welcome screen.
+ *
+ * <p>Two sources:
+ * <ol>
+ *   <li>A bundled {@code blog-posts.json} generated at build time from {@code docusaurus/blog/*.md}.
+ *       Always available, works offline, but stale between releases.</li>
+ *   <li>The live RSS feed at {@code https://genie.devoxx.com/blog/rss.xml}, fetched asynchronously
+ *       and cached in {@link PropertiesComponent} for {@value #CACHE_TTL_MILLIS} ms.</li>
+ * </ol>
+ *
+ * <p>Callers should display the bundled list immediately, then call
+ * {@link #refreshRemoteAsync(Consumer)} to update the UI when fresh posts arrive.
+ */
+@Slf4j
+public final class BlogFeedService {
+
+    private static final String BUNDLED_RESOURCE = "/devoxxgenie/blog-posts.json";
+    private static final String FEED_URL = "https://genie.devoxx.com/blog/rss.xml";
+
+    private static final String CACHE_KEY = "devoxxgenie.blog.cache.json";
+    private static final String CACHE_TIMESTAMP_KEY = "devoxxgenie.blog.cache.ts";
+    private static final long CACHE_TTL_MILLIS = 6L * 60 * 60 * 1000; // 6 hours
+
+    private static final BlogFeedService INSTANCE = new BlogFeedService();
+
+    private final Gson gson = new Gson();
+
+    private BlogFeedService() {}
+
+    public static BlogFeedService getInstance() {
+        return INSTANCE;
+    }
+
+    /** Synchronously load the bundled blog post list from the plugin classpath. */
+    public @NotNull List<BlogPost> getBundled() {
+        try (InputStream in = BlogFeedService.class.getResourceAsStream(BUNDLED_RESOURCE)) {
+            if (in == null) {
+                log.warn("Bundled blog index not found at {}", BUNDLED_RESOURCE);
+                return Collections.emptyList();
+            }
+            BlogPost[] posts = gson.fromJson(new InputStreamReader(in, StandardCharsets.UTF_8), BlogPost[].class);
+            return posts == null ? Collections.emptyList() : List.of(posts);
+        } catch (Exception e) {
+            log.warn("Failed to load bundled blog index", e);
+            return Collections.emptyList();
+        }
+    }
+
+    /**
+     * Returns cached remote posts if a fresh cache exists; otherwise {@code null}.
+     * Cheap and safe to call on the EDT.
+     */
+    public @Nullable List<BlogPost> getCachedRemote() {
+        PropertiesComponent props = PropertiesComponent.getInstance();
+        String json = props.getValue(CACHE_KEY);
+        long ts = props.getLong(CACHE_TIMESTAMP_KEY, 0L);
+        if (json == null || json.isEmpty()) return null;
+        if (System.currentTimeMillis() - ts > CACHE_TTL_MILLIS) return null;
+        try {
+            BlogPost[] posts = gson.fromJson(json, BlogPost[].class);
+            return posts == null ? null : List.of(posts);
+        } catch (Exception e) {
+            log.debug("Failed to parse cached blog posts", e);
+            return null;
+        }
+    }
+
+    /**
+     * Best-effort: returns cached remote posts if fresh, otherwise the bundled list.
+     * Never blocks on network — safe for the initial welcome render.
+     */
+    public @NotNull List<BlogPost> getInitialPosts() {
+        List<BlogPost> cached = getCachedRemote();
+        if (cached != null && !cached.isEmpty()) {
+            return cached;
+        }
+        return getBundled();
+    }
+
+    /**
+     * Fetch the live RSS feed off the EDT and invoke {@code onUpdated} with fresh posts when
+     * (and only if) they differ from what is currently cached. Failures are silent.
+     */
+    public void refreshRemoteAsync(@NotNull Consumer<List<BlogPost>> onUpdated) {
+        // Snapshot whether the UI is currently backed by a fresh remote cache. If it is,
+        // and the fetched feed matches that cache, we can skip the UI update. Otherwise
+        // (no cache, expired cache, or content changed) we must push the fetched posts
+        // to the UI so the welcome screen leaves bundled-stale data behind.
+        final boolean initialWasFreshRemote = getCachedRemote() != null;
+
+        CompletableFuture.supplyAsync(this::fetchRemote, ApplicationManager.getApplication()::executeOnPooledThread)
+                .thenAccept(posts -> {
+                    if (posts == null || posts.isEmpty()) return;
+
+                    PropertiesComponent props = PropertiesComponent.getInstance();
+                    String previous = props.getValue(CACHE_KEY);
+                    String fresh = gson.toJson(posts);
+                    boolean contentChanged = !fresh.equals(previous);
+
+                    if (contentChanged) {
+                        props.setValue(CACHE_KEY, fresh);
+                    }
+                    props.setValue(CACHE_TIMESTAMP_KEY, String.valueOf(System.currentTimeMillis()));
+
+                    // Push to UI when content actually changed, OR when the UI was
+                    // previously showing bundled/stale data (so it can switch to remote).
+                    if (contentChanged || !initialWasFreshRemote) {
+                        ApplicationManager.getApplication().invokeLater(() -> onUpdated.accept(posts));
+                    }
+                })
+                .exceptionally(ex -> {
+                    log.debug("Remote blog refresh failed: {}", ex.getMessage());
+                    return null;
+                });
+    }
+
+    private @Nullable List<BlogPost> fetchRemote() {
+        Request request = new Request.Builder().url(FEED_URL).get().build();
+        try (Response response = HttpClientProvider.getClient().newCall(request).execute()) {
+            if (!response.isSuccessful()) {
+                log.debug("Blog RSS fetch returned {}", response.code());
+                return null;
+            }
+            ResponseBody body = response.body();
+            if (body == null) return null;
+            return parseRss(body.bytes());
+        } catch (Exception e) {
+            log.debug("Blog RSS fetch failed", e);
+            return null;
+        }
+    }
+
+    private @Nullable List<BlogPost> parseRss(byte[] xml) {
+        try {
+            DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+            // Defensive XML parser configuration
+            dbf.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+            dbf.setFeature("http://xml.org/sax/features/external-general-entities", false);
+            dbf.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+            dbf.setXIncludeAware(false);
+            dbf.setExpandEntityReferences(false);
+
+            DocumentBuilder db = dbf.newDocumentBuilder();
+            Document doc = db.parse(new ByteArrayInputStream(xml));
+
+            NodeList items = doc.getElementsByTagName("item");
+            List<BlogPost> posts = new ArrayList<>(items.getLength());
+            for (int i = 0; i < items.getLength(); i++) {
+                Element item = (Element) items.item(i);
+                String title = textOf(item, "title");
+                String link = textOf(item, "link");
+                String description = stripHtml(textOf(item, "description"));
+                String pubDate = textOf(item, "pubDate");
+                if (title == null || link == null) continue;
+
+                String slug = slugFromLink(link);
+                String date = normalizeDate(pubDate);
+                posts.add(new BlogPost(slug, title, date, description == null ? "" : description));
+            }
+            return posts;
+        } catch (Exception e) {
+            log.debug("Failed to parse RSS feed", e);
+            return null;
+        }
+    }
+
+    private static @Nullable String textOf(@NotNull Element parent, @NotNull String tag) {
+        NodeList nl = parent.getElementsByTagName(tag);
+        if (nl.getLength() == 0) return null;
+        String text = nl.item(0).getTextContent();
+        return text == null ? null : text.trim();
+    }
+
+    private static @NotNull String slugFromLink(@NotNull String link) {
+        // Expect https://genie.devoxx.com/blog/<slug>(/)
+        int idx = link.indexOf("/blog/");
+        if (idx < 0) return link;
+        String tail = link.substring(idx + "/blog/".length());
+        if (tail.endsWith("/")) tail = tail.substring(0, tail.length() - 1);
+        return tail;
+    }
+
+    private static @NotNull String normalizeDate(@Nullable String pubDate) {
+        if (pubDate == null || pubDate.isEmpty()) return "";
+        try {
+            ZonedDateTime zdt = ZonedDateTime.parse(pubDate, DateTimeFormatter.RFC_1123_DATE_TIME);
+            return zdt.toLocalDate().toString();
+        } catch (Exception e) {
+            return pubDate;
+        }
+    }
+
+    private static @NotNull String stripHtml(@Nullable String s) {
+        if (s == null) return "";
+        return s.replaceAll("<[^>]+>", "").replaceAll("\\s+", " ").trim();
+    }
+}

--- a/src/main/java/com/devoxx/genie/service/blog/BlogPost.java
+++ b/src/main/java/com/devoxx/genie/service/blog/BlogPost.java
@@ -1,0 +1,16 @@
+package com.devoxx.genie.service.blog;
+
+/**
+ * A blog post entry shown on the welcome screen.
+ *
+ * @param slug        the post slug, used to build the URL (https://genie.devoxx.com/blog/{slug})
+ * @param title       the post title
+ * @param date        the publication date as ISO string (yyyy-MM-dd)
+ * @param description short description / excerpt
+ */
+public record BlogPost(String slug, String title, String date, String description) {
+
+    public String url() {
+        return "https://genie.devoxx.com/blog/" + slug;
+    }
+}

--- a/src/main/java/com/devoxx/genie/ui/settings/general/GeneralSettingsComponent.java
+++ b/src/main/java/com/devoxx/genie/ui/settings/general/GeneralSettingsComponent.java
@@ -3,6 +3,7 @@ package com.devoxx.genie.ui.settings.general;
 import com.devoxx.genie.service.PropertiesService;
 import com.devoxx.genie.service.analytics.DevoxxGenieSettingsChangedTopic;
 import com.devoxx.genie.ui.settings.DevoxxGenieStateService;
+import com.intellij.ui.HyperlinkLabel;
 import com.intellij.ui.components.JBLabel;
 import com.intellij.util.ui.JBUI;
 import com.intellij.util.ui.UIUtil;
@@ -17,14 +18,40 @@ import java.awt.*;
  */
 public class GeneralSettingsComponent {
 
+    private static final String ANALYTICS_SOURCE_URL =
+            "https://github.com/devoxx/DevoxxGenieIDEAPlugin/blob/master/" +
+                    "src/main/java/com/devoxx/genie/service/analytics/AnalyticsEventBuilder.java";
+
     private final JPanel panel;
     private final JCheckBox analyticsEnabledCheckBox;
 
     public GeneralSettingsComponent() {
         DevoxxGenieStateService state = DevoxxGenieStateService.getInstance();
 
-        analyticsEnabledCheckBox = new JCheckBox("Send anonymous usage statistics");
+        analyticsEnabledCheckBox = new JCheckBox("Help improve DevoxxGenie by sending anonymous usage data");
         analyticsEnabledCheckBox.setSelected(Boolean.TRUE.equals(state.getAnalyticsEnabled()));
+
+        JBLabel intro = new JBLabel(
+                "<html><body style='width:480px'>" +
+                        "We're a small open-source team, and <b>anonymous</b> usage data is the only way " +
+                        "we know which features are actually worth our time. " +
+                        "<b>No prompts, no code, no file paths, no API keys</b> — ever. " +
+                        "Just things like which LLM provider you picked and whether RAG is enabled." +
+                        "</body></html>");
+
+        HyperlinkLabel sourceLink = new HyperlinkLabel("See exactly what we send: AnalyticsEventBuilder.java");
+        sourceLink.setHyperlinkTarget(ANALYTICS_SOURCE_URL);
+
+        JBLabel notSentHeader = new JBLabel("<html><b>What is never sent:</b></html>");
+        JBLabel notSentList = new JBLabel(
+                "<html><ul style='margin-left:18px'>" +
+                        "<li>Prompt text, response text, conversation history</li>" +
+                        "<li>File content, file paths, project name, git remote</li>" +
+                        "<li>MCP server names, URLs, commands, tool names, or environment variables</li>" +
+                        "<li>User-defined custom prompt names or bodies</li>" +
+                        "<li>API keys, credentials, user name, email</li>" +
+                        "<li>Token counts or cost data</li>" +
+                        "</ul></html>");
 
         JBLabel sentHeader = new JBLabel("<html><b>What is sent</b> (per LLM prompt, model selection, or session):</html>");
         JBLabel sentList = new JBLabel(
@@ -40,20 +67,8 @@ public class GeneralSettingsComponent {
                         "(feature identifiers only, never prompt text or file content)</li>" +
                         "</ul></html>");
 
-        JBLabel notSentHeader = new JBLabel("<html><b>What is never sent:</b></html>");
-        JBLabel notSentList = new JBLabel(
-                "<html><ul style='margin-left:18px'>" +
-                        "<li>Prompt text, response text, conversation history</li>" +
-                        "<li>File content, file paths, project name, git remote</li>" +
-                        "<li>MCP server names, URLs, commands, tool names, or environment variables</li>" +
-                        "<li>User-defined custom prompt names or bodies</li>" +
-                        "<li>API keys, credentials, user name, email</li>" +
-                        "<li>Token counts or cost data</li>" +
-                        "</ul>This data is used only to guide which features and LLM providers receive " +
-                        "engineering investment.</html>");
-
         Color subtle = UIUtil.getContextHelpForeground();
-        for (JBLabel l : new JBLabel[]{sentHeader, sentList, notSentHeader, notSentList}) {
+        for (JBLabel l : new JBLabel[]{intro, sentHeader, sentList, notSentHeader, notSentList}) {
             l.setForeground(subtle);
         }
 
@@ -62,6 +77,8 @@ public class GeneralSettingsComponent {
         panel.setBorder(JBUI.Borders.empty(12));
 
         analyticsEnabledCheckBox.setAlignmentX(Component.LEFT_ALIGNMENT);
+        intro.setAlignmentX(Component.LEFT_ALIGNMENT);
+        sourceLink.setAlignmentX(Component.LEFT_ALIGNMENT);
         sentHeader.setAlignmentX(Component.LEFT_ALIGNMENT);
         sentList.setAlignmentX(Component.LEFT_ALIGNMENT);
         notSentHeader.setAlignmentX(Component.LEFT_ALIGNMENT);
@@ -72,15 +89,19 @@ public class GeneralSettingsComponent {
         versionLabel.setAlignmentX(Component.LEFT_ALIGNMENT);
         versionLabel.setForeground(UIUtil.getContextHelpForeground());
 
+        panel.add(intro);
+        panel.add(Box.createVerticalStrut(10));
         panel.add(analyticsEnabledCheckBox);
-        panel.add(Box.createVerticalStrut(8));
+        panel.add(Box.createVerticalStrut(6));
+        panel.add(sourceLink);
+        panel.add(Box.createVerticalStrut(6));
         panel.add(versionLabel);
         panel.add(Box.createVerticalStrut(16));
-        panel.add(sentHeader);
-        panel.add(sentList);
-        panel.add(Box.createVerticalStrut(8));
         panel.add(notSentHeader);
         panel.add(notSentList);
+        panel.add(Box.createVerticalStrut(8));
+        panel.add(sentHeader);
+        panel.add(sentList);
         panel.add(Box.createVerticalGlue());
     }
 

--- a/src/main/kotlin/com/devoxx/genie/ui/compose/model/ConversationState.kt
+++ b/src/main/kotlin/com/devoxx/genie/ui/compose/model/ConversationState.kt
@@ -7,10 +7,18 @@ data class CustomPromptUi(
     val prompt: String,
 )
 
+data class BlogPostUi(
+    val title: String,
+    val description: String,
+    val date: String,
+    val url: String,
+)
+
 sealed class ConversationState {
     data class Welcome(
         val resourceBundle: ResourceBundle,
         val customPrompts: List<CustomPromptUi> = emptyList(),
+        val blogPosts: List<BlogPostUi> = emptyList(),
     ) : ConversationState()
 
     data class Chat(

--- a/src/main/kotlin/com/devoxx/genie/ui/compose/screen/ConversationScreen.kt
+++ b/src/main/kotlin/com/devoxx/genie/ui/compose/screen/ConversationScreen.kt
@@ -25,6 +25,7 @@ fun ConversationScreen(
                 WelcomeScreen(
                     resourceBundle = s.resourceBundle,
                     customPrompts = s.customPrompts,
+                    blogPosts = s.blogPosts,
                     onCustomPromptClick = onCustomPromptClick,
                     modifier = modifier,
                 )

--- a/src/main/kotlin/com/devoxx/genie/ui/compose/screen/WelcomeScreen.kt
+++ b/src/main/kotlin/com/devoxx/genie/ui/compose/screen/WelcomeScreen.kt
@@ -26,6 +26,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.devoxx.genie.ui.compose.model.BlogPostUi
 import com.devoxx.genie.ui.compose.model.CustomPromptUi
 import com.devoxx.genie.ui.compose.model.FEATURES
 import com.devoxx.genie.ui.compose.model.FeatureDoc
@@ -40,6 +41,7 @@ import java.util.ResourceBundle
 fun WelcomeScreen(
     resourceBundle: ResourceBundle,
     customPrompts: List<CustomPromptUi>,
+    blogPosts: List<BlogPostUi> = emptyList(),
     onCustomPromptClick: (String) -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -109,6 +111,14 @@ fun WelcomeScreen(
         }
 
         Spacer(Modifier.height(20.dp))
+
+        // Latest from the blog
+        if (blogPosts.isNotEmpty()) {
+            SectionHeader("Latest from the Blog")
+            Spacer(Modifier.height(8.dp))
+            BlogPostList(blogPosts)
+            Spacer(Modifier.height(20.dp))
+        }
 
         // Footer
         FooterLinks()
@@ -272,6 +282,67 @@ private fun CommandsList(
                     maxLines = 1,
                     overflow = TextOverflow.Ellipsis,
                 )
+            }
+        }
+    }
+}
+
+@Composable
+private fun BlogPostList(posts: List<BlogPostUi>) {
+    val colors = DevoxxGenieThemeAccessor.colors
+    val typography = DevoxxGenieThemeAccessor.typography
+    val cardBg = colors.surface.blendWith(colors.onSurface, 0.04f)
+    val cardBorder = colors.surface.blendWith(colors.onSurface, 0.12f)
+    val shape = RoundedCornerShape(8.dp)
+
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .background(cardBg, shape)
+            .border(1.dp, cardBorder, shape)
+            .padding(12.dp),
+        verticalArrangement = Arrangement.spacedBy(10.dp),
+    ) {
+        posts.forEach { post ->
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clip(RoundedCornerShape(4.dp))
+                    .clickable { BrowserUtil.browse(post.url) }
+                    .pointerHoverIcon(PointerIcon.Hand)
+                    .padding(vertical = 4.dp, horizontal = 4.dp),
+            ) {
+                BasicText(
+                    text = post.title,
+                    style = typography.body2.copy(
+                        fontWeight = FontWeight.SemiBold,
+                        color = DevoxxBlue,
+                    ),
+                    maxLines = 2,
+                    overflow = TextOverflow.Ellipsis,
+                )
+                if (post.description.isNotEmpty()) {
+                    Spacer(Modifier.height(2.dp))
+                    BasicText(
+                        text = post.description,
+                        style = typography.caption.copy(
+                            fontSize = 11.sp,
+                            color = colors.textSecondary,
+                        ),
+                        maxLines = 2,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                }
+                if (post.date.isNotEmpty()) {
+                    Spacer(Modifier.height(2.dp))
+                    BasicText(
+                        text = post.date,
+                        style = typography.caption.copy(
+                            fontSize = 10.sp,
+                            color = colors.textSecondary.copy(alpha = 0.7f),
+                        ),
+                    )
+                }
             }
         }
     }

--- a/src/main/kotlin/com/devoxx/genie/ui/compose/viewmodel/ConversationViewModel.kt
+++ b/src/main/kotlin/com/devoxx/genie/ui/compose/viewmodel/ConversationViewModel.kt
@@ -8,6 +8,8 @@ import com.devoxx.genie.model.activity.ActivityMessage
 import com.devoxx.genie.model.activity.ActivitySource
 import com.devoxx.genie.model.agent.AgentType
 import com.devoxx.genie.model.request.ChatMessageContext
+import com.devoxx.genie.service.blog.BlogFeedService
+import com.devoxx.genie.service.blog.BlogPost
 import com.devoxx.genie.ui.compose.model.*
 import com.devoxx.genie.ui.settings.DevoxxGenieStateService
 import com.intellij.openapi.vfs.VirtualFile
@@ -21,6 +23,7 @@ class ConversationViewModel {
         ConversationState.Welcome(
             resourceBundle = ResourceBundle.getBundle("messages"),
             customPrompts = loadCustomPrompts(),
+            blogPosts = loadBlogPosts(),
         )
     )
         private set
@@ -67,7 +70,9 @@ class ConversationViewModel {
         state = ConversationState.Welcome(
             resourceBundle = resourceBundle,
             customPrompts = loadCustomPrompts(),
+            blogPosts = loadBlogPosts(),
         )
+        refreshBlogPostsAsync()
     }
 
     fun updateCustomPrompts(resourceBundle: ResourceBundle) {
@@ -234,6 +239,7 @@ class ConversationViewModel {
         state = ConversationState.Welcome(
             resourceBundle = rb,
             customPrompts = loadCustomPrompts(),
+            blogPosts = loadBlogPosts(),
         )
     }
 
@@ -263,6 +269,38 @@ class ConversationViewModel {
         val provider = model.provider?.name ?: return name
         return "$provider : $name"
     }
+
+    private fun loadBlogPosts(): List<BlogPostUi> {
+        return try {
+            BlogFeedService.getInstance().initialPosts
+                .take(5)
+                .map { it.toUi() }
+        } catch (_: Exception) {
+            emptyList()
+        }
+    }
+
+    private fun refreshBlogPostsAsync() {
+        try {
+            BlogFeedService.getInstance().refreshRemoteAsync { fresh ->
+                val current = state
+                if (current is ConversationState.Welcome) {
+                    state = current.copy(
+                        blogPosts = fresh.take(5).map { it.toUi() },
+                    )
+                }
+            }
+        } catch (_: Exception) {
+            // best-effort — ignore
+        }
+    }
+
+    private fun BlogPost.toUi(): BlogPostUi = BlogPostUi(
+        title = title(),
+        description = description(),
+        date = date(),
+        url = url(),
+    )
 
     private fun loadCustomPrompts(): List<CustomPromptUi> {
         return try {


### PR DESCRIPTION
## Summary

- **Welcome screen blog feed** — surfaces the most recent posts from genie.devoxx.com on the DevoxxGenie tool-window welcome screen using a hybrid bundled + remote strategy. A new `generateBlogIndex` Gradle task parses YAML frontmatter from `docusaurus/blog/*.md` into `build/generated-resources/blog/devoxxgenie/blog-posts.json` (no source-tree pollution). At runtime, `BlogFeedService` loads the bundled JSON synchronously for instant render, then asynchronously fetches the live RSS feed off the EDT via `HttpClientProvider` (with a hardened `DocumentBuilder`), caching for 6h in `PropertiesComponent`. Falls back silently to bundled data on any failure.
- **Compose UI** — new "Latest from the Blog" section between Quick Commands and the footer, rendered from a new `Welcome.blogPosts` state field. Each entry opens the post in the browser via `BrowserUtil`.
- **Analytics consent copy rewrite** — the first-run balloon and the Settings → DevoxxGenie → Analytics page both previously read like a legal disclosure. Rewritten to lead with the open-source framing, put reassurance ("no prompts, no code, no file paths, no API keys") before any data list, and add an inline link to `AnalyticsEventBuilder.java` on GitHub so technical users can verify the payload directly. Affirmative action label changed from "OK, Keep Enabled" to "Sure, help out".

## Test plan

- [ ] `./gradlew generateBlogIndex` — verify it parses `docusaurus/blog/*.md` and writes `build/generated-resources/blog/devoxxgenie/blog-posts.json`
- [ ] `./gradlew clean processResources` — verify generated file ends up at `build/resources/main/devoxxgenie/blog-posts.json`
- [ ] `./gradlew runIde` — open the DevoxxGenie tool window on a fresh project, confirm the "Latest from the Blog" section renders with bundled posts, and that clicking a post opens the correct URL
- [ ] With network available, confirm the section refreshes with the live RSS feed (check IDE logs for `BlogFeedService` debug output if needed)
- [ ] Disconnect network, reopen the tool window — confirm bundled posts still display and no errors are logged
- [ ] Reset analytics consent state and reopen the IDE — verify the new "Help shape DevoxxGenie" balloon appears, the GitHub link is clickable, and both action buttons set the expected state
- [ ] Settings → DevoxxGenie → Analytics — verify the new intro paragraph, the friendlier checkbox label, the clickable "AnalyticsEventBuilder.java" link, and that "What is never sent" appears before "What is sent"

🤖 Generated with [Claude Code](https://claude.com/claude-code)