### PR TITLE
fix: revert Compose/Kotlin ecosystem bump that broke the UI

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -235,7 +235,7 @@ Key services under `service/`:
 
 - Java minimum: JDK 17
 - IntelliJ minimum: 2023.3.4
-- Langchain4J version: 1.10.0 (beta: 1.10.0-beta18 for MCP/Chroma/web search)
+- Langchain4J version: 1.14.0 (beta: 1.14.0-beta24 for MCP/Chroma/web search/reactor)
 - Uses Lombok for boilerplate reduction
 - Shadow plugin for fat JAR creation with dependency merging
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,10 +4,10 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
     java
-    kotlin("jvm") version "2.3.21"
-    kotlin("plugin.lombok") version "2.3.21"
-    kotlin("plugin.compose") version "2.3.21"
-    id("org.jetbrains.intellij.platform") version "2.16.0"
+    kotlin("jvm") version "2.1.10"
+    kotlin("plugin.lombok") version "2.1.10"
+    kotlin("plugin.compose") version "2.1.10"
+    id("org.jetbrains.intellij.platform") version "2.13.1"
     jacoco
 }
 
@@ -227,9 +227,9 @@ dependencies {
     val commonmarkVersion = "0.28.0"
     val jsoupVersion = "1.22.2"
     val nettyVersion = "4.2.13.Final"
-    val composeCompileVersion = "1.10.3"
-    val markdownRendererVersion = "0.40.2"
-    val skikoVersion = "0.144.5"
+    val composeCompileVersion = "1.7.3"
+    val markdownRendererVersion = "0.28.0"
+    val skikoVersion = "0.8.18"
     val logbackVersion = "1.5.32"
     val gitignoreReaderVersion = "1.14.1"
     val junitJupiterVersion = "6.1.0-RC1"

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,1 @@
-version=1.4.1
+version=1.4.3

--- a/src/test/java/com/devoxx/genie/chatmodel/cloud/anthropic/AnthropicChatModelTest.java
+++ b/src/test/java/com/devoxx/genie/chatmodel/cloud/anthropic/AnthropicChatModelTest.java
@@ -16,7 +16,7 @@ public class AnthropicChatModelTest {
 
         AnthropicChatModel model = AnthropicChatModel.builder()
                 .apiKey(apiKeyValue)
-                .modelName(AnthropicChatModelName.CLAUDE_3_HAIKU_20240307)
+                .modelName(AnthropicChatModelName.CLAUDE_HAIKU_4_5_20251001)
                 .maxRetries(1)
                 .build();
 


### PR DESCRIPTION
## Summary
- Dependabot bump `4ccdd646` re-applied the exact version bundle (Kotlin 2.3.21, Compose 1.10.3, Skiko 0.144.5, markdown-renderer 0.40.2, IntelliJ Platform plugin 2.16.0) that commit `1b21aea5` had deliberately rolled back a month earlier — re-breaking the build and the Compose UI.
- That bundle needs a newer Kotlin stdlib than the targeted IntelliJ platform ships, causing a `NoSuchMethodError` in `kotlin.time.Duration` at runtime.
- Reverted to the proven-good versions (Kotlin 2.1.10, Compose 1.7.3, Skiko 0.8.18, markdown-renderer 0.28.0, IntelliJ Platform plugin 2.13.1), and synced the stale Langchain4J version note in `CLAUDE.md`.

## Test plan
- [ ] `./gradlew buildPlugin` succeeds (JDK 21)
- [ ] `./gradlew test` passes
- [ ] `./gradlew runIde` — Compose tool window renders without `NoSuchMethodError` / Skiko crash
- [ ] AI/User chat bubbles render markdown + code blocks correctly

## Follow-up
Consider adding a `.github/dependabot.yml` ignore rule for the Compose/Kotlin/Skiko/markdown-renderer group so this bump doesn't recur a third time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)