### PR TITLE
fix: destroy process tree in AcpTransport.close() to prevent thread leak

### DIFF
--- a/src/main/java/com/devoxx/genie/service/acp/protocol/AcpTransport.java
+++ b/src/main/java/com/devoxx/genie/service/acp/protocol/AcpTransport.java
@@ -261,6 +261,18 @@ public class AcpTransport implements AutoCloseable {
         pendingRequests.forEach((id, future) -> future.cancel(true));
         pendingRequests.clear();
         if (process != null) {
+            // Destroy descendants first so they can't keep stdout/stderr open
+            try {
+                process.descendants().forEach(ph -> {
+                    try {
+                        ph.destroy();
+                    } catch (Exception ignored) {
+                        // best-effort
+                    }
+                });
+            } catch (Exception ignored) {
+                // best-effort
+            }
             process.destroy();
             // Close stdout explicitly: the child may have spawned grandchildren that
             // inherit the pipe, leaving the reader thread blocked on readLine() even
@@ -272,11 +284,33 @@ public class AcpTransport implements AutoCloseable {
             }
             try {
                 if (!process.waitFor(SHUTDOWN_WAIT_SECONDS, TimeUnit.SECONDS)) {
+                    try {
+                        process.descendants().forEach(ph -> {
+                            try {
+                                ph.destroyForcibly();
+                            } catch (Exception ignored) {
+                                // best-effort
+                            }
+                        });
+                    } catch (Exception ignored) {
+                        // best-effort
+                    }
                     process.destroyForcibly();
                     process.waitFor(SHUTDOWN_WAIT_SECONDS, TimeUnit.SECONDS);
                 }
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
+                try {
+                    process.descendants().forEach(ph -> {
+                        try {
+                            ph.destroyForcibly();
+                        } catch (Exception ignored) {
+                            // best-effort
+                        }
+                    });
+                } catch (Exception ignored) {
+                    // best-effort
+                }
                 process.destroyForcibly();
             }
         }


### PR DESCRIPTION
## Summary
- Fixes `AcpClientTest > testPing_timeout_returnsFalse` failing on GitHub CI (ubuntu-latest) due to `ThreadLeakTracker` detecting a leftover `acp-reader` thread.
- On Linux, child processes spawned by the ACP transport (e.g. `sleep` from shell scripts in tests) could keep stdout pipes open after `process.destroy()`, causing the reader thread to stay blocked on `BufferedReader.readLine()` indefinitely.
- Updated `AcpTransport.close()` to destroy the entire process tree (descendants first, then parent) so child processes cannot hold pipes open, ensuring the reader thread exits cleanly.

## Test plan
- [ ] CI passes on ubuntu-latest
- [ ] `AcpClientTest` suite passes
- [ ] `AcpTransportTest` suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)