### PR TITLE
read_file tool: Use guessProjectDir instead of contentRoots[0]

### DIFF
--- a/src/main/java/com/devoxx/genie/service/agent/tool/ReadFileToolExecutor.java
+++ b/src/main/java/com/devoxx/genie/service/agent/tool/ReadFileToolExecutor.java
@@ -2,7 +2,7 @@ package com.devoxx.genie.service.agent.tool;
 
 import com.intellij.openapi.application.ReadAction;
 import com.intellij.openapi.project.Project;
-import com.intellij.openapi.roots.ProjectRootManager;
+import com.intellij.openapi.project.ProjectUtil;
 import com.intellij.openapi.vfs.VfsUtilCore;
 import com.intellij.openapi.vfs.VirtualFile;
 import dev.langchain4j.agent.tool.ToolExecutionRequest;
@@ -65,8 +65,7 @@ public class ReadFileToolExecutor implements ToolExecutor {
     }
 
     VirtualFile getProjectBaseDir() {
-        VirtualFile[] contentRoots = ProjectRootManager.getInstance(project).getContentRoots();
-        return contentRoots.length > 0 ? contentRoots[0] : null;
+        return ProjectUtil.guessProjectDir(project);
     }
 
     VirtualFile findFile(VirtualFile projectBase, String path) {


### PR DESCRIPTION
# Pull Request

## 📚 Documentation

Before submitting, please review our [Contributing Guide](https://genie.devoxx.com/docs/contributing).

## Description

When used in a project with multiple submodules, `read_file` tool fails to find a file (although `list_files` tool does find it). It turns out that other ToolExecutor subclasses (ListFilesToolExecutor included) already use alternative approach of finding project base directory: ProjectUtil.guessProjectDir(project)

This fix simply aligns ReadFileToolExecutor with ListFilesToolExecutor in this aspect.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test addition/improvement

## Related Issue

None, I've not filed an issue. Just fixed the problem I bumped when using DevoxxGenie against my commercial project.

## Changes Made

ReadFileToolExecutor stops relying on the assumption that `contentRoots[0]` is always the project root directory. Instead it now uses `ProjectUtil.guessProjectDir(project)` (this approach is already used in other parts of the plugin).

## Testing

**How has this been tested?**

- [ ] Unit tests
- [ ] Integration tests
- [x] Manual testing in IntelliJ IDEA
- [x] Tested with local LLM (Ollama/LMStudio/GPT4All)
- [ ] Tested with cloud LLM (OpenAI/Anthropic/Gemini)
- [ ] Tested with MCP servers
- [ ] Tested with RAG enabled

**Test Configuration:**
- IntelliJ IDEA version: 2026.1.1
- JDK version: 17
- OS: Linux

## Documentation

- [ ] I have updated the documentation at [genie.devoxx.com](https://genie.devoxx.com) if needed
- [ ] I have updated CLAUDE.md if architecture/patterns changed
- [ ] I have added/updated code comments for complex logic
- [ ] I have updated the README.md if needed

## Checklist

- [x] My code follows the existing code style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Screenshots/Videos (if applicable)

<!-- Add screenshots or videos demonstrating the changes, especially for UI changes -->

## Additional Notes

<!-- Any additional information that reviewers should know -->

## Breaking Changes

<!-- If this PR introduces breaking changes, describe them here and update the version accordingly -->

---

By submitting this pull request, I confirm that my contribution is made under the terms of the project's license.
