### PR TITLE
fix: surface multi-line run_command output in agent log preview

### DIFF
--- a/src/main/java/com/devoxx/genie/ui/panel/log/AgentMcpLogPanel.java
+++ b/src/main/java/com/devoxx/genie/ui/panel/log/AgentMcpLogPanel.java
@@ -40,6 +40,7 @@ import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.Function;
 
 /**
  * Unified log panel that merges Agent and MCP log streams with source-based filtering.
@@ -51,10 +52,17 @@ public class AgentMcpLogPanel extends SimpleToolWindowPanel implements ActivityL
     private static final int DEFAULT_MAX_LOG_ENTRIES = 1000;
     private static final int BATCH_SIZE = 20;
     /**
-     * Maximum characters shown in the single-line preview of a tool argument/result. The full
-     * content remains available via tooltip (hover) and the double-click editor view.
+     * Maximum characters per individual line shown in the panel preview. Very long single lines
+     * are truncated with an ellipsis; the full content remains available via tooltip and the
+     * double-click editor view.
      */
-    private static final int INLINE_PREVIEW_MAX_LEN = 500;
+    private static final int INLINE_PREVIEW_MAX_LINE_LEN = 500;
+    /**
+     * Maximum number of lines rendered in a single panel row. Multi-line tool output beyond
+     * this cap is collapsed into a "(N more lines)" hint so a giant {@code ps -ef} doesn't eat
+     * the whole panel.
+     */
+    private static final int INLINE_PREVIEW_MAX_LINES = 10;
 
     /** Maximum characters shown in the hover tooltip. Beyond this, content is truncated with an ellipsis. */
     private static final int TOOLTIP_MAX_LEN = 8_000;
@@ -69,6 +77,7 @@ public class AgentMcpLogPanel extends SimpleToolWindowPanel implements ActivityL
         LogSource source,
         AgentType agentType,  // null for MCP entries
         String message,
+        String clipboardMessage,
         String fullContent
     ) {
         @Override
@@ -99,7 +108,7 @@ public class AgentMcpLogPanel extends SimpleToolWindowPanel implements ActivityL
         };
         logList.setCellRenderer(new CombinedLogEntryRenderer());
         logList.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
-        logList.setFixedCellHeight(24);
+        // No fixed cell height — multi-line entries grow to fit their content.
         logList.setVisibleRowCount(20);
 
         logList.addMouseListener(new MouseAdapter() {
@@ -246,13 +255,15 @@ public class AgentMcpLogPanel extends SimpleToolWindowPanel implements ActivityL
         }
 
         if (message.getSource() == ActivitySource.AGENT) {
-            String displayText = formatAgentActivityMessage(message);
+            String displayText = formatAgentActivityMessage(message, AgentMcpLogPanel::formatForRow);
+            String clipboardText = formatAgentActivityMessage(message, AgentMcpLogPanel::formatForClipboard);
             String fullContent = buildAgentActivityFullContent(message);
             LogEntry entry = new LogEntry(
                     LocalDateTime.now().format(TIME_FORMATTER),
                     LogSource.AGENT,
                     message.getAgentType(),
                     displayText,
+                    clipboardText,
                     fullContent
             );
             addToPending(entry);
@@ -262,6 +273,7 @@ public class AgentMcpLogPanel extends SimpleToolWindowPanel implements ActivityL
                     LocalDateTime.now().format(TIME_FORMATTER),
                     LogSource.MCP,
                     null,
+                    content,
                     content,
                     content
             );
@@ -288,6 +300,7 @@ public class AgentMcpLogPanel extends SimpleToolWindowPanel implements ActivityL
                 LocalDateTime.now().format(TIME_FORMATTER),
                 LogSource.MCP,
                 null,
+                content,
                 content,
                 content
         );
@@ -339,7 +352,8 @@ public class AgentMcpLogPanel extends SimpleToolWindowPanel implements ActivityL
         }
     }
 
-    static @NotNull String formatAgentActivityMessage(@NotNull ActivityMessage message) {
+    static @NotNull String formatAgentActivityMessage(@NotNull ActivityMessage message,
+                                                      @NotNull Function<String, String> contentFormatter) {
         StringBuilder sb = new StringBuilder();
         if (message.getAgentType() != AgentType.INTERMEDIATE_RESPONSE) {
             sb.append("[").append(message.getCallNumber()).append("/").append(message.getMaxCalls()).append("] ");
@@ -348,11 +362,11 @@ public class AgentMcpLogPanel extends SimpleToolWindowPanel implements ActivityL
             sb.append("[").append(message.getSubAgentId()).append("] ");
         }
         switch (message.getAgentType()) {
-            case TOOL_REQUEST:    formatToolRequest(sb, message);    break;
-            case TOOL_RESPONSE:   formatToolResponse(sb, message);   break;
+            case TOOL_REQUEST:    formatToolRequest(sb, message, contentFormatter);    break;
+            case TOOL_RESPONSE:   formatToolResponse(sb, message, contentFormatter);   break;
             case TOOL_ERROR:
                 sb.append("✖ ").append(message.getToolName());
-                if (message.getResult() != null) sb.append(" → ").append(flattenForRow(message.getResult()));
+                if (message.getResult() != null) sb.append(" → ").append(contentFormatter.apply(message.getResult()));
                 break;
             case LOOP_LIMIT:
                 sb.append("⚠ LOOP LIMIT REACHED (").append(message.getMaxCalls()).append(" calls)");
@@ -366,7 +380,7 @@ public class AgentMcpLogPanel extends SimpleToolWindowPanel implements ActivityL
             case APPROVAL_DENIED:
                 sb.append("✖ Approval denied for ").append(message.getToolName());
                 break;
-            case INTERMEDIATE_RESPONSE: formatIntermediateResponse(sb, message); break;
+            case INTERMEDIATE_RESPONSE: formatIntermediateResponse(sb, message, contentFormatter); break;
             case SUB_AGENT_STARTED:
                 sb.append("⬇ Sub-agent started: ").append(message.getSubAgentId());
                 break;
@@ -375,76 +389,99 @@ public class AgentMcpLogPanel extends SimpleToolWindowPanel implements ActivityL
                 break;
             case SUB_AGENT_ERROR:
                 sb.append("✖ Sub-agent error: ").append(message.getSubAgentId());
-                if (message.getResult() != null) sb.append(" → ").append(flattenForRow(message.getResult()));
+                if (message.getResult() != null) sb.append(" → ").append(contentFormatter.apply(message.getResult()));
                 break;
         }
         return sb.toString();
     }
 
-    private static void formatToolRequest(@NotNull StringBuilder sb, @NotNull ActivityMessage message) {
+    private static void formatToolRequest(@NotNull StringBuilder sb, @NotNull ActivityMessage message,
+                                          @NotNull Function<String, String> contentFormatter) {
         sb.append("▶ ").append(message.getToolName());
         if (message.getArguments() != null) {
-            sb.append(" ← ").append(flattenForRow(message.getArguments()));
+            sb.append(" ← ").append(contentFormatter.apply(message.getArguments()));
         }
     }
 
-    private static void formatToolResponse(@NotNull StringBuilder sb, @NotNull ActivityMessage message) {
+    private static void formatToolResponse(@NotNull StringBuilder sb, @NotNull ActivityMessage message,
+                                           @NotNull Function<String, String> contentFormatter) {
         sb.append("✔ ").append(message.getToolName());
         if (message.getResult() != null) {
-            sb.append(" → ").append(flattenForRow(message.getResult()));
+            sb.append(" → ").append(contentFormatter.apply(message.getResult()));
         }
     }
 
-    private static void formatIntermediateResponse(@NotNull StringBuilder sb, @NotNull ActivityMessage message) {
+    private static void formatIntermediateResponse(@NotNull StringBuilder sb, @NotNull ActivityMessage message,
+                                                   @NotNull Function<String, String> contentFormatter) {
         sb.append("\uD83D\uDCAC ");
         if (message.getResult() != null) {
-            sb.append(flattenForRow(message.getResult()));
+            sb.append(contentFormatter.apply(message.getResult()));
         } else {
             sb.append("LLM intermediate response");
         }
     }
 
     /**
-     * Compresses a multi-line tool result/argument into a one-line preview suitable for the
-     * fixed-height list row, while still hinting at the structure of the full content.
-     * <ul>
-     *   <li>Newlines are replaced with a visible "⏎ " separator so the user can see line
-     *       boundaries instead of one long run-together string.</li>
-     *   <li>Long content is truncated with an ellipsis and a "(N lines)" suffix so the user
-     *       knows there's more to see (double-click opens the full content).</li>
-     * </ul>
+     * Formats a tool argument/result for the multi-line panel preview. Each input line maps to
+     * an output line (real {@code \n} separators) so the renderer can render rows that grow
+     * vertically. Each line is truncated to {@link #INLINE_PREVIEW_MAX_LINE_LEN} characters and
+     * the overall block is capped at {@link #INLINE_PREVIEW_MAX_LINES} lines with a "(N more
+     * lines)" hint; the full content remains available via tooltip and the double-click editor.
      */
-    static @NotNull String flattenForRow(@NotNull String text) {
-        return flattenForRow(text, INLINE_PREVIEW_MAX_LEN);
+    static @NotNull String formatForRow(@NotNull String text) {
+        return formatForRow(text, INLINE_PREVIEW_MAX_LINE_LEN, INLINE_PREVIEW_MAX_LINES);
     }
 
-    static @NotNull String flattenForRow(@NotNull String text, int maxLen) {
-        // Normalise line endings, then split.
-        String[] lines = text.replace("\r\n", "\n").replace('\r', '\n').split("\n", -1);
-        // Drop trailing empty lines that come from final newline(s) in the result, so e.g.
-        // "line1\n\n" is reported as a single-line result rather than "(2 lines)".
-        int effectiveLineCount = lines.length;
-        while (effectiveLineCount > 0 && lines[effectiveLineCount - 1].isEmpty()) {
-            effectiveLineCount--;
-        }
+    static @NotNull String formatForRow(@NotNull String text, int maxLineLen, int maxLines) {
+        String[] lines = splitLines(text);
+        int total = effectiveLineCount(lines);
+        if (total == 0) return "";
 
-        String joined;
-        if (effectiveLineCount <= 1) {
-            joined = effectiveLineCount == 0 ? "" : lines[0];
-        } else {
-            StringBuilder sb = new StringBuilder();
-            for (int i = 0; i < effectiveLineCount; i++) {
-                if (i > 0) sb.append(" ⏎ ");
-                sb.append(lines[i]);
+        int shown = Math.min(total, maxLines);
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < shown; i++) {
+            if (i > 0) sb.append('\n');
+            String line = lines[i];
+            if (line.length() > maxLineLen) {
+                sb.append(line, 0, maxLineLen).append('…');
+            } else {
+                sb.append(line);
             }
-            joined = sb.toString();
         }
+        if (total > shown) {
+            sb.append('\n').append("… (").append(total - shown).append(" more lines)");
+        }
+        return sb.toString();
+    }
 
-        String truncated = joined.length() > maxLen ? joined.substring(0, maxLen) + "…" : joined;
-        if (effectiveLineCount > 1) {
-            return truncated + " (" + effectiveLineCount + " lines)";
+    /**
+     * Formats a tool argument/result for the copy-to-clipboard action. Single-line content
+     * stays on the same line as its prefix (e.g. {@code → ok}). Multi-line content is moved
+     * onto subsequent indented lines so newlines are preserved verbatim without losing the
+     * visual link to the entry header.
+     */
+    static @NotNull String formatForClipboard(@NotNull String text) {
+        String[] lines = splitLines(text);
+        int total = effectiveLineCount(lines);
+        if (total == 0) return "";
+        if (total == 1) return lines[0];
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < total; i++) {
+            sb.append('\n').append("    ").append(lines[i]);
         }
-        return truncated;
+        return sb.toString();
+    }
+
+    private static String[] splitLines(@NotNull String text) {
+        return text.replace("\r\n", "\n").replace('\r', '\n').split("\n", -1);
+    }
+
+    private static int effectiveLineCount(String[] lines) {
+        int n = lines.length;
+        // Drop all trailing empty lines from final newline(s), so e.g. "line1\n\n" is reported
+        // as a single-line result rather than "(2 lines)".
+        while (n > 0 && lines[n - 1].isEmpty()) n--;
+        return n;
     }
 
     private @NotNull String buildAgentActivityFullContent(@NotNull ActivityMessage message) {
@@ -523,7 +560,7 @@ public class AgentMcpLogPanel extends SimpleToolWindowPanel implements ActivityL
         StringBuilder sb = new StringBuilder();
         for (LogEntry entry : logsToExport) {
             sb.append(entry.timestamp()).append(" [").append(entry.source()).append("] ")
-              .append(entry.message()).append("\n");
+              .append(entry.clipboardMessage()).append("\n");
         }
         if (sb.isEmpty()) {
             NotificationUtil.sendNotification(project, "No logs to copy.");
@@ -617,7 +654,9 @@ public class AgentMcpLogPanel extends SimpleToolWindowPanel implements ActivityL
             if (value instanceof LogEntry entry && !isSelected) {
                 String sourceTag = entry.source() == LogSource.MCP ? "[MCP] " : "[AGT] ";
                 String badge = currentFilter == LogFilter.ALL ? sourceTag : "";
-                label.setText(entry.timestamp() + " " + badge + entry.message());
+                String plain = entry.timestamp() + " " + badge + entry.message();
+                label.setText(toHtmlRow(plain));
+                label.setVerticalAlignment(SwingConstants.TOP);
                 // Tooltip shows the full (multi-line) result so users can hover instead of double-clicking.
                 String fc = entry.fullContent();
                 label.setToolTipText(fc != null ? toHtmlTooltip(fc) : null);
@@ -627,6 +666,15 @@ public class AgentMcpLogPanel extends SimpleToolWindowPanel implements ActivityL
                 }
             }
             return label;
+        }
+
+        private @NotNull String toHtmlRow(@NotNull String text) {
+            String escaped = text
+                    .replace("&", "&amp;")
+                    .replace("<", "&lt;")
+                    .replace(">", "&gt;")
+                    .replace("\n", "<br>");
+            return "<html><pre style=\"font-family:monospace;margin:0;padding:0\">" + escaped + "</pre></html>";
         }
 
         private Color resolveEntryColor(LogEntry entry) {

--- a/src/main/java/com/devoxx/genie/ui/panel/log/AgentMcpLogPanel.java
+++ b/src/main/java/com/devoxx/genie/ui/panel/log/AgentMcpLogPanel.java
@@ -339,7 +339,7 @@ public class AgentMcpLogPanel extends SimpleToolWindowPanel implements ActivityL
         }
     }
 
-    private @NotNull String formatAgentActivityMessage(@NotNull ActivityMessage message) {
+    static @NotNull String formatAgentActivityMessage(@NotNull ActivityMessage message) {
         StringBuilder sb = new StringBuilder();
         if (message.getAgentType() != AgentType.INTERMEDIATE_RESPONSE) {
             sb.append("[").append(message.getCallNumber()).append("/").append(message.getMaxCalls()).append("] ");
@@ -352,7 +352,7 @@ public class AgentMcpLogPanel extends SimpleToolWindowPanel implements ActivityL
             case TOOL_RESPONSE:   formatToolResponse(sb, message);   break;
             case TOOL_ERROR:
                 sb.append("✖ ").append(message.getToolName());
-                if (message.getResult() != null) sb.append(" → ").append(message.getResult());
+                if (message.getResult() != null) sb.append(" → ").append(flattenForRow(message.getResult()));
                 break;
             case LOOP_LIMIT:
                 sb.append("⚠ LOOP LIMIT REACHED (").append(message.getMaxCalls()).append(" calls)");
@@ -375,27 +375,27 @@ public class AgentMcpLogPanel extends SimpleToolWindowPanel implements ActivityL
                 break;
             case SUB_AGENT_ERROR:
                 sb.append("✖ Sub-agent error: ").append(message.getSubAgentId());
-                if (message.getResult() != null) sb.append(" → ").append(message.getResult());
+                if (message.getResult() != null) sb.append(" → ").append(flattenForRow(message.getResult()));
                 break;
         }
         return sb.toString();
     }
 
-    private void formatToolRequest(@NotNull StringBuilder sb, @NotNull ActivityMessage message) {
+    private static void formatToolRequest(@NotNull StringBuilder sb, @NotNull ActivityMessage message) {
         sb.append("▶ ").append(message.getToolName());
         if (message.getArguments() != null) {
             sb.append(" ← ").append(flattenForRow(message.getArguments()));
         }
     }
 
-    private void formatToolResponse(@NotNull StringBuilder sb, @NotNull ActivityMessage message) {
+    private static void formatToolResponse(@NotNull StringBuilder sb, @NotNull ActivityMessage message) {
         sb.append("✔ ").append(message.getToolName());
         if (message.getResult() != null) {
             sb.append(" → ").append(flattenForRow(message.getResult()));
         }
     }
 
-    private void formatIntermediateResponse(@NotNull StringBuilder sb, @NotNull ActivityMessage message) {
+    private static void formatIntermediateResponse(@NotNull StringBuilder sb, @NotNull ActivityMessage message) {
         sb.append("\uD83D\uDCAC ");
         if (message.getResult() != null) {
             sb.append(flattenForRow(message.getResult()));
@@ -421,9 +421,10 @@ public class AgentMcpLogPanel extends SimpleToolWindowPanel implements ActivityL
     static @NotNull String flattenForRow(@NotNull String text, int maxLen) {
         // Normalise line endings, then split.
         String[] lines = text.replace("\r\n", "\n").replace('\r', '\n').split("\n", -1);
-        // Drop trailing empty line that comes from a final \n in the result.
+        // Drop trailing empty lines that come from final newline(s) in the result, so e.g.
+        // "line1\n\n" is reported as a single-line result rather than "(2 lines)".
         int effectiveLineCount = lines.length;
-        if (effectiveLineCount > 0 && lines[effectiveLineCount - 1].isEmpty()) {
+        while (effectiveLineCount > 0 && lines[effectiveLineCount - 1].isEmpty()) {
             effectiveLineCount--;
         }
 
@@ -618,7 +619,8 @@ public class AgentMcpLogPanel extends SimpleToolWindowPanel implements ActivityL
                 String badge = currentFilter == LogFilter.ALL ? sourceTag : "";
                 label.setText(entry.timestamp() + " " + badge + entry.message());
                 // Tooltip shows the full (multi-line) result so users can hover instead of double-clicking.
-                label.setToolTipText(toHtmlTooltip(entry.fullContent()));
+                String fc = entry.fullContent();
+                label.setToolTipText(fc != null ? toHtmlTooltip(fc) : null);
                 Color fg = resolveEntryColor(entry);
                 if (fg != null) {
                     label.setForeground(fg);

--- a/src/main/java/com/devoxx/genie/ui/panel/log/AgentMcpLogPanel.java
+++ b/src/main/java/com/devoxx/genie/ui/panel/log/AgentMcpLogPanel.java
@@ -50,6 +50,14 @@ public class AgentMcpLogPanel extends SimpleToolWindowPanel implements ActivityL
 
     private static final int DEFAULT_MAX_LOG_ENTRIES = 1000;
     private static final int BATCH_SIZE = 20;
+    /**
+     * Maximum characters shown in the single-line preview of a tool argument/result. The full
+     * content remains available via tooltip (hover) and the double-click editor view.
+     */
+    private static final int INLINE_PREVIEW_MAX_LEN = 500;
+
+    /** Maximum characters shown in the hover tooltip. Beyond this, content is truncated with an ellipsis. */
+    private static final int TOOLTIP_MAX_LEN = 8_000;
     private static final DateTimeFormatter TIME_FORMATTER = DateTimeFormatter.ofPattern("HH:mm:ss.SSS");
     private static final ObjectMapper JSON_MAPPER = new ObjectMapper().enable(SerializationFeature.INDENT_OUTPUT);
 
@@ -376,24 +384,66 @@ public class AgentMcpLogPanel extends SimpleToolWindowPanel implements ActivityL
     private void formatToolRequest(@NotNull StringBuilder sb, @NotNull ActivityMessage message) {
         sb.append("▶ ").append(message.getToolName());
         if (message.getArguments() != null) {
-            sb.append(" ← ").append(message.getArguments().replace("\n", " "));
+            sb.append(" ← ").append(flattenForRow(message.getArguments()));
         }
     }
 
     private void formatToolResponse(@NotNull StringBuilder sb, @NotNull ActivityMessage message) {
         sb.append("✔ ").append(message.getToolName());
         if (message.getResult() != null) {
-            sb.append(" → ").append(message.getResult().replace("\n", " "));
+            sb.append(" → ").append(flattenForRow(message.getResult()));
         }
     }
 
     private void formatIntermediateResponse(@NotNull StringBuilder sb, @NotNull ActivityMessage message) {
         sb.append("\uD83D\uDCAC ");
         if (message.getResult() != null) {
-            sb.append(message.getResult().replace("\n", " "));
+            sb.append(flattenForRow(message.getResult()));
         } else {
             sb.append("LLM intermediate response");
         }
+    }
+
+    /**
+     * Compresses a multi-line tool result/argument into a one-line preview suitable for the
+     * fixed-height list row, while still hinting at the structure of the full content.
+     * <ul>
+     *   <li>Newlines are replaced with a visible "⏎ " separator so the user can see line
+     *       boundaries instead of one long run-together string.</li>
+     *   <li>Long content is truncated with an ellipsis and a "(N lines)" suffix so the user
+     *       knows there's more to see (double-click opens the full content).</li>
+     * </ul>
+     */
+    static @NotNull String flattenForRow(@NotNull String text) {
+        return flattenForRow(text, INLINE_PREVIEW_MAX_LEN);
+    }
+
+    static @NotNull String flattenForRow(@NotNull String text, int maxLen) {
+        // Normalise line endings, then split.
+        String[] lines = text.replace("\r\n", "\n").replace('\r', '\n').split("\n", -1);
+        // Drop trailing empty line that comes from a final \n in the result.
+        int effectiveLineCount = lines.length;
+        if (effectiveLineCount > 0 && lines[effectiveLineCount - 1].isEmpty()) {
+            effectiveLineCount--;
+        }
+
+        String joined;
+        if (effectiveLineCount <= 1) {
+            joined = effectiveLineCount == 0 ? "" : lines[0];
+        } else {
+            StringBuilder sb = new StringBuilder();
+            for (int i = 0; i < effectiveLineCount; i++) {
+                if (i > 0) sb.append(" ⏎ ");
+                sb.append(lines[i]);
+            }
+            joined = sb.toString();
+        }
+
+        String truncated = joined.length() > maxLen ? joined.substring(0, maxLen) + "…" : joined;
+        if (effectiveLineCount > 1) {
+            return truncated + " (" + effectiveLineCount + " lines)";
+        }
+        return truncated;
     }
 
     private @NotNull String buildAgentActivityFullContent(@NotNull ActivityMessage message) {
@@ -408,6 +458,25 @@ public class AgentMcpLogPanel extends SimpleToolWindowPanel implements ActivityL
         if (message.getArguments() != null) sb.append("--- Arguments ---\n").append(message.getArguments()).append("\n\n");
         if (message.getResult() != null) sb.append("--- Result ---\n").append(message.getResult()).append("\n");
         return sb.toString();
+    }
+
+    /**
+     * Wraps text as an HTML Swing tooltip so newlines render as line breaks instead of being
+     * collapsed into a single line. Long content is truncated with an ellipsis to keep the
+     * tooltip usable; the full content remains available via double-click.
+     */
+    static @NotNull String toHtmlTooltip(@NotNull String text) {
+        return toHtmlTooltip(text, TOOLTIP_MAX_LEN);
+    }
+
+    static @NotNull String toHtmlTooltip(@NotNull String text, int maxLen) {
+        String trimmed = text.length() > maxLen ? text.substring(0, maxLen) + "\n… (double-click to view full content)" : text;
+        String escaped = trimmed
+                .replace("&", "&amp;")
+                .replace("<", "&lt;")
+                .replace(">", "&gt;")
+                .replace("\n", "<br>");
+        return "<html><pre style=\"font-family:monospace;margin:0\">" + escaped + "</pre></html>";
     }
 
     private void openLogInEditor(LogEntry logEntry) {
@@ -548,7 +617,8 @@ public class AgentMcpLogPanel extends SimpleToolWindowPanel implements ActivityL
                 String sourceTag = entry.source() == LogSource.MCP ? "[MCP] " : "[AGT] ";
                 String badge = currentFilter == LogFilter.ALL ? sourceTag : "";
                 label.setText(entry.timestamp() + " " + badge + entry.message());
-                label.setToolTipText(entry.message());
+                // Tooltip shows the full (multi-line) result so users can hover instead of double-clicking.
+                label.setToolTipText(toHtmlTooltip(entry.fullContent()));
                 Color fg = resolveEntryColor(entry);
                 if (fg != null) {
                     label.setForeground(fg);

--- a/src/test/java/com/devoxx/genie/ui/panel/log/AgentMcpLogPanelFormatTest.java
+++ b/src/test/java/com/devoxx/genie/ui/panel/log/AgentMcpLogPanelFormatTest.java
@@ -8,80 +8,127 @@ import org.junit.jupiter.api.Test;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
- * Unit tests for the inline-preview and tooltip helpers used by {@link AgentMcpLogPanel}.
- * These guard the contract that the list-row preview and the hover tooltip surface enough
- * information about a multi-line tool result for the user to recognise when the full output
- * needs to be inspected (instead of silently appearing as a single error line).
+ * Unit tests for the row-preview, clipboard, and tooltip helpers used by {@link AgentMcpLogPanel}.
+ * These guard the contract that:
+ * <ul>
+ *   <li>panel rows render multi-line tool output across real lines (no {@code ⏎} markers),</li>
+ *   <li>copy-to-clipboard preserves the original newlines verbatim under the entry header,</li>
+ *   <li>the hover tooltip surfaces the full multi-line content as HTML.</li>
+ * </ul>
  */
 class AgentMcpLogPanelFormatTest {
 
+    // --- formatForRow ---------------------------------------------------------------------
+
     @Test
-    void flattenForRow_singleLine_returnsAsIs() {
-        assertThat(AgentMcpLogPanel.flattenForRow("hello")).isEqualTo("hello");
+    void formatForRow_singleLine_returnsAsIs() {
+        assertThat(AgentMcpLogPanel.formatForRow("hello")).isEqualTo("hello");
     }
 
     @Test
-    void flattenForRow_emptyString_returnsEmpty() {
-        assertThat(AgentMcpLogPanel.flattenForRow("")).isEmpty();
+    void formatForRow_emptyString_returnsEmpty() {
+        assertThat(AgentMcpLogPanel.formatForRow("")).isEmpty();
     }
 
     @Test
-    void flattenForRow_trailingNewlineOnly_isTreatedAsSingleLine() {
+    void formatForRow_trailingNewlineOnly_isTreatedAsSingleLine() {
         // RunCommandToolExecutor appends a trailing '\n' to each line, so a single-line result
         // ends with '\n'. That trailing empty segment must not be reported as a second line.
-        assertThat(AgentMcpLogPanel.flattenForRow("output\n")).isEqualTo("output");
+        assertThat(AgentMcpLogPanel.formatForRow("output\n")).isEqualTo("output");
     }
 
     @Test
-    void flattenForRow_multiLine_usesVisibleSeparatorAndLineCount() {
+    void formatForRow_multiLine_keepsRealNewlinesNoMarker() {
         String input = "line1\nline2\nline3";
-        String preview = AgentMcpLogPanel.flattenForRow(input);
-        assertThat(preview).contains("line1");
-        assertThat(preview).contains("line2");
-        assertThat(preview).contains("line3");
-        assertThat(preview).contains("\u23ce"); // visible return separator
-        assertThat(preview).endsWith("(3 lines)");
+        String preview = AgentMcpLogPanel.formatForRow(input);
+        assertThat(preview).isEqualTo("line1\nline2\nline3");
+        assertThat(preview).doesNotContain("⏎");
     }
 
     @Test
-    void flattenForRow_realWorldRunCommandOutput_showsBothStderrAndStdout() {
-        // Reproduces the bug pattern from #1027 follow-up: the agent log row only showed
-        // the sdkman stderr noise and the user thought the JAVA_HOME value was missing.
-        // With the new formatting, both lines are visible plus a "(2 lines)" marker.
+    void formatForRow_realWorldRunCommandOutput_showsBothStderrAndStdout() {
+        // Reproduces the bug pattern from #1027 follow-up: the agent log row used to collapse
+        // both lines into one with a ⏎ marker. With multi-line rendering both lines appear on
+        // their own line in the panel.
         String input = "/Users/x/.sdkman/path-helpers.sh: line 61: ${name^^}: bad substitution\n"
                 + "/Library/Java/jdk21\n";
-        String preview = AgentMcpLogPanel.flattenForRow(input);
-        assertThat(preview).contains("bad substitution");
-        assertThat(preview).contains("/Library/Java/jdk21");
-        assertThat(preview).endsWith("(2 lines)");
+        String preview = AgentMcpLogPanel.formatForRow(input);
+        assertThat(preview.split("\n")).containsExactly(
+                "/Users/x/.sdkman/path-helpers.sh: line 61: ${name^^}: bad substitution",
+                "/Library/Java/jdk21"
+        );
     }
 
     @Test
-    void flattenForRow_longSingleLine_isTruncatedWithEllipsis() {
+    void formatForRow_longSingleLine_isTruncatedWithEllipsis() {
         String input = "x".repeat(800);
-        String preview = AgentMcpLogPanel.flattenForRow(input, 100);
+        String preview = AgentMcpLogPanel.formatForRow(input, 100, 10);
         assertThat(preview).hasSize(101); // 100 chars + ellipsis
-        assertThat(preview).endsWith("\u2026");
+        assertThat(preview).endsWith("…");
     }
 
     @Test
-    void flattenForRow_longMultiLine_truncatesAndKeepsLineCount() {
-        String input = "a".repeat(600) + "\n" + "b".repeat(600);
-        String preview = AgentMcpLogPanel.flattenForRow(input, 50);
-        assertThat(preview).startsWith("a");
-        assertThat(preview).contains("\u2026");
-        assertThat(preview).endsWith("(2 lines)");
+    void formatForRow_exceedingMaxLines_isCappedWithMoreLinesHint() {
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < 25; i++) sb.append("line").append(i).append('\n');
+        String preview = AgentMcpLogPanel.formatForRow(sb.toString(), 500, 10);
+        String[] lines = preview.split("\n");
+        assertThat(lines).hasSize(11); // 10 content lines + 1 hint line
+        assertThat(lines[0]).isEqualTo("line0");
+        assertThat(lines[9]).isEqualTo("line9");
+        assertThat(lines[10]).isEqualTo("… (15 more lines)");
     }
 
     @Test
-    void flattenForRow_crlfLineEndings_areNormalised() {
+    void formatForRow_crlfLineEndings_areNormalised() {
         String input = "first\r\nsecond\r\nthird";
-        String preview = AgentMcpLogPanel.flattenForRow(input);
-        assertThat(preview).contains("first");
-        assertThat(preview).contains("second");
-        assertThat(preview).contains("third");
-        assertThat(preview).endsWith("(3 lines)");
+        String preview = AgentMcpLogPanel.formatForRow(input);
+        assertThat(preview).isEqualTo("first\nsecond\nthird");
     }
+
+    // --- formatForClipboard ---------------------------------------------------------------
+
+    @Test
+    void formatForClipboard_singleLine_returnsAsIs() {
+        assertThat(AgentMcpLogPanel.formatForClipboard("hello")).isEqualTo("hello");
+    }
+
+    @Test
+    void formatForClipboard_emptyString_returnsEmpty() {
+        assertThat(AgentMcpLogPanel.formatForClipboard("")).isEmpty();
+    }
+
+    @Test
+    void formatForClipboard_trailingNewlineOnly_isTreatedAsSingleLine() {
+        assertThat(AgentMcpLogPanel.formatForClipboard("output\n")).isEqualTo("output");
+    }
+
+    @Test
+    void formatForClipboard_multiLine_indentsUnderHeaderWithRealNewlines() {
+        // Multi-line content is moved onto subsequent indented lines so the entry header
+        // (timestamp, tool name) stays on its own line and the body is unambiguously attached.
+        String input = "UID PID CMD\n0 1 launchd\n0 2 logd";
+        String formatted = AgentMcpLogPanel.formatForClipboard(input);
+        assertThat(formatted).isEqualTo(
+                "\n    UID PID CMD" +
+                "\n    0 1 launchd" +
+                "\n    0 2 logd"
+        );
+    }
+
+    @Test
+    void formatForClipboard_doesNotTruncateVeryLongOutput() {
+        String input = "x".repeat(20_000);
+        assertThat(AgentMcpLogPanel.formatForClipboard(input)).isEqualTo("x".repeat(20_000));
+    }
+
+    @Test
+    void formatForClipboard_crlfLineEndings_areNormalised() {
+        String input = "first\r\nsecond";
+        assertThat(AgentMcpLogPanel.formatForClipboard(input)).isEqualTo("\n    first\n    second");
+    }
+
+    // --- toHtmlTooltip --------------------------------------------------------------------
 
     @Test
     void toHtmlTooltip_wrapsInHtmlAndConvertsNewlines() {
@@ -106,21 +153,23 @@ class AgentMcpLogPanelFormatTest {
     }
 
     @Test
-    void flattenForRow_doubleTrailingNewline_countsAsOneLine() {
-        // "a\n\n" should be treated as a single-line result, not (2 lines).
-        String preview = AgentMcpLogPanel.flattenForRow("a\n\n");
+    void formatForRow_doubleTrailingNewline_countsAsOneLine() {
+        // "a\n\n" should collapse to a single-line result, not show a "(N more lines)" hint.
+        String preview = AgentMcpLogPanel.formatForRow("a\n\n");
         assertThat(preview).isEqualTo("a");
-        assertThat(preview).doesNotContain("lines");
+        assertThat(preview).doesNotContain("more lines");
     }
 
     @Test
-    void flattenForRow_manyTrailingNewlines_countsAsOneLine() {
-        String preview = AgentMcpLogPanel.flattenForRow("only-real-line\n\n\n\n");
+    void formatForRow_manyTrailingNewlines_countsAsOneLine() {
+        String preview = AgentMcpLogPanel.formatForRow("only-real-line\n\n\n\n");
         assertThat(preview).isEqualTo("only-real-line");
     }
 
+    // --- formatAgentActivityMessage -------------------------------------------------------
+
     @Test
-    void formatAgentActivity_toolErrorWithMultiLineResult_isFlattened() {
+    void formatAgentActivityMessage_toolErrorWithMultiLineResult_rendersAcrossLines() {
         ActivityMessage err = ActivityMessage.builder()
                 .source(ActivitySource.AGENT)
                 .agentType(AgentType.TOOL_ERROR)
@@ -129,17 +178,18 @@ class AgentMcpLogPanelFormatTest {
                 .callNumber(2)
                 .maxCalls(25)
                 .build();
-        String row = AgentMcpLogPanel.formatAgentActivityMessage(err);
+        String row = AgentMcpLogPanel.formatAgentActivityMessage(err, AgentMcpLogPanel::formatForRow);
         assertThat(row).startsWith("[2/25] \u2716 run_command \u2192 ");
-        assertThat(row).contains("Error: failed to spawn process");
-        assertThat(row).contains("stacktrace line 1");
-        assertThat(row).contains("stacktrace line 2");
-        assertThat(row).contains("\u23ce"); // visible newline separator
-        assertThat(row).endsWith("(3 lines)");
+        assertThat(row.split("\n")).containsExactly(
+                "[2/25] \u2716 run_command \u2192 Error: failed to spawn process",
+                "stacktrace line 1",
+                "stacktrace line 2"
+        );
+        assertThat(row).doesNotContain("\u23ce");
     }
 
     @Test
-    void formatAgentActivity_subAgentErrorWithMultiLineResult_isFlattened() {
+    void formatAgentActivityMessage_subAgentErrorWithMultiLineResult_rendersAcrossLines() {
         ActivityMessage err = ActivityMessage.builder()
                 .source(ActivitySource.AGENT)
                 .agentType(AgentType.SUB_AGENT_ERROR)
@@ -148,10 +198,30 @@ class AgentMcpLogPanelFormatTest {
                 .callNumber(1)
                 .maxCalls(25)
                 .build();
-        String row = AgentMcpLogPanel.formatAgentActivityMessage(err);
+        String row = AgentMcpLogPanel.formatAgentActivityMessage(err, AgentMcpLogPanel::formatForRow);
         assertThat(row).contains("Sub-agent error: explorer-1");
-        assertThat(row).contains("\u23ce");
-        assertThat(row).endsWith("(2 lines)");
+        assertThat(row.split("\n")).containsExactly(
+                "[1/25] [explorer-1] \u2716 Sub-agent error: explorer-1 \u2192 first error line",
+                "second error line"
+        );
+    }
+
+    @Test
+    void formatAgentActivityMessage_toolErrorWithMultiLineResult_clipboardIndentsBody() {
+        ActivityMessage err = ActivityMessage.builder()
+                .source(ActivitySource.AGENT)
+                .agentType(AgentType.TOOL_ERROR)
+                .toolName("run_command")
+                .result("Error: failed to spawn process\nstacktrace line 1")
+                .callNumber(2)
+                .maxCalls(25)
+                .build();
+        String row = AgentMcpLogPanel.formatAgentActivityMessage(err, AgentMcpLogPanel::formatForClipboard);
+        assertThat(row).isEqualTo(
+                "[2/25] \u2716 run_command \u2192 " +
+                "\n    Error: failed to spawn process" +
+                "\n    stacktrace line 1"
+        );
     }
 
     @Test

--- a/src/test/java/com/devoxx/genie/ui/panel/log/AgentMcpLogPanelFormatTest.java
+++ b/src/test/java/com/devoxx/genie/ui/panel/log/AgentMcpLogPanelFormatTest.java
@@ -1,0 +1,104 @@
+package com.devoxx.genie.ui.panel.log;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests for the inline-preview and tooltip helpers used by {@link AgentMcpLogPanel}.
+ * These guard the contract that the list-row preview and the hover tooltip surface enough
+ * information about a multi-line tool result for the user to recognise when the full output
+ * needs to be inspected (instead of silently appearing as a single error line).
+ */
+class AgentMcpLogPanelFormatTest {
+
+    @Test
+    void flattenForRow_singleLine_returnsAsIs() {
+        assertThat(AgentMcpLogPanel.flattenForRow("hello")).isEqualTo("hello");
+    }
+
+    @Test
+    void flattenForRow_emptyString_returnsEmpty() {
+        assertThat(AgentMcpLogPanel.flattenForRow("")).isEmpty();
+    }
+
+    @Test
+    void flattenForRow_trailingNewlineOnly_isTreatedAsSingleLine() {
+        // RunCommandToolExecutor appends a trailing '\n' to each line, so a single-line result
+        // ends with '\n'. That trailing empty segment must not be reported as a second line.
+        assertThat(AgentMcpLogPanel.flattenForRow("output\n")).isEqualTo("output");
+    }
+
+    @Test
+    void flattenForRow_multiLine_usesVisibleSeparatorAndLineCount() {
+        String input = "line1\nline2\nline3";
+        String preview = AgentMcpLogPanel.flattenForRow(input);
+        assertThat(preview).contains("line1");
+        assertThat(preview).contains("line2");
+        assertThat(preview).contains("line3");
+        assertThat(preview).contains("\u23ce"); // visible return separator
+        assertThat(preview).endsWith("(3 lines)");
+    }
+
+    @Test
+    void flattenForRow_realWorldRunCommandOutput_showsBothStderrAndStdout() {
+        // Reproduces the bug pattern from #1027 follow-up: the agent log row only showed
+        // the sdkman stderr noise and the user thought the JAVA_HOME value was missing.
+        // With the new formatting, both lines are visible plus a "(2 lines)" marker.
+        String input = "/Users/x/.sdkman/path-helpers.sh: line 61: ${name^^}: bad substitution\n"
+                + "/Library/Java/jdk21\n";
+        String preview = AgentMcpLogPanel.flattenForRow(input);
+        assertThat(preview).contains("bad substitution");
+        assertThat(preview).contains("/Library/Java/jdk21");
+        assertThat(preview).endsWith("(2 lines)");
+    }
+
+    @Test
+    void flattenForRow_longSingleLine_isTruncatedWithEllipsis() {
+        String input = "x".repeat(800);
+        String preview = AgentMcpLogPanel.flattenForRow(input, 100);
+        assertThat(preview).hasSize(101); // 100 chars + ellipsis
+        assertThat(preview).endsWith("\u2026");
+    }
+
+    @Test
+    void flattenForRow_longMultiLine_truncatesAndKeepsLineCount() {
+        String input = "a".repeat(600) + "\n" + "b".repeat(600);
+        String preview = AgentMcpLogPanel.flattenForRow(input, 50);
+        assertThat(preview).startsWith("a");
+        assertThat(preview).contains("\u2026");
+        assertThat(preview).endsWith("(2 lines)");
+    }
+
+    @Test
+    void flattenForRow_crlfLineEndings_areNormalised() {
+        String input = "first\r\nsecond\r\nthird";
+        String preview = AgentMcpLogPanel.flattenForRow(input);
+        assertThat(preview).contains("first");
+        assertThat(preview).contains("second");
+        assertThat(preview).contains("third");
+        assertThat(preview).endsWith("(3 lines)");
+    }
+
+    @Test
+    void toHtmlTooltip_wrapsInHtmlAndConvertsNewlines() {
+        String tooltip = AgentMcpLogPanel.toHtmlTooltip("alpha\nbeta");
+        assertThat(tooltip).startsWith("<html>");
+        assertThat(tooltip).endsWith("</html>");
+        assertThat(tooltip).contains("alpha<br>beta");
+    }
+
+    @Test
+    void toHtmlTooltip_escapesHtmlSpecials() {
+        String tooltip = AgentMcpLogPanel.toHtmlTooltip("<script>alert(\"x\")</script> & done");
+        assertThat(tooltip).doesNotContain("<script>");
+        assertThat(tooltip).contains("&lt;script&gt;");
+        assertThat(tooltip).contains("&amp; done");
+    }
+
+    @Test
+    void toHtmlTooltip_truncatesVeryLongContentWithHint() {
+        String tooltip = AgentMcpLogPanel.toHtmlTooltip("x".repeat(20_000), 100);
+        assertThat(tooltip).contains("double-click to view full content");
+    }
+}

--- a/src/test/java/com/devoxx/genie/ui/panel/log/AgentMcpLogPanelFormatTest.java
+++ b/src/test/java/com/devoxx/genie/ui/panel/log/AgentMcpLogPanelFormatTest.java
@@ -1,5 +1,8 @@
 package com.devoxx.genie.ui.panel.log;
 
+import com.devoxx.genie.model.activity.ActivityMessage;
+import com.devoxx.genie.model.activity.ActivitySource;
+import com.devoxx.genie.model.agent.AgentType;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -100,5 +103,63 @@ class AgentMcpLogPanelFormatTest {
     void toHtmlTooltip_truncatesVeryLongContentWithHint() {
         String tooltip = AgentMcpLogPanel.toHtmlTooltip("x".repeat(20_000), 100);
         assertThat(tooltip).contains("double-click to view full content");
+    }
+
+    @Test
+    void flattenForRow_doubleTrailingNewline_countsAsOneLine() {
+        // "a\n\n" should be treated as a single-line result, not (2 lines).
+        String preview = AgentMcpLogPanel.flattenForRow("a\n\n");
+        assertThat(preview).isEqualTo("a");
+        assertThat(preview).doesNotContain("lines");
+    }
+
+    @Test
+    void flattenForRow_manyTrailingNewlines_countsAsOneLine() {
+        String preview = AgentMcpLogPanel.flattenForRow("only-real-line\n\n\n\n");
+        assertThat(preview).isEqualTo("only-real-line");
+    }
+
+    @Test
+    void formatAgentActivity_toolErrorWithMultiLineResult_isFlattened() {
+        ActivityMessage err = ActivityMessage.builder()
+                .source(ActivitySource.AGENT)
+                .agentType(AgentType.TOOL_ERROR)
+                .toolName("run_command")
+                .result("Error: failed to spawn process\nstacktrace line 1\nstacktrace line 2")
+                .callNumber(2)
+                .maxCalls(25)
+                .build();
+        String row = AgentMcpLogPanel.formatAgentActivityMessage(err);
+        assertThat(row).startsWith("[2/25] \u2716 run_command \u2192 ");
+        assertThat(row).contains("Error: failed to spawn process");
+        assertThat(row).contains("stacktrace line 1");
+        assertThat(row).contains("stacktrace line 2");
+        assertThat(row).contains("\u23ce"); // visible newline separator
+        assertThat(row).endsWith("(3 lines)");
+    }
+
+    @Test
+    void formatAgentActivity_subAgentErrorWithMultiLineResult_isFlattened() {
+        ActivityMessage err = ActivityMessage.builder()
+                .source(ActivitySource.AGENT)
+                .agentType(AgentType.SUB_AGENT_ERROR)
+                .subAgentId("explorer-1")
+                .result("first error line\nsecond error line")
+                .callNumber(1)
+                .maxCalls(25)
+                .build();
+        String row = AgentMcpLogPanel.formatAgentActivityMessage(err);
+        assertThat(row).contains("Sub-agent error: explorer-1");
+        assertThat(row).contains("\u23ce");
+        assertThat(row).endsWith("(2 lines)");
+    }
+
+    @Test
+    void toHtmlTooltip_nullGuardInRenderer() {
+        // Mirrors the cell-renderer guard: pass null through the same code path the renderer
+        // uses, ensuring no NPE. The renderer is: fc != null ? toHtmlTooltip(fc) : null
+        String fullContent = null;
+        String tooltip = fullContent != null ? AgentMcpLogPanel.toHtmlTooltip(fullContent) : null;
+        assertThat(tooltip).isNull();
     }
 }


### PR DESCRIPTION
## Problem
When a `run_command` tool result spans multiple lines, the agent log row only appeared to show one line (the first one). Example failure mode: with an sdkman init that errors out, users saw only the stderr noise and assumed the actual stdout (e.g. the `$JAVA_HOME` value) was being dropped.

Root cause: `formatToolResponse` joined newlines with plain spaces. The full multi-line content was preserved in `fullContent` (visible on double-click), but the list row gave no indication that more lines existed, and the tooltip just echoed the same single-line preview.

## Fix
- Inline preview now uses a visible `⏎` separator between lines, caps total length to 500 chars with `…`, and appends a `(N lines)` marker when the result is multi-line. Trailing newlines (typical of `RunCommandToolExecutor` output) are not counted as a phantom extra line.
- Cell tooltip is now HTML-formatted (`<br>` instead of space), so hovering shows the result with line breaks preserved. Escapes `&`, `<`, `>` to avoid HTML injection. Capped at 8000 chars with a 'double-click for full content' hint beyond that.
- Same treatment applied to `▶ tool ← arguments` and `💬 intermediate response` rows.

## Tests
Added `AgentMcpLogPanelFormatTest` (11 cases) covering single-line, empty, trailing-\n, multi-line with separator and line-count, real-world sdkman-style output, length truncation, CRLF normalisation, HTML wrapping and escaping, and tooltip truncation. All pass.