### PR TITLE
docs(backlog): add Phase 4 RAG follow-up tasks 217-219

### DIFF
--- a/backlog/tasks/task-212 - Make-the-RAG-embedding-model-configurable.md
+++ b/backlog/tasks/task-212 - Make-the-RAG-embedding-model-configurable.md
@@ -1,0 +1,70 @@
+---
+id: TASK-212
+title: Make the RAG embedding model configurable (default to a code-tuned model)
+status: To Do
+assignee: []
+created_date: '2026-05-26 18:00'
+updated_date: '2026-05-26 18:00'
+labels:
+  - enhancement
+  - RAG
+  - settings
+dependencies: []
+references:
+  - src/main/java/com/devoxx/genie/service/chromadb/ChromaEmbeddingService.java
+  - src/main/java/com/devoxx/genie/service/rag/IndexerConstants.java
+  - src/main/java/com/devoxx/genie/service/rag/ProjectIndexerService.java
+  - src/main/java/com/devoxx/genie/service/rag/manifest/IndexManifest.java
+  - src/main/java/com/devoxx/genie/service/rag/validator/NomicEmbedTextValidator.java
+  - src/main/java/com/devoxx/genie/ui/settings/DevoxxGenieStateService.java
+  - src/main/java/com/devoxx/genie/ui/settings/rag/RAGSettingsComponent.java
+  - 'https://ollama.com/library/nomic-embed-text'
+  - 'https://huggingface.co/nomic-ai/nomic-embed-code'
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+The embedding model is hardcoded to `nomic-embed-text` in `ChromaEmbeddingService.EMBEDDING_MODEL_NAME`. That model is a strong generic embedder, but code-tuned alternatives (e.g. `nomic-embed-code`, `jina-embeddings-v2-base-code`, `bge-code-v1`) consistently outperform it on code retrieval benchmarks. Power users on capable hardware should be able to opt in.
+
+This task adds a single setting — the Ollama model name used for RAG embeddings — and propagates it through the indexing, retrieval, and validator paths. It must coexist cleanly with the v2 schema written by the post-Phase-1 indexer: changing the model invalidates every existing embedding, so the change must trigger (or prompt for) a full re-index.
+
+**Investigation areas:**
+- **Settings UI.** Add a "RAG embedding model" text field (or combo with curated suggestions) to `RAGSettingsComponent`, persisted on `DevoxxGenieStateService`. Default = `nomic-embed-text` so existing users see no behavior change.
+- **Schema-version coupling.** Different models produce different-dimensional, incompatible embeddings. Either bump `IndexerConstants.CURRENT_EMBEDDING_SCHEMA_VERSION` whenever the model changes (e.g. compose it with the model name), or record the model name on every manifest entry and refuse to use stored chunks that were produced by a different model. The manifest already carries `schemaVersion`; the cheapest fix is to make the "schema" include the model name.
+- **Validator update.** `NomicEmbedTextValidator` currently hardcodes the prefix `nomic-embed-text`. Generalize it to check whichever model the user configured, and update its messaging and the "pull this model" action (`ValidationActionType.PULL_NOMIC`) accordingly. Consider renaming the validator to something model-agnostic.
+- **Re-index UX.** On model change: show a notification telling the user the existing index is now stale and offer a one-click "Re-index now" action. Do NOT silently start a multi-minute embed job.
+- **Documentation.** Mention 1-2 recommended code-tuned models in the docusaurus RAG page and link to their Ollama tags.
+
+This is a small but high-leverage knob: it unlocks a quality dimension the Phase 1+2 work cannot reach on its own.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 A "RAG embedding model" setting (Ollama model name) is exposed in the RAG settings panel and persisted via `DevoxxGenieStateService`; default is `nomic-embed-text` so existing installs see no change
+- [ ] #2 `ChromaEmbeddingService.getEmbeddingModel()` reads the configured model name (no more hardcoded constant); the cached model is rebuilt when the model name changes, mirroring the existing URL-change behaviour
+- [ ] #3 The embedding schema is bound to the model so that mixing models is impossible: either `CURRENT_EMBEDDING_SCHEMA_VERSION` includes the model name, or every manifest entry stores the model name and `isCurrent` rejects entries written by a different model
+- [ ] #4 Changing the model in settings notifies the user that the existing index is stale and offers a one-click "Re-index now" action; no automatic re-index happens silently
+- [ ] #5 The Ollama model validator is generalized to verify whatever model the user configured (not only the `nomic-embed-text` prefix) and its action/messaging reflects the configured name
+- [ ] #6 Unit tests cover: settings round-trip, the model-change-invalidates-manifest behaviour, and the validator working for a non-`nomic` model name
+- [ ] #7 The docusaurus RAG page mentions at least one recommended code-tuned alternative and how to pull it via Ollama
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Background from the Phase-1/2 RAG review: the embedding model was identified as a low-effort, high-yield quality knob. Phase 1 fixed correctness (embed content not paths) and Phase 2 added caching/batching/parallelism/manifest, but the embedding model itself stayed pinned. Code-tuned models on the same Ollama runtime tend to lift retrieval recall meaningfully on code queries.
+
+Implementation sequence suggestion:
+1. Add `getEmbeddingModelName()` / `setEmbeddingModelName()` to `DevoxxGenieStateService` (default `"nomic-embed-text"`).
+2. Replace `ChromaEmbeddingService.EMBEDDING_MODEL_NAME` reads with the state lookup; keep the cache invalidation that already watches URL changes and add the model name to its key.
+3. Decide schema-binding strategy. Two equivalent options:
+   - Concatenate model name into the schema constant: `CURRENT_EMBEDDING_SCHEMA_VERSION = "v2:" + modelName` (computed at access time).
+   - Add `embeddingModel` to `IndexManifestEntry` and reject mismatches in `isCurrent`.
+   The latter is more explicit and shows up in the JSON sidecar — preferred.
+4. Wire a settings-change listener that fires the "index stale" notification with a Re-index action.
+5. Generalize the Nomic validator (rename to `OllamaEmbeddingModelValidator`?). Keep `PULL_NOMIC` action type if other code already references it, or rename the enum value.
+
+Out of scope: cloud-hosted embedders (OpenAI / Voyage / etc.) — Phase 4 if there's demand.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-213 - Add-BM25-hybrid-retrieval-with-RRF-merge.md
+++ b/backlog/tasks/task-213 - Add-BM25-hybrid-retrieval-with-RRF-merge.md
@@ -1,0 +1,68 @@
+---
+id: TASK-213
+title: Add BM25 hybrid retrieval and RRF-merge with vector results
+status: To Do
+assignee: []
+created_date: '2026-05-26 18:00'
+updated_date: '2026-05-26 18:00'
+labels:
+  - enhancement
+  - RAG
+  - retrieval-quality
+dependencies: []
+references:
+  - src/main/java/com/devoxx/genie/service/rag/SemanticSearchService.java
+  - src/main/java/com/devoxx/genie/service/rag/ProjectIndexerService.java
+  - src/main/java/com/devoxx/genie/service/rag/SearchResult.java
+  - src/main/java/com/devoxx/genie/service/rag/manifest/IndexManifest.java
+  - src/main/java/com/devoxx/genie/service/MessageCreationService.java
+  - 'https://en.wikipedia.org/wiki/Reciprocal_rank_fusion'
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Pure cosine similarity over a single small embedding model is the weakest retrieval setup for code. Identifiers, symbol names, exact substrings — all carry strong semantic weight that small embedders frequently miss. A user asking "where is `AuthService` defined?" can get back chunks with semantically similar themes but the wrong class entirely, while a trivial keyword match would have nailed it.
+
+This task adds a parallel **BM25** keyword retriever over the same chunks the vector store holds, runs it alongside the existing vector retriever, and merges the two ranked lists using **Reciprocal Rank Fusion** (RRF). RRF requires no tuning — it just blends ranks — and consistently outperforms either retriever alone on code corpora.
+
+**Investigation areas:**
+- **BM25 index location.** Two options: (a) compute BM25 on the fly over chunks loaded from Chroma at query time — simple but slow on large projects; (b) maintain an inverted index on disk alongside the existing manifest. Recommended: (b), keyed by chunk id (file path + chunk index). Lucene is overkill and a heavy dep; a small in-process BM25 implementation (~200 lines) is the right size and the project already has the chunks in memory during indexing.
+- **What to tokenize.** Code-aware tokenization beats whitespace splitting: split on case transitions (camelCase → `camel Case`), on `_` and `-`, and lowercase. Treat numeric tokens as low-weight. Optionally remove very common stop tokens.
+- **Update hooks.** The BM25 index must be updated by the same code paths that touch the vector store: `ProjectIndexerService.indexFile`, `reindexFiles`, `removeFiles`. The watcher already routes through those, so no listener changes needed.
+- **Persistence.** BM25 inverted index → sidecar JSON / binary file in the plugin data dir, peer to the manifest. Loaded once per project. Use the manifest's `flush` discipline so a crash doesn't corrupt state.
+- **Merge math.** RRF score for a chunk = `sum(1 / (k + rank_i))` over each retriever's rank lists, with `k = 60` (Cormack et al. default). Final top-K is the configured `IndexerMaxResults`. Document this; do not expose `k` as a setting (unnecessary knob).
+- **Toggle.** Add a "Hybrid retrieval (BM25 + vector)" toggle in RAG settings, default OFF for the first release so users can opt in. Once we have confidence, flip the default ON.
+- **Logging.** The "Show RAG Only" log entries (task-completed in Phase 2) should annotate each hit with which retriever (or both) surfaced it, so debugging "why this chunk?" is tractable.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 A persistent BM25 inverted index is maintained per project, updated by the same code paths that mutate the vector store (`indexFile` / `reindexFiles` / `removeFiles`) so the two stay in sync
+- [ ] #2 BM25 tokenization splits camelCase / snake_case / kebab-case, lowercases, and demotes pure-numeric tokens — measurably stronger on code identifiers than a whitespace split
+- [ ] #3 `SemanticSearchService.search` runs both retrievers in parallel and returns an RRF-merged ranked list (k=60, configured `IndexerMaxResults` returned); when the BM25 toggle is OFF, behaviour is unchanged from current
+- [ ] #4 The "Show RAG Only" log records, per hit, which retrievers contributed (`vector` / `bm25` / `both`) so chunk provenance is debuggable
+- [ ] #5 A "Hybrid retrieval (BM25 + vector)" toggle exists in RAG settings; default OFF; persisted via `DevoxxGenieStateService`
+- [ ] #6 BM25 index is loaded lazily on first search and persisted via a flush model peer to `IndexManifest` (atomic write); corruption is detected on load and triggers a one-time rebuild rather than a crash
+- [ ] #7 Unit tests cover: tokenizer (camelCase/_/-/digit handling), RRF merge correctness on synthetic ranked lists, BM25 update on file add/edit/delete, and end-to-end "exact identifier query returns the right chunk even when vector retrieval misses"
+- [ ] #8 Indexing throughput regression is acceptable: BM25 update cost is dominated by reads, so total indexing time stays within +15% of pre-BM25 measurements on a representative project
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Background from the Phase-1/2 RAG review: the review explicitly called out hybrid retrieval as one of two cheapest, highest-yield additions for code (the other is task-214 reranking). Vector-only is particularly weak for symbol queries — embedders compress identifier semantics into the same neighbourhood as conceptually related code, often missing the exact symbol the user typed.
+
+Recommended sub-design:
+- `Bm25Index` class: `Map<term, PostingsList>`; `PostingsList` = list of `(chunkId, termFrequency)`. Track document length per chunk and average length for the BM25 score formula.
+- `Bm25Tokenizer`: regex-driven; pure function.
+- `Bm25IndexService` (project-level @Service): owns one `Bm25Index` per project, like `IndexManifestService`.
+- Score formula: `score(D, Q) = sum_t IDF(t) * tf(t,D)*(k1+1) / (tf(t,D) + k1*(1 - b + b*|D|/avgDL))` with `k1=1.2`, `b=0.75`.
+- Chunk id format: `"{fileAbsPath}#{chunkIndex}"`.
+- Storage format: gzipped JSON (or simple binary if size matters). Keep `embeddingSchemaVersion` so a schema bump invalidates BM25 too.
+
+Open question to resolve in implementation: should BM25 update be synchronous (inside `storeSegments`) or async (after the embed batch returns)? Synchronous is simpler and won't outpace the vector store since BM25 is much cheaper.
+
+Out of scope: cross-encoder reranking (separate task 214), AST-aware chunking (task 215), Lucene/Tantivy bindings (over-engineering for a single corpus this size).
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-214 - Add-a-cross-encoder-reranker-stage.md
+++ b/backlog/tasks/task-214 - Add-a-cross-encoder-reranker-stage.md
@@ -1,0 +1,69 @@
+---
+id: TASK-214
+title: Add a cross-encoder reranker stage after retrieval
+status: To Do
+assignee: []
+created_date: '2026-05-26 18:00'
+updated_date: '2026-05-26 18:00'
+labels:
+  - enhancement
+  - RAG
+  - retrieval-quality
+dependencies:
+  - TASK-213
+references:
+  - src/main/java/com/devoxx/genie/service/rag/SemanticSearchService.java
+  - src/main/java/com/devoxx/genie/service/rag/SearchResult.java
+  - src/main/java/com/devoxx/genie/service/chromadb/ChromaEmbeddingService.java
+  - src/main/java/com/devoxx/genie/service/MessageCreationService.java
+  - 'https://huggingface.co/BAAI/bge-reranker-v2-m3'
+  - 'https://ollama.com/library/bge-reranker'
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Bi-encoder (vector) retrieval is fast but coarse: it compares query and chunk in independently-computed embedding spaces, missing fine-grained relevance signals. A **cross-encoder reranker** runs the query and each candidate chunk *together* through a small transformer and produces a scalar relevance score — much more accurate, but too slow to apply at the corpus level. The standard pattern is to retrieve top-K (e.g. 30) cheaply and rerank that shortlist down to top-N (e.g. 5).
+
+Reranking alone — without changing anything else — frequently doubles answer quality on RAG benchmarks. It's especially worth it once we have BM25 (task-213) feeding more candidates into the reranker.
+
+**Investigation areas:**
+- **Where the reranker lives.** Two options: (a) Ollama-hosted reranker model (e.g. `bge-reranker`) — keeps the stack one-runtime, slow on CPU; (b) cloud reranker (Cohere Rerank, Voyage AI rerank) — fast but adds an API key and an external dependency. Recommended: support (a) as the default to stay local-first, and (b) as an opt-in via existing API key plumbing. Phase 4 if there's demand for hosted.
+- **Shortlist size.** Retrieval should fetch a wider net than today's top-K. Suggested: retrieval top-K = 30 (configurable via existing `IndexerMaxResults` setting, with a separate "reranker shortlist size" knob), reranked to the user-configured `IndexerMaxResults` for the prompt. Document the cost tradeoff (30 reranker calls per query).
+- **Latency budget.** Local CPU reranking can take 1-3s on 30 candidates with a base model; that's added to every prompt when RAG is active. The "skip RAG on short follow-ups" feature (task-completed in Phase 2) limits the damage but it's still meaningful. Add a "Reranker timeout" setting (e.g. 2000ms) — if it expires, fall back to the unranked retrieval results and log a warning to the RAG log panel.
+- **Toggle and default.** Off by default for the first release — opt-in via a "Rerank results" toggle in RAG settings, with the model name configurable. Once stable, consider enabling by default for the cloud reranker path (where latency is sub-second).
+- **Provenance in logs.** The "Show RAG Only" log already records vector hits; extend it with each chunk's pre-rerank rank and reranker score so debugging "why did the reranker drop X?" is possible.
+
+This task depends on task-213 (BM25) because reranking shines most when the candidate pool is diverse — a vector-only pool tends to be redundant near the embedding ridge, so reranking 30 vector-only candidates returns diminishing returns. Doing 213 first means 214's evaluation is realistic.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 An optional reranker stage runs after retrieval (vector + optional BM25 via RRF) and reorders the shortlist before it reaches `MessageCreationService`; the prompt receives the reranker's top-N (configured `IndexerMaxResults`)
+- [ ] #2 Local-first reranking via an Ollama-hosted reranker model is supported and is the default backend; the model name is a setting (default e.g. `bge-reranker` once available, or the chosen equivalent)
+- [ ] #3 A separate "Reranker shortlist size" setting controls how many candidates retrieval returns to the reranker (default 30); the existing `IndexerMaxResults` continues to control how many reach the prompt
+- [ ] #4 A "Reranker timeout (ms)" setting (default 2000) bounds the reranker call; on timeout, the original retrieval order is used and a `WARN`-level RAG log entry records the fallback
+- [ ] #5 A "Rerank results" toggle (default OFF) gates the feature in RAG settings; persisted via `DevoxxGenieStateService`
+- [ ] #6 The "Show RAG Only" log records, per final hit, its pre-rerank rank and the reranker's score so chunk-survival/elimination is debuggable
+- [ ] #7 A new validator (or extension of the existing chain) checks the reranker model is available in Ollama; failure surfaces in the RAG status with a pull action, matching the existing `nomic-embed-text` pattern
+- [ ] #8 Unit tests mock the reranker call and cover: reordering happens, timeout falls back cleanly, top-N truncation is correct, OFF toggle is a no-op
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Background from the Phase-1/2 RAG review: reranking was called out as one of the two cheapest, highest-yield retrieval improvements (the other being BM25 hybrid retrieval). Reranking can double answer quality on its own; combined with BM25 it's compounding.
+
+Suggested layering:
+- `Reranker` interface: `List<SearchResult> rerank(String query, List<SearchResult> candidates, int topN, long timeoutMs)`.
+- `OllamaReranker` impl: POSTs query+candidate pairs to Ollama's embeddings or chat completion endpoint depending on what the chosen reranker model supports. Run in parallel within a small bounded executor (like the Phase 2 indexer parallelism).
+- `NoOpReranker` for tests / when the toggle is off.
+- Plug into `SemanticSearchService.search` as the last step before returning.
+
+Open question: as of writing, Ollama's official model library may not host a first-class reranker. If not, the practical first implementation may need to use a chat-completion reranker prompt ("Score this code chunk for relevance to the query") which is slower but works with any chat model the user already has. Document this in the task when implementing.
+
+Out of scope: cloud reranker integrations (Phase 4 if demand), per-language reranker selection.
+
+Depends on task-213 because the reranker's value depends on having a diverse candidate pool, which the BM25 retriever ensures.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-215 - AST-aware-code-chunking-via-language-analyzers.md
+++ b/backlog/tasks/task-215 - AST-aware-code-chunking-via-language-analyzers.md
@@ -1,0 +1,70 @@
+---
+id: TASK-215
+title: AST-aware code chunking via the existing language analyzers
+status: To Do
+assignee: []
+created_date: '2026-05-26 18:00'
+updated_date: '2026-05-26 18:00'
+labels:
+  - enhancement
+  - RAG
+  - retrieval-quality
+dependencies: []
+references:
+  - src/main/java/com/devoxx/genie/service/rag/ProjectIndexerService.java
+  - src/main/java/com/devoxx/genie/service/analyzer/ProjectAnalyzer.java
+  - src/main/java/com/devoxx/genie/service/analyzer/languages/
+  - src/main/java/com/devoxx/genie/service/rag/manifest/IndexManifest.java
+  - 'https://github.com/devoxx/DevoxxGenieIDEAPlugin/issues/564'
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Phase 2 added a per-extension splitter that picks line-based vs. paragraph-based splitting based on file extension. That's a substantial win over character-recursive splitting, but it still doesn't respect **semantic** code boundaries: a method can be sliced across two chunks, a class header can end up separated from its body, and Javadoc can land in a different chunk than the method it documents.
+
+The plugin already has language-aware AST scanners under `service/analyzer/languages/` (Java, Kotlin, Python, JavaScript, Go, Rust, C++, PHP), coordinated by `ProjectAnalyzer`. This task uses those analyzers to chunk on **AST boundaries** — one chunk per method (or class for small classes, with method-level fallback when a class exceeds the token budget) — and adds metadata that makes retrieval much more precise.
+
+**Investigation areas:**
+- **Analyzer reuse.** The scanners currently extract context for prompt augmentation (parent classes, field references). Audit whether they expose a structured-enough view to produce chunk boundaries directly, or whether we need a thin adapter that walks the same data and emits `(symbolName, symbolKind, startLine, endLine, text)` tuples.
+- **Chunk-per-method, with class fallback for tiny classes.** Default: every method becomes one chunk with its Javadoc/docstring attached. Classes shorter than `CHUNK_SIZE_TOKENS` become a single chunk. Top-level functions in Python/JS/Go follow the same rule.
+- **Metadata for precision.** Each chunk should carry `symbolName`, `symbolKind` (`method` | `class` | `function` | `field`), `parentClass` (nullable), `startLine`, `endLine`, and the existing `FILE_PATH` / `LAST_MODIFIED`. Retrieval can use these for richer prompt rendering ("`AuthService.authenticate (lines 42-87)`") and future symbol-aware reranking.
+- **Fallback for very long methods.** A 5000-line generated method shouldn't become a 5000-line chunk. If a method exceeds `CHUNK_SIZE_TOKENS * 2`, fall back to the line splitter for that method only and carry the same symbol metadata across the resulting sub-chunks.
+- **Non-code files keep the Phase-2 routing.** Markdown still goes to paragraph splitter; everything else to the recursive default. Only the languages with AST scanners get this treatment.
+- **Schema bump.** Adding new metadata fields and changing chunk semantics is a schema break for the manifest. Bump `CURRENT_EMBEDDING_SCHEMA_VERSION` to `v3` (or align with the model-versioning chosen in task-212) so existing v2 chunks are ignored and a re-index is prompted.
+- **Performance.** AST parsing per file is heavier than line splitting. The Phase-2 parallel indexer (`INDEXING_PARALLELISM = 2`) should absorb most of it, but measure on a representative project; if regressions exceed ~30% indexing time, parallelism may need to bump.
+
+This is the biggest retrieval-quality lever still on the table after Phase 1+2. Done well, it makes "where is `AuthService.authenticate` defined?" return exactly that method, not a 500-token slice that may or may not contain the signature.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 For languages with an existing analyzer (Java, Kotlin, Python, JavaScript, Go, Rust, C++, PHP), `ProjectIndexerService.splitterFor` produces one chunk per method (or per small class) with attached Javadoc/docstring; methods over 2× `CHUNK_SIZE_TOKENS` fall back to line-splitting while preserving symbol metadata
+- [ ] #2 Each chunk carries `symbolName`, `symbolKind` (`method` / `class` / `function` / `field`), `parentClass` (nullable), `startLine`, `endLine` in its metadata, alongside the existing `FILE_PATH` / `LAST_MODIFIED` / `INDEXED_AT` / schema version
+- [ ] #3 Non-source files (markdown, generic text, etc.) keep the Phase-2 splitter routing — only the listed language extensions use AST chunking
+- [ ] #4 The embedding schema is bumped (e.g. `v3`) so existing v2 chunks are invalidated and the indexer prompts the user for a re-index — this is communicated in the UI, not silent
+- [ ] #5 The "Show RAG Only" log entries (and the prompt rendering in `MessageCreationService`) include symbol-aware location info: `File: Foo.java (AuthService.authenticate, lines 42-87)` rather than just the file path
+- [ ] #6 Indexing throughput regression on a representative project is documented; if it exceeds ~30% the parallelism default is reconsidered, with the chosen number recorded in the commit message
+- [ ] #7 Unit tests cover: each supported language produces method-level chunks for a fixture file, oversized methods fall back to line splitting with retained symbol metadata, a class smaller than the chunk budget produces a single class-scoped chunk, and metadata fields are populated correctly
+- [ ] #8 Files in unsupported languages or when an analyzer throws are handled gracefully: fall back to the Phase-2 per-extension splitter and log a `WARN` once per file
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Background from the Phase-1/2 RAG review: AST chunking was called out as the biggest retrieval-quality lever still on the table after Phase 1+2 — bigger than reranking, bigger than hybrid retrieval. The Phase-2 per-extension splitter was an explicit cheap-first-pass that bought time for this proper version.
+
+The existing analyzers under `service/analyzer/languages/` are already loaded for prompt-context extraction; reuse them rather than introducing a new tree-sitter or JavaParser dependency. If their public surface doesn't expose enough structure to drive chunking directly, a thin internal adapter is fine.
+
+Suggested skeleton:
+- `SymbolChunk` record: `(String symbolName, SymbolKind kind, String parentClass, int startLine, int endLine, String text)`.
+- `AstChunker` interface: per-language impl; takes `Path` + file content, returns `List<SymbolChunk>`.
+- `AstChunkerRegistry`: maps extension → chunker; falls back to the Phase-2 splitter for misses.
+- In `ProjectIndexerService.splitterFor`, when an AST chunker exists for the extension, use it; otherwise the Phase-2 path.
+- In `processPath`, propagate `SymbolChunk` metadata into the segment `Metadata` written to Chroma + manifest.
+
+Open question to resolve in implementation: should the manifest track per-symbol entries (one row per method) or stay one row per file? Per-file is simpler and matches the current code; per-symbol unlocks "this method was deleted but the file still exists" precision. Recommended: stay per-file for v3, revisit later.
+
+Out of scope: language-server-protocol-based chunking, symbol-aware reranking (could be a follow-up that consumes the metadata this task adds).
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-216 - RAG-health-and-diagnostics-UI-panel.md
+++ b/backlog/tasks/task-216 - RAG-health-and-diagnostics-UI-panel.md
@@ -1,0 +1,77 @@
+---
+id: TASK-216
+title: RAG health & diagnostics panel in the Settings UI
+status: To Do
+assignee: []
+created_date: '2026-05-26 18:00'
+updated_date: '2026-05-26 18:00'
+labels:
+  - enhancement
+  - RAG
+  - UX
+dependencies: []
+references:
+  - src/main/java/com/devoxx/genie/ui/settings/rag/RAGSettingsComponent.java
+  - src/main/java/com/devoxx/genie/ui/settings/rag/RAGSettingsConfigurable.java
+  - src/main/java/com/devoxx/genie/service/rag/manifest/IndexManifest.java
+  - src/main/java/com/devoxx/genie/service/rag/manifest/IndexManifestService.java
+  - src/main/java/com/devoxx/genie/service/rag/manifest/JsonFileIndexManifest.java
+  - src/main/java/com/devoxx/genie/service/rag/RagValidatorService.java
+  - src/main/java/com/devoxx/genie/ui/panel/log/AgentMcpLogPanel.java
+priority: low
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Users currently have no way to see whether RAG is actually working for their project. The settings panel has the toggles and thresholds; the new "Show RAG Only" log shows per-query retrievals; but there's no single place to answer "is my index healthy, how big is it, when was it last updated, which files made it in?".
+
+This task adds a small **RAG health/diagnostics** section to the existing RAG settings panel that surfaces the state of the index so users can self-diagnose retrieval problems before opening an issue.
+
+**Investigation areas:**
+- **Where it lives.** Add a "RAG Status" sub-section to `RAGSettingsComponent`, below the existing toggles and thresholds. Don't introduce a new tool window — one place to look for everything RAG.
+- **What to show.**
+  - Indexed file count (from the manifest).
+  - Total chunk count (sum of `segmentCount` across manifest entries — already stored).
+  - Last index time (max of `indexedAt`).
+  - Embedding model in use, schema version, and warn if the manifest contains entries from older schemas (which would have been ignored by `isCurrent` anyway).
+  - Manifest file path and size on disk.
+  - ChromaDB collection name (so users can inspect with `chromadb` CLI tools if they want).
+  - Validator status snapshot (Docker / Chroma / Ollama / embedding-model) — running the same checks as `RagValidatorService` and rendering a green/red row per check.
+  - File-watcher status: ON/OFF, count of files reindexed in this session.
+- **Actions.** Three buttons:
+  - "Refresh" — re-run validators and recount the manifest.
+  - "Open log panel" — opens the DevoxxGenie Logs tool window with the "Show RAG Only" filter preselected.
+  - "Reset project index" — confirmation dialog, then wipes the manifest and the project's Chroma collection. Useful when the user changes embedding models or just wants a clean slate.
+- **Refresh model.** Computing the stats requires a small manifest pass (cheap, in-memory). Refresh on panel open; manual refresh via the button. No automatic polling.
+- **Headless-safe.** Validators and manifest reads must not block the EDT. Compute on a background thread, render to EDT via `invokeLater`.
+
+This is the lowest-priority Phase 3 item — retrieval quality matters more than diagnostic UX — but it pays for itself the first time a user reports "RAG doesn't work" and we can ask them to screenshot this panel.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 A "RAG Status" section is added to the existing RAG settings panel showing: indexed file count, total chunk count, last index time, embedding model + schema version, manifest path + on-disk size, ChromaDB collection name
+- [ ] #2 A row per validator (Docker / ChromaDB / Ollama / embedding model) is rendered with green/red status, mirroring what `RagValidatorService` already computes — no duplicate validation logic, just a renderer
+- [ ] #3 The file-watcher's status is shown: ON/OFF and the count of files reindexed in the current IDE session (small in-memory counter on `RAGFileWatcher`)
+- [ ] #4 Three buttons work: "Refresh" re-runs validators and recounts the manifest; "Open log panel" opens DevoxxGenie Logs with the Show RAG Only filter preselected; "Reset project index" prompts for confirmation, wipes the manifest, drops the project's Chroma collection, and shows a notification when done
+- [ ] #5 All computation runs off the EDT — opening the settings panel must never block the UI even if the manifest holds tens of thousands of entries
+- [ ] #6 If RAG is disabled or no manifest exists yet, the section shows a friendly empty-state ("No index for this project yet — click Index Files to build one") rather than zeros and dashes
+- [ ] #7 Unit tests cover the manifest-summary computation (file count, chunk count, last-indexed timestamp) on a synthetic manifest
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Background from the Phase-1/2 RAG review: the review listed a "UI health surface" among Phase 3 items, scoped explicitly as a diagnostic aid not a redesign of the settings panel. This task implements that aid.
+
+Suggested split:
+- `RagHealthSnapshot` value object: holds everything to render. Computed by a `RagHealthService.snapshot(Project)` call on a background thread.
+- `RAGSettingsComponent` gains a "RAG Status" `JPanel` with a small table for stats and a row of action buttons. Use existing IntelliJ UI components (`JBLabel`, `JBPanel`, etc.) to match the panel's look.
+- Track the watcher's session reindex count via an `AtomicInteger` on `RAGFileWatcher`; expose a getter; reset on dispose.
+- "Open log panel" should call `ToolWindowManager.getInstance(project).getToolWindow("DevoxxGenieLogs").show()` (or whatever the registered ID is) and somehow set the filter to `RAG_ONLY` — extend `AgentMcpLogPanel` to accept a default filter at construction or via a small static setter, and call it before `.show()`.
+
+Out of scope: a real-time dashboard that auto-refreshes, charts/graphs, history of index changes. This is a snapshot view, not telemetry.
+
+Low priority: ship this after task-212 (configurable embedding model) and the retrieval-quality tasks (213, 214, 215) — those move the needle for end users, this helps developers debug.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-217 - RAG-query-expansion-show-loading-indicator-before-variant-LLM-calls-start.md
+++ b/backlog/tasks/task-217 - RAG-query-expansion-show-loading-indicator-before-variant-LLM-calls-start.md
@@ -1,0 +1,75 @@
+---
+id: TASK-217
+title: 'RAG query expansion: show loading indicator before variant LLM calls start'
+status: To Do
+assignee: []
+created_date: '2026-05-26 20:13'
+labels:
+  - rag
+  - ui
+  - bug
+dependencies: []
+references:
+  - src/main/java/com/devoxx/genie/ui/settings/rag/RAGSettingsHandler.java
+  - src/main/java/com/devoxx/genie/service/rag/
+  - src/main/java/com/devoxx/genie/controller/PromptExecutionController.java
+  - src/main/java/com/devoxx/genie/service/PromptExecutionService.java
+  - src/main/java/com/devoxx/genie/ui/panel/UserPromptPanel.java
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+## Problem
+
+When **Query expansion** is enabled in RAG settings (`Settings → RAG → Query expansion → Enable LLM query expansion`), submitting a user prompt appears to freeze the UI:
+
+- The user clicks Submit.
+- Nothing visible happens — no blue glowing border, no spinner, no progress.
+- After the N variant LLM calls (default 3) complete, the blue glowing loading indicator finally appears and the actual RAG search + main prompt continue.
+
+This gives the strong impression that the plugin has hung. Users may click Submit again, cancel, or assume the plugin is broken.
+
+## Expected Behavior
+
+The blue glowing border (loading indicator on the prompt panel / output panel) must appear **immediately** when the user submits the prompt — *before* the query expansion LLM calls start — so the user has continuous visual feedback throughout the entire pipeline:
+
+1. Submit pressed → blue glowing border ON
+2. Query expansion (N variant LLM calls) runs
+3. RAG search (per-variant retrieval + RRF fusion) runs
+4. Main LLM prompt runs (streaming/non-streaming)
+5. Final response rendered → blue glowing border OFF
+
+## Reproduction
+
+1. Enable RAG.
+2. Settings → RAG → check "Enable LLM query expansion", keep "Number of variants" at 3.
+3. Submit any prompt against a RAG-indexed project.
+4. Observe: no visual feedback for several seconds while the 3 variant queries run, then the loading indicator appears.
+
+## Likely Root Cause
+
+The loading indicator activation happens inside the prompt execution pipeline *after* the RAG preprocessing step (which now includes query expansion). The activation needs to be hoisted earlier — to the point of `PromptExecutionController.handlePromptSubmission()` / `UserPromptPanel` submission — so that any RAG preprocessing (including the extra LLM round-trips for query expansion) is wrapped by the loading state.
+
+## Suggested Fix
+
+- Trigger the blue glowing border / loading state at the entry point of prompt submission, before `PromptExecutionService.executeQuery()` invokes RAG.
+- Verify the indicator remains active during query expansion, RAG retrieval, and the main LLM call, and is correctly cleared on completion, cancellation, and error.
+- Ensure no race condition with the existing "deactivate handlers BEFORE hiding loading indicator" pattern.
+
+## UI Reference
+
+Settings UI text: "Paraphrase the query into multiple variants and fuse the per-variant results (Reciprocal Rank Fusion). Improves retrieval on meta-style questions such as 'where do we discuss X?' at the cost of one extra LLM call per RAG search."
+
+(Note: the help text currently says "one extra LLM call" but the implementation issues N calls — one per variant. This is a separate copy/UX issue worth tracking but not part of this fix.)
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Blue glowing loading border appears immediately on prompt submission, before any query-expansion LLM call starts
+- [ ] #2 Loading indicator remains visible continuously through query expansion, RAG retrieval, and main LLM response
+- [ ] #3 Loading indicator is correctly cleared on successful completion, user cancellation, and error
+- [ ] #4 Behavior verified with query expansion enabled (variants = 3) and disabled
+- [ ] #5 No regression in non-RAG prompt submissions or in standard RAG (without query expansion)
+<!-- AC:END -->

--- a/backlog/tasks/task-218 - RAG-query-expansion-fix-misleading-one-extra-LLM-call-help-text.md
+++ b/backlog/tasks/task-218 - RAG-query-expansion-fix-misleading-one-extra-LLM-call-help-text.md
@@ -1,0 +1,53 @@
+---
+id: TASK-218
+title: 'RAG query expansion: fix misleading "one extra LLM call" help text'
+status: To Do
+assignee: []
+created_date: '2026-05-26 20:15'
+labels:
+  - rag
+  - ui
+  - docs
+dependencies:
+  - TASK-217
+references:
+  - src/main/java/com/devoxx/genie/ui/settings/rag/RAGSettingsHandler.java
+priority: low
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+## Problem
+
+The help text under the **Query expansion** checkbox in `Settings → RAG` says:
+
+> "Paraphrase the query into multiple variants and fuse the per-variant results (Reciprocal Rank Fusion). Improves retrieval on meta-style questions such as 'where do we discuss X?' at the cost of **one extra LLM call per RAG search**."
+
+The checkbox label itself also says: *"Enable LLM query expansion (one extra LLM call per RAG search)"*.
+
+This is misleading. The "Number of variants" spinner directly below controls how many additional queries are issued. With the default value of 3, each RAG search performs **N additional LLM calls**, not one.
+
+## Expected Behavior
+
+Help text and checkbox label should accurately reflect that the cost scales with the number of variants.
+
+## Suggested Wording
+
+- Checkbox label: `Enable LLM query expansion (extra LLM calls scale with the number of variants)`
+- Help text trailing sentence: `... at the cost of one extra LLM call per variant per RAG search.`
+
+(Exact wording is up to the maintainer — the requirement is that "one extra LLM call" is no longer stated as a fixed cost.)
+
+## Files
+
+- `src/main/java/com/devoxx/genie/ui/settings/rag/RAGSettingsHandler.java`
+- Any associated resource bundles / message files used for the label and help text.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Checkbox label no longer claims a fixed 'one extra LLM call' cost when the variants spinner controls additional calls
+- [ ] #2 Help text accurately describes that the number of extra LLM calls equals the number of variants
+- [ ] #3 Wording reviewed for clarity and consistency with the rest of the RAG settings panel
+<!-- AC:END -->

--- a/backlog/tasks/task-219 - Make-RAG-mutually-exclusive-with-MCP-and-Agent-mode-in-settings-UI.md
+++ b/backlog/tasks/task-219 - Make-RAG-mutually-exclusive-with-MCP-and-Agent-mode-in-settings-UI.md
@@ -1,0 +1,72 @@
+---
+id: TASK-219
+title: Make RAG mutually exclusive with MCP and Agent mode in settings UI
+status: To Do
+assignee: []
+created_date: '2026-05-26 20:16'
+labels:
+  - rag
+  - mcp
+  - agent
+  - ui
+  - bug
+dependencies: []
+references:
+  - src/main/java/com/devoxx/genie/ui/settings/rag/RAGSettingsComponent.java
+  - src/main/java/com/devoxx/genie/ui/settings/rag/RAGSettingsHandler.java
+  - src/main/java/com/devoxx/genie/ui/settings/mcp/MCPSettingsComponent.java
+  - src/main/java/com/devoxx/genie/service/PromptExecutionService.java
+  - src/main/java/com/devoxx/genie/controller/PromptExecutionController.java
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+## Problem
+
+When **RAG** is enabled simultaneously with **MCP** and/or **Agent mode**, the three pipelines conflict with each other. RAG injects retrieved context into the prompt, while MCP/Agent dynamically inject tools and reshape the request — leading to inconsistent behavior, wasted LLM calls, and unpredictable output.
+
+These features were not designed to be combined and the current UI permits all three to be enabled at the same time.
+
+## Expected Behavior
+
+RAG, MCP, and Agent mode should be mutually exclusive at the settings/UI layer:
+
+- When **RAG** is enabled → MCP and Agent mode controls should be disabled (greyed out) with a tooltip explaining the conflict.
+- When **MCP** or **Agent mode** is enabled → the RAG enable checkbox should be disabled with a similar tooltip.
+- Switching one on should automatically and visibly switch the conflicting ones off (or block toggling with an explanatory message — decision needed).
+
+## Suggested Implementation
+
+1. Centralize the mutual-exclusion rule in a small helper (e.g. `FeatureExclusivityCoordinator`) rather than duplicating wiring in each settings component.
+2. Update:
+   - `RAGSettingsComponent` / `RAGSettingsHandler`
+   - `MCPSettingsComponent`
+   - Agent mode settings (wherever the toggle lives in `DevoxxGenieStateService`)
+3. On settings load: if multiple are already true in persisted state (legacy users), keep the highest-priority one enabled (suggested priority: Agent > MCP > RAG, but confirm) and disable the others with a one-time notification.
+4. At prompt-submission time, add a defensive guard so that even if state somehow has multiple enabled, only one pipeline runs.
+
+## Open Questions
+
+- Should switching one feature on **auto-disable** the others, or **block** the toggle until the user disables the others manually? (Auto-disable is friendlier; blocking is more explicit.)
+- Confirm the priority order for the legacy-state migration case.
+
+## Files (Likely Touched)
+
+- `src/main/java/com/devoxx/genie/ui/settings/rag/RAGSettingsComponent.java`
+- `src/main/java/com/devoxx/genie/ui/settings/rag/RAGSettingsHandler.java`
+- `src/main/java/com/devoxx/genie/ui/settings/mcp/MCPSettingsComponent.java`
+- Agent mode settings component (location to confirm)
+- `DevoxxGenieStateService` (for the persisted toggles)
+- `PromptExecutionController` / `PromptExecutionService` (defensive runtime guard)
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Enabling RAG disables and visually greys out the MCP and Agent mode toggles, with a tooltip explaining the conflict
+- [ ] #2 Enabling MCP or Agent mode disables and visually greys out the RAG enable checkbox, with an equivalent tooltip
+- [ ] #3 Persisted settings that already have multiple of {RAG, MCP, Agent} enabled are reconciled on load to a single active feature using a documented priority order
+- [ ] #4 A defensive guard in the prompt execution pipeline ensures only one of {RAG, MCP, Agent} actually runs even if state is inconsistent
+- [ ] #5 Toggling behavior (auto-disable vs block-with-message) is decided, documented in the task, and applied consistently across all three settings panels
+<!-- AC:END -->

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -121,6 +121,18 @@ tasks.named("buildPlugin") {
     dependsOn("updateProperties")
 }
 
+// Diagnostic CLI for the RAG store. Talks to the same ChromaDB + Ollama the plugin uses.
+// Examples:
+//   ./gradlew ragQuery --args="list agenticengineeringworkshop mcp"
+//   ./gradlew ragQuery --args="query agenticengineeringworkshop 'where do we discuss MCP?' 20"
+tasks.register<JavaExec>("ragQuery") {
+    group = "verification"
+    description = "Query the RAG store from the command line (see RagCli for usage)."
+    mainClass.set("com.devoxx.genie.service.rag.cli.RagCli")
+    classpath = sourceSets["main"].runtimeClasspath
+    standardInput = System.`in`
+}
+
 val generatedBlogResourcesDir = layout.buildDirectory.dir("generated-resources/blog")
 
 sourceSets.named("main") {

--- a/src/main/java/com/devoxx/genie/model/Constant.java
+++ b/src/main/java/com/devoxx/genie/model/Constant.java
@@ -62,6 +62,13 @@ public class Constant {
 
     // Agent mode settings
     public static final int AGENT_MAX_TOOL_CALLS = 25;
+    /**
+     * Wall-clock cap (seconds) for a single MCP/agent prompt conversation.
+     * Simple (non-agent, non-MCP) prompts use the per-request timeout instead. The agent cap is
+     * a *safety net* against silent hangs (e.g., an MCP tool that never returns); each individual
+     * HTTP call still has its own per-request timeout via the Langchain4j SDK.
+     */
+    public static final int AGENT_MAX_EXECUTION_SECONDS = 300;
     public static final int SUB_AGENT_MAX_TOOL_CALLS = 200;
     public static final int SUB_AGENT_DEFAULT_PARALLELISM = 3;
     public static final int SUB_AGENT_MAX_PARALLELISM = 10;

--- a/src/main/java/com/devoxx/genie/model/rag/RAGLogMessage.java
+++ b/src/main/java/com/devoxx/genie/model/rag/RAGLogMessage.java
@@ -1,0 +1,56 @@
+package com.devoxx.genie.model.rag;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.Singular;
+
+import java.util.List;
+
+/**
+ * One RAG retrieval event surfaced to the unified log panel. Carries enough detail that a
+ * developer can audit "did RAG actually pick the right chunks for this query?" without
+ * tailing {@code idea.log}.
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class RAGLogMessage {
+
+    /** Identifies the project that produced this message; used to filter cross-project noise. */
+    private String projectLocationHash;
+
+    /** The user prompt that was sent through the retriever (already trimmed). */
+    private String query;
+
+    /** Embedding model the retriever used (e.g. {@code nomic-embed-text}). May be null in tests. */
+    private String embeddingModel;
+
+    /** Configured minimum similarity score for this search. */
+    private Double minScore;
+
+    /** Configured top-K (max results) for this search. */
+    private Integer maxResults;
+
+    /** One entry per retrieved chunk; preserves duplicates from the same file. */
+    @Singular("hit")
+    private List<Hit> hits;
+
+    /** Total time the retrieval took, in milliseconds. */
+    private long durationMs;
+
+    @Data
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class Hit {
+        private String filePath;
+        private Double score;
+        /** Truncated preview of the chunk content (full text remains in the prompt). */
+        private String preview;
+        /** Length of the original (un-truncated) chunk in characters. */
+        private int chunkLength;
+    }
+}

--- a/src/main/java/com/devoxx/genie/service/MessageCreationService.java
+++ b/src/main/java/com/devoxx/genie/service/MessageCreationService.java
@@ -223,7 +223,13 @@ public class MessageCreationService {
 
         try {
             SemanticSearchService semanticSearchService = SemanticSearchService.getInstance();
-            searchResults = semanticSearchService.search(chatMessageContext.getProject(), userPrompt);
+            // Pass the chat model so SemanticSearchService can run query expansion when enabled.
+            // chatModel may be null in streaming-only flows; SemanticSearchService falls back to
+            // single-query search in that case.
+            searchResults = semanticSearchService.search(
+                    chatMessageContext.getProject(),
+                    userPrompt,
+                    chatMessageContext.getChatModel());
 
             // Task-209: emit feature_used with the real provider_type from the active model.
             com.devoxx.genie.service.analytics.FeatureUsageTracker.semanticSearchUsed(

--- a/src/main/java/com/devoxx/genie/service/MessageCreationService.java
+++ b/src/main/java/com/devoxx/genie/service/MessageCreationService.java
@@ -24,13 +24,9 @@ import org.jetbrains.annotations.NotNull;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Base64;
 import java.util.List;
-import java.util.Map;
-import java.util.Set;
 import java.util.stream.Collectors;
 
 import static com.devoxx.genie.action.AddSnippetAction.SELECTED_TEXT_KEY;
@@ -45,7 +41,7 @@ public class MessageCreationService {
     public static final String SEMANTIC_RESULT = """
             File: %s%n
             Score: %.2f%n
-            ```java%n
+            ```%s%n
             %s%n
             ```%n
             """;
@@ -202,8 +198,7 @@ public class MessageCreationService {
         try {
             SemanticSearchService semanticSearchService = SemanticSearchService.getInstance();
 
-            // Get semantic search results from ChromaDB
-            Map<String, SearchResult> searchResults =
+            List<SearchResult> searchResults =
                     semanticSearchService.search(chatMessageContext.getProject(), chatMessageContext.getUserPrompt());
 
             // Task-209: emit feature_used with the real provider_type from the active model.
@@ -212,26 +207,22 @@ public class MessageCreationService {
 
             if (!searchResults.isEmpty()) {
                 List<SemanticFile> fileReferences = extractFileReferences(searchResults);
-
-                // Store references in chat message context for UI use
                 chatMessageContext.setSemanticReferences(fileReferences);
 
                 contextBuilder.append("Referenced files:\n");
                 fileReferences.forEach(file -> contextBuilder.append("- ").append(file).append("\n"));
                 contextBuilder.append("\n");
 
-                Set<Map.Entry<String, SearchResult>> entries = searchResults.entrySet();
-                // Format search results
-                String formattedResults = entries.stream()
-                        .map(MessageCreationService::getFileContent)
+                String formattedResults = searchResults.stream()
+                        .map(MessageCreationService::formatSemanticResult)
                         .collect(Collectors.joining("\n"));
 
                 contextBuilder.append(formattedResults);
 
-                // Log the number of relevant snippets found
+                long uniqueFiles = fileReferences.stream().map(SemanticFile::filePath).distinct().count();
                 NotificationUtil.sendNotification(
                         chatMessageContext.getProject(),
-                        String.format("Found %d relevant project file%s using RAG", searchResults.size(), searchResults.size() > 1 ? "s" : "")
+                        String.format("Found %d relevant project file%s using RAG", uniqueFiles, uniqueFiles > 1 ? "s" : "")
                 );
             }
         } catch (Exception e) {
@@ -241,19 +232,48 @@ public class MessageCreationService {
         return contextBuilder.toString();
     }
 
-    private static @NotNull String getFileContent(Map.@NotNull Entry<String, SearchResult> entry) {
-        String fileContent;
-        try {
-            fileContent = Files.readString(Paths.get(entry.getKey()));
-        } catch (IOException e) {
-            return "";
-        }
-        return SEMANTIC_RESULT.formatted(entry.getKey(), entry.getValue().score(), fileContent);
+    /**
+     * Format a single search hit for inclusion in the prompt. Uses the chunk text returned
+     * by the vector store — does NOT re-read the full file from disk.
+     */
+    private static @NotNull String formatSemanticResult(@NotNull SearchResult result) {
+        String filePath = result.filePath() != null ? result.filePath() : "(unknown)";
+        return SEMANTIC_RESULT.formatted(filePath, result.score(), inferFenceLanguage(filePath), result.content());
     }
 
-    public static List<SemanticFile> extractFileReferences(@NotNull Map<String, SearchResult> searchResults) {
-        return searchResults.keySet().stream()
-                .map(value -> new SemanticFile(value, searchResults.get(value).score()))
+    private static @NotNull String inferFenceLanguage(@NotNull String filePath) {
+        int dot = filePath.lastIndexOf('.');
+        if (dot < 0 || dot == filePath.length() - 1) return "";
+        String ext = filePath.substring(dot + 1).toLowerCase();
+        return switch (ext) {
+            case "java" -> "java";
+            case "kt", "kts" -> "kotlin";
+            case "py" -> "python";
+            case "js", "mjs", "cjs" -> "javascript";
+            case "ts", "tsx" -> "typescript";
+            case "jsx" -> "jsx";
+            case "go" -> "go";
+            case "rs" -> "rust";
+            case "cpp", "cc", "cxx", "hpp", "h" -> "cpp";
+            case "c" -> "c";
+            case "php" -> "php";
+            case "rb" -> "ruby";
+            case "scala" -> "scala";
+            case "sh", "bash" -> "bash";
+            case "sql" -> "sql";
+            case "yml", "yaml" -> "yaml";
+            case "json" -> "json";
+            case "xml" -> "xml";
+            case "html", "htm" -> "html";
+            case "css" -> "css";
+            case "md" -> "markdown";
+            default -> ext;
+        };
+    }
+
+    public static List<SemanticFile> extractFileReferences(@NotNull List<SearchResult> searchResults) {
+        return searchResults.stream()
+                .map(r -> new SemanticFile(r.filePath(), r.score()))
                 .toList();
     }
 

--- a/src/main/java/com/devoxx/genie/service/MessageCreationService.java
+++ b/src/main/java/com/devoxx/genie/service/MessageCreationService.java
@@ -1,9 +1,11 @@
 package com.devoxx.genie.service;
 
+import com.devoxx.genie.model.rag.RAGLogMessage;
 import com.devoxx.genie.model.request.ChatMessageContext;
 import com.devoxx.genie.model.request.EditorInfo;
 import com.devoxx.genie.model.request.SemanticFile;
 import com.devoxx.genie.service.mcp.MCPService;
+import com.devoxx.genie.service.rag.RAGEventPublisher;
 import com.devoxx.genie.service.rag.SearchResult;
 import com.devoxx.genie.service.rag.SemanticSearchService;
 import com.devoxx.genie.ui.settings.DevoxxGenieStateService;
@@ -194,12 +196,13 @@ public class MessageCreationService {
         log.debug("Adding semantic search results to user message");
 
         StringBuilder contextBuilder = new StringBuilder();
+        String userPrompt = chatMessageContext.getUserPrompt();
+        long startNanos = System.nanoTime();
+        List<SearchResult> searchResults = new ArrayList<>();
 
         try {
             SemanticSearchService semanticSearchService = SemanticSearchService.getInstance();
-
-            List<SearchResult> searchResults =
-                    semanticSearchService.search(chatMessageContext.getProject(), chatMessageContext.getUserPrompt());
+            searchResults = semanticSearchService.search(chatMessageContext.getProject(), userPrompt);
 
             // Task-209: emit feature_used with the real provider_type from the active model.
             com.devoxx.genie.service.analytics.FeatureUsageTracker.semanticSearchUsed(
@@ -222,11 +225,15 @@ public class MessageCreationService {
                 long uniqueFiles = fileReferences.stream().map(SemanticFile::filePath).distinct().count();
                 NotificationUtil.sendNotification(
                         chatMessageContext.getProject(),
-                        String.format("Found %d relevant project file%s using RAG", uniqueFiles, uniqueFiles > 1 ? "s" : "")
+                        String.format("Found %d relevant project file%s using RAG — see DevoxxGenie Logs (Show RAG Only) for details",
+                                uniqueFiles, uniqueFiles > 1 ? "s" : "")
                 );
             }
         } catch (Exception e) {
             log.warn("Failed to get semantic search results: " + e.getMessage());
+        } finally {
+            long durationMs = (System.nanoTime() - startNanos) / 1_000_000L;
+            RAGEventPublisher.publish(chatMessageContext.getProject(), userPrompt, searchResults, durationMs);
         }
 
         return contextBuilder.toString();

--- a/src/main/java/com/devoxx/genie/service/MessageCreationService.java
+++ b/src/main/java/com/devoxx/genie/service/MessageCreationService.java
@@ -141,6 +141,12 @@ public class MessageCreationService {
         chatMessageContext.setUserMessage(UserMessage.from(stringBuilder.toString()));
     }
 
+    /** Queries shorter than this are treated as follow-up clarifications ("explain", "more?",
+     *  "and?") that should reuse the previous turn's context rather than triggering a new RAG
+     *  retrieval. This keeps the prompt-cache hot for chatty back-and-forth and saves an
+     *  Ollama embedding call per follow-up. */
+    static final int RAG_MIN_QUERY_LENGTH = 15;
+
     private void constructUserMessageWithCombinedContext(@NotNull ChatMessageContext chatMessageContext) {
         log.debug("Constructing user message with combined context");
 
@@ -156,16 +162,6 @@ public class MessageCreationService {
         // (set once per conversation in ChatMemoryManager.buildSystemPrompt()) rather than repeated
         // in every user message.
 
-        if (Boolean.TRUE.equals(DevoxxGenieStateService.getInstance().getRagActivated())) {
-            // Semantic search is enabled, add search results
-            String semanticContext = addSemanticSearchResults(chatMessageContext);
-            if (!semanticContext.isEmpty()) {
-                stringBuilder.append("<SemanticContext>\n");
-                stringBuilder.append(semanticContext);
-                stringBuilder.append("\n</SemanticContext>");
-            }
-        }
-
         if (MCPService.isMCPEnabled()) {
             // We'll add more info about the project path so tools can use this info.
             stringBuilder
@@ -180,10 +176,35 @@ public class MessageCreationService {
             stringBuilder.append(editorContent);
         }
 
+        // Retrieval context immediately precedes the user prompt. Two reasons:
+        //   1. Providers that hit prompt caches (Anthropic, OpenAI) only cache the stable
+        //      prefix; varying retrieval content at the top defeats that cache for everyone.
+        //   2. Many local models pay more attention to whatever is closest to the user
+        //      question — keeping RAG hits adjacent to the prompt improves grounding.
+        if (Boolean.TRUE.equals(DevoxxGenieStateService.getInstance().getRagActivated())
+                && shouldRunRagFor(chatMessageContext.getUserPrompt())) {
+            String semanticContext = addSemanticSearchResults(chatMessageContext);
+            if (!semanticContext.isEmpty()) {
+                stringBuilder.append("<SemanticContext>\n");
+                stringBuilder.append(semanticContext);
+                stringBuilder.append("\n</SemanticContext>");
+            }
+        }
+
         // Add the user's prompt, this MUST BE at the bottom of the prompt for some local models to understand!
         stringBuilder.append("<UserPrompt>\n").append(chatMessageContext.getUserPrompt()).append("\n</UserPrompt>\n\n");
 
         chatMessageContext.setUserMessage(UserMessage.from(stringBuilder.toString()));
+    }
+
+    /**
+     * Decide whether to run a RAG retrieval for {@code userPrompt}. Skips very short
+     * follow-up-style messages ({@code "more?"}, {@code "explain"}, {@code "why?"}) where
+     * the LLM should rely on the prior turn's context instead. Visible for tests.
+     */
+    static boolean shouldRunRagFor(String userPrompt) {
+        if (userPrompt == null) return false;
+        return userPrompt.trim().length() >= RAG_MIN_QUERY_LENGTH;
     }
 
     /**

--- a/src/main/java/com/devoxx/genie/service/PostStartupActivity.java
+++ b/src/main/java/com/devoxx/genie/service/PostStartupActivity.java
@@ -9,6 +9,9 @@ import com.devoxx.genie.service.automation.listeners.ProcessExitListener;
 import com.devoxx.genie.service.prompt.memory.ChatMemoryManager;
 import com.devoxx.genie.service.prompt.threading.ThreadPoolManager;
 import com.devoxx.genie.service.prompt.threading.ThreadPoolShutdownManager;
+import com.devoxx.genie.service.rag.watcher.RAGFileWatcher;
+import com.devoxx.genie.ui.settings.DevoxxGenieStateService;
+import com.devoxx.genie.ui.topic.AppTopics;
 import com.devoxx.genie.ui.util.ThemeChangeListener;
 import com.intellij.execution.ExecutionManager;
 import com.intellij.openapi.compiler.CompilationStatusListener;
@@ -60,6 +63,11 @@ public class PostStartupActivity implements ProjectActivity {
         // Register event automation listeners (project-scoped)
         registerEventAutomationListeners(project);
 
+        // Spin up the RAG file watcher if RAG is enabled at startup; otherwise wire a one-shot
+        // listener so it starts the moment the user toggles RAG on. The watcher is project-scoped
+        // and disposed with the project.
+        maybeStartRagWatcher(project);
+
         // First-launch analytics consent notification (task-206). Self-disables after firing once.
         AnalyticsConsentNotifier.maybeShow(project);
 
@@ -67,6 +75,19 @@ public class PostStartupActivity implements ProjectActivity {
         AnalyticsSessionSnapshotService.getInstance().snapshotIfNeeded();
 
         return Unit.INSTANCE;
+    }
+
+    private void maybeStartRagWatcher(@NotNull Project project) {
+        if (Boolean.TRUE.equals(DevoxxGenieStateService.getInstance().getRagEnabled())) {
+            RAGFileWatcher.getInstance(project); // forces lazy init
+        }
+        // App-level topic — when the user enables RAG mid-session, start the per-project watcher.
+        project.getMessageBus().connect().subscribe(AppTopics.RAG_STATE_TOPIC,
+                (com.devoxx.genie.ui.listener.RAGStateListener) enabled -> {
+                    if (enabled) {
+                        RAGFileWatcher.getInstance(project);
+                    }
+                });
     }
 
     /**

--- a/src/main/java/com/devoxx/genie/service/chromadb/ChromaDBManager.java
+++ b/src/main/java/com/devoxx/genie/service/chromadb/ChromaDBManager.java
@@ -14,6 +14,7 @@ import com.intellij.openapi.project.Project;
 import lombok.extern.slf4j.Slf4j;
 import okhttp3.OkHttpClient;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import retrofit2.Retrofit;
 import retrofit2.converter.gson.GsonConverterFactory;
 
@@ -95,7 +96,7 @@ public final class ChromaDBManager {
     private void startContainer(Project project,
                                 @NotNull ProgressIndicator indicator,
                                 ChromaDBStatusCallback callback) {
-        indicator.setText("Starting ChromaDB container...");
+        indicator.setText("Preparing ChromaDB...");
         try {
             ChromaDockerService dockerService = ApplicationManager.getApplication()
                     .getService(ChromaDockerService.class);
@@ -104,6 +105,7 @@ public final class ChromaDBManager {
                 public void onSuccess() {
                     // Wait for ChromaDB to be fully operational
                     indicator.setText("Waiting for ChromaDB to be ready...");
+                    indicator.setText2("");
                     if (waitForChromaDB(indicator)) {
                         callback.onSuccess();
                     } else {
@@ -115,7 +117,7 @@ public final class ChromaDBManager {
                 public void onError(String message) {
                     callback.onError(message);
                 }
-            });
+            }, indicator);
         } catch (Exception e) {
             log.error("Failed to start ChromaDB", e);
             callback.onError("Failed to start ChromaDB: " + e.getMessage());
@@ -123,6 +125,17 @@ public final class ChromaDBManager {
     }
 
     public void pullChromaDockerImage(Project project, ChromaDBStatusCallback callback) {
+        pullChromaDockerImage(project, callback, null);
+    }
+
+    /**
+     * @param progressListener invoked on a Docker-API thread for each layer status update
+     *                         (e.g. "abc123: Downloading"). Callers that update Swing widgets
+     *                         must hop to the EDT inside the listener.
+     */
+    public void pullChromaDockerImage(Project project,
+                                      ChromaDBStatusCallback callback,
+                                      @Nullable java.util.function.Consumer<String> progressListener) {
         ProgressManager.getInstance().run(new Task.Backgroundable(project, "Pulling chromaDB image") {
             @Override
             public void run(@NotNull ProgressIndicator indicator) {
@@ -132,7 +145,7 @@ public final class ChromaDBManager {
                 try {
                     ChromaDockerService dockerService =
                             ApplicationManager.getApplication().getService(ChromaDockerService.class);
-                    dockerService.pullChromaDockerImage(callback);
+                    dockerService.pullChromaDockerImage(callback, indicator, progressListener);
                     callback.onSuccess();
                 } catch (Exception e) {
                     log.error("Error pulling ChromaDB image", e);

--- a/src/main/java/com/devoxx/genie/service/chromadb/ChromaDockerService.java
+++ b/src/main/java/com/devoxx/genie/service/chromadb/ChromaDockerService.java
@@ -5,14 +5,18 @@ import com.devoxx.genie.service.chromadb.exception.DockerException;
 import com.devoxx.genie.ui.settings.DevoxxGenieStateService;
 import com.devoxx.genie.util.DockerUtil;
 import com.github.dockerjava.api.DockerClient;
+import com.github.dockerjava.api.async.ResultCallback;
+import com.github.dockerjava.api.command.PullImageResultCallback;
 import com.github.dockerjava.api.exception.NotModifiedException;
 import com.github.dockerjava.api.model.*;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.application.PathManager;
 import com.intellij.openapi.components.Service;
+import com.intellij.openapi.progress.ProgressIndicator;
 import com.intellij.openapi.project.Project;
 import lombok.extern.slf4j.Slf4j;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -26,14 +30,16 @@ import java.util.stream.Stream;
 @Service
 public final class ChromaDockerService {
     
-    private static final String CHROMA_IMAGE = "chromadb/chroma:0.6.2";
+    /** Single source of truth for the ChromaDB Docker image version. Referenced by the validator
+     *  (status message) and its test, so bumping the version only requires editing this line. */
+    public static final String CHROMA_VERSION = "0.6.2";
+    public static final String CHROMADB_DOCKER_NAME = "chromadb/chroma";
+    private static final String CHROMA_IMAGE = CHROMADB_DOCKER_NAME + ":" + CHROMA_VERSION;
     private static final String CONTAINER_NAME = "devoxx-genie-chromadb";
 
     public static final String FAILED_TO_PULL_CHROMA_DB_IMAGE = "Failed to pull ChromaDB image: ";
     public static final String FAILED_TO_START_CHROMA_DB = "Failed to start ChromaDB: ";
     public static final String FAILED_TO_CREATE_VOLUME_DIRECTORY = "Failed to create volume directory: ";
-
-    public static final String CHROMADB_DOCKER_NAME = "chromadb/chroma";
 
     // Docker states
     public static final String RUNNING = "running";
@@ -41,6 +47,10 @@ public final class ChromaDockerService {
     public static final String CREATED = "created";
 
     public void startChromaDB(Project project, ChromaDBStatusCallback callback) {
+        startChromaDB(project, callback, null);
+    }
+
+    public void startChromaDB(Project project, ChromaDBStatusCallback callback, @Nullable ProgressIndicator indicator) {
         try {
             // We assume Docker is already installed and running
             if (isChromaDBRunning()) {
@@ -49,7 +59,9 @@ public final class ChromaDockerService {
                 return;
             }
 
-            pullChromaDockerImage(callback);
+            if (indicator != null) indicator.setText("Pulling ChromaDB image " + CHROMA_VERSION + " (may take several minutes on first install)...");
+            pullChromaDockerImage(callback, indicator);
+            if (indicator != null) indicator.setText("Starting ChromaDB container...");
             String volumePath = setupVolumeDirectory(project);
             startChromaContainer(volumePath, callback);
 
@@ -86,15 +98,48 @@ public final class ChromaDockerService {
         return volumePath.toString();
     }
 
-    /**
-     * Pull the ChromaDB Docker image
-     *
-     * @param callback the callback to notify the status
-     * @throws DockerException if an error occurs while pulling the image
-     */
     public void pullChromaDockerImage(ChromaDBStatusCallback callback) throws DockerException {
+        pullChromaDockerImage(callback, null, null);
+    }
+
+    public void pullChromaDockerImage(ChromaDBStatusCallback callback, @Nullable ProgressIndicator indicator) throws DockerException {
+        pullChromaDockerImage(callback, indicator, null);
+    }
+
+    /**
+     * Pull the ChromaDB Docker image. Layer-level download progress is forwarded to:
+     * <ul>
+     *   <li>{@code indicator.setText2(...)} when {@code indicator != null} — surfaces in
+     *       the IDE's background-task status bar.</li>
+     *   <li>{@code progressListener.accept(...)} when non-null — lets callers surface the
+     *       same text inline in their own UI (e.g. the RAG settings panel) so the user sees
+     *       activity without having to look at the status bar spinner.</li>
+     * </ul>
+     * The listener is invoked on a Docker-API callback thread; UI-touching callers must
+     * hop to the EDT themselves.
+     */
+    public void pullChromaDockerImage(ChromaDBStatusCallback callback,
+                                      @Nullable ProgressIndicator indicator,
+                                      @Nullable java.util.function.Consumer<String> progressListener) throws DockerException {
         try (DockerClient dockerClient = DockerUtil.getDockerClient()) {
-            dockerClient.pullImageCmd(CHROMA_IMAGE).start().awaitCompletion();
+            ResultCallback.Adapter<PullResponseItem> progressCallback = new PullImageResultCallback() {
+                @Override
+                public void onNext(PullResponseItem item) {
+                    String status = item.getStatus();
+                    if (status != null) {
+                        String id = item.getId();
+                        String text = id != null ? id + ": " + status : status;
+                        if (indicator != null && !indicator.isCanceled()) {
+                            indicator.setText2(text);
+                        }
+                        if (progressListener != null) {
+                            progressListener.accept(text);
+                        }
+                    }
+                    super.onNext(item);
+                }
+            };
+            dockerClient.pullImageCmd(CHROMA_IMAGE).exec(progressCallback).awaitCompletion();
         } catch (IOException e) {
             callback.onError(FAILED_TO_PULL_CHROMA_DB_IMAGE + e.getMessage());
             throw new DockerException("Failed to pull ChromaDB image", e);
@@ -155,16 +200,29 @@ public final class ChromaDockerService {
 
                 // Start the container
                 dockerClient.startContainerCmd(containerId).exec();
+                callback.onSuccess();
             } else {
-                // Reuse existing container
+                // Reuse existing container, but only if it was built from the current image.
+                // Otherwise a previous plugin version's container (e.g. chromadb/chroma:0.6.2)
+                // would be silently restarted, defeating the version bump and confusing users
+                // who think they're now on the new version.
                 Container existingContainer = existingContainers.getFirst();
+                String existingImage = existingContainer.getImage();
+                if (existingImage != null && !existingImage.equals(CHROMA_IMAGE)) {
+                    callback.onError(String.format(
+                            "Existing ChromaDB container is on image '%s' but this plugin version expects '%s'. " +
+                                    "Remove the old container first:  docker rm -f %s  " +
+                                    "(ChromaDB 0.x → 1.x changed the on-disk format — if you upgraded across that boundary, " +
+                                    "also clear the data volume and re-index your project.)",
+                            existingImage, CHROMA_IMAGE, CONTAINER_NAME));
+                    return;
+                }
 
-                // Check the actual container state
                 String containerState = existingContainer.getState();
-
-                // Only start if the container is stopped or created
                 if (EXITED.equalsIgnoreCase(containerState) || CREATED.equalsIgnoreCase(containerState)) {
                     startExistingContainer(dockerClient, existingContainer.getId(), callback);
+                } else if (RUNNING.equalsIgnoreCase(containerState)) {
+                    callback.onSuccess();
                 }
             }
         } catch (IOException e) {

--- a/src/main/java/com/devoxx/genie/service/chromadb/ChromaEmbeddingService.java
+++ b/src/main/java/com/devoxx/genie/service/chromadb/ChromaEmbeddingService.java
@@ -1,24 +1,33 @@
 package com.devoxx.genie.service.chromadb;
 
 import com.devoxx.genie.ui.settings.DevoxxGenieStateService;
-import com.devoxx.genie.ui.util.NotificationUtil;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.components.Service;
 import com.intellij.openapi.project.Project;
+import dev.langchain4j.data.segment.TextSegment;
+import dev.langchain4j.model.embedding.EmbeddingModel;
 import dev.langchain4j.model.ollama.OllamaEmbeddingModel;
+import dev.langchain4j.store.embedding.EmbeddingStore;
 import dev.langchain4j.store.embedding.chroma.ChromaEmbeddingStore;
-import lombok.Getter;
+import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.TestOnly;
 
 @Slf4j
 @Service
 public final class ChromaEmbeddingService {
-    
+
     private final DevoxxGenieStateService stateService = DevoxxGenieStateService.getInstance();
 
-    @Getter
-    private ChromaEmbeddingStore embeddingStore;
+    private EmbeddingStore<TextSegment> embeddingStore;
+
+    /**
+     * Test-only override for the embedding model. When non-null, {@link #getEmbeddingModel()}
+     * returns this instead of building a new {@link OllamaEmbeddingModel}.
+     */
+    @Setter
+    private EmbeddingModel embeddingModelOverride;
 
     @NotNull
     public static ChromaEmbeddingService getInstance() {
@@ -40,18 +49,25 @@ public final class ChromaEmbeddingService {
         }
     }
 
-    /**
-     * Get the Chroma DB collection name for the given project.
-     * @param project the project
-     * @return the collection name for the project
-     */
+    public EmbeddingStore<TextSegment> getEmbeddingStore() {
+        return embeddingStore;
+    }
+
+    @TestOnly
+    public void setEmbeddingStore(EmbeddingStore<TextSegment> embeddingStore) {
+        this.embeddingStore = embeddingStore;
+    }
+
     private @NotNull String getCollectionName(@NotNull Project project) {
         return project.getName()
                       .toLowerCase()
                       .replaceAll("[^a-z0-9-]", "-");
     }
 
-    public OllamaEmbeddingModel getEmbeddingModel() {
+    public EmbeddingModel getEmbeddingModel() {
+        if (embeddingModelOverride != null) {
+            return embeddingModelOverride;
+        }
         return OllamaEmbeddingModel.builder()
                 .baseUrl(stateService.getOllamaModelUrl())
                 .modelName("nomic-embed-text")

--- a/src/main/java/com/devoxx/genie/service/chromadb/ChromaEmbeddingService.java
+++ b/src/main/java/com/devoxx/genie/service/chromadb/ChromaEmbeddingService.java
@@ -18,7 +18,7 @@ import org.jetbrains.annotations.TestOnly;
 @Service
 public final class ChromaEmbeddingService {
 
-    static final String EMBEDDING_MODEL_NAME = "nomic-embed-text";
+    public static final String EMBEDDING_MODEL_NAME = "nomic-embed-text";
 
     private final DevoxxGenieStateService stateService = DevoxxGenieStateService.getInstance();
 

--- a/src/main/java/com/devoxx/genie/service/chromadb/ChromaEmbeddingService.java
+++ b/src/main/java/com/devoxx/genie/service/chromadb/ChromaEmbeddingService.java
@@ -18,6 +18,8 @@ import org.jetbrains.annotations.TestOnly;
 @Service
 public final class ChromaEmbeddingService {
 
+    static final String EMBEDDING_MODEL_NAME = "nomic-embed-text";
+
     private final DevoxxGenieStateService stateService = DevoxxGenieStateService.getInstance();
 
     private EmbeddingStore<TextSegment> embeddingStore;
@@ -28,6 +30,11 @@ public final class ChromaEmbeddingService {
      */
     @Setter
     private EmbeddingModel embeddingModelOverride;
+
+    // Cached embedding model; rebuilt when the Ollama URL or model name changes.
+    private EmbeddingModel cachedEmbeddingModel;
+    private String cachedEmbeddingUrl;
+    private String cachedEmbeddingModelName;
 
     @NotNull
     public static ChromaEmbeddingService getInstance() {
@@ -64,13 +71,27 @@ public final class ChromaEmbeddingService {
                       .replaceAll("[^a-z0-9-]", "-");
     }
 
-    public EmbeddingModel getEmbeddingModel() {
+    /**
+     * Returns a cached {@link OllamaEmbeddingModel}, rebuilding it only when the configured
+     * Ollama URL or model name changes. The previous implementation built a fresh model
+     * (and underlying HTTP client) on every call, costing a setup + handshake per chunk
+     * during indexing.
+     */
+    public synchronized EmbeddingModel getEmbeddingModel() {
         if (embeddingModelOverride != null) {
             return embeddingModelOverride;
         }
-        return OllamaEmbeddingModel.builder()
-                .baseUrl(stateService.getOllamaModelUrl())
-                .modelName("nomic-embed-text")
-                .build();
+        String url = stateService.getOllamaModelUrl();
+        if (cachedEmbeddingModel == null
+                || !EMBEDDING_MODEL_NAME.equals(cachedEmbeddingModelName)
+                || url == null || !url.equals(cachedEmbeddingUrl)) {
+            cachedEmbeddingModel = OllamaEmbeddingModel.builder()
+                    .baseUrl(url)
+                    .modelName(EMBEDDING_MODEL_NAME)
+                    .build();
+            cachedEmbeddingUrl = url;
+            cachedEmbeddingModelName = EMBEDDING_MODEL_NAME;
+        }
+        return cachedEmbeddingModel;
     }
 }

--- a/src/main/java/com/devoxx/genie/service/prompt/response/nonstreaming/NonStreamingPromptExecutionService.java
+++ b/src/main/java/com/devoxx/genie/service/prompt/response/nonstreaming/NonStreamingPromptExecutionService.java
@@ -84,17 +84,18 @@ public class NonStreamingPromptExecutionService {
                 threadPoolManager.getPromptExecutionPool()
             );
 
-        // Only apply a blanket timeout for simple (non-agent, non-MCP) prompts.
-        // Agent/MCP conversations involve many HTTP round trips; each individual
-        // request already has a timeout via the Langchain4j SDK.
-        boolean isAgentOrMcp = Boolean.TRUE.equals(
-                DevoxxGenieStateService.getInstance().getAgentModeEnabled())
+        // Apply a wall-clock cap to every prompt — simple prompts use the per-request timeout,
+        // agent/MCP conversations use the (much longer) agent cap. The agent cap is a safety
+        // net against silent hangs (e.g. an MCP tool that never returns); individual HTTP
+        // round trips still have their own per-request timeouts via the Langchain4j SDK.
+        DevoxxGenieStateService settings = DevoxxGenieStateService.getInstance();
+        boolean isAgentOrMcp = Boolean.TRUE.equals(settings.getAgentModeEnabled())
                 || MCPService.isMCPEnabled();
-        if (!isAgentOrMcp) {
-            queryFuture = queryFuture.orTimeout(
-                    chatMessageContext.getTimeout() == null ? 60 : chatMessageContext.getTimeout(),
-                    TimeUnit.SECONDS);
-        }
+        long timeoutSeconds = resolveTimeoutSeconds(
+                chatMessageContext.getTimeout(),
+                isAgentOrMcp,
+                settings.getAgentMaxExecutionTimeSeconds());
+        queryFuture = queryFuture.orTimeout(timeoutSeconds, TimeUnit.SECONDS);
 
         queryFuture = queryFuture
             .thenApply(result -> {
@@ -137,6 +138,25 @@ public class NonStreamingPromptExecutionService {
         queryFutures.put(tabKey, queryFuture);
 
         return queryFuture;
+    }
+
+    /**
+     * Resolve the wall-clock cap (seconds) for a prompt's overall future.
+     *
+     * <p>Agent/MCP conversations use {@code agentCapSeconds} (default
+     * {@link com.devoxx.genie.model.Constant#AGENT_MAX_EXECUTION_SECONDS}) because they make
+     * multiple tool round-trips and the per-request HTTP timeout is not a sufficient safety
+     * net. Simple prompts use the caller's per-request {@code requestedSeconds} (default 60s).
+     *
+     * <p>Package-private for unit testing.
+     */
+    static long resolveTimeoutSeconds(Integer requestedSeconds, boolean isAgentOrMcp, Integer agentCapSeconds) {
+        if (isAgentOrMcp) {
+            return agentCapSeconds == null || agentCapSeconds <= 0
+                    ? com.devoxx.genie.model.Constant.AGENT_MAX_EXECUTION_SECONDS
+                    : agentCapSeconds;
+        }
+        return requestedSeconds == null || requestedSeconds <= 0 ? 60L : requestedSeconds;
     }
 
     /**

--- a/src/main/java/com/devoxx/genie/service/prompt/strategy/NonStreamingPromptStrategy.java
+++ b/src/main/java/com/devoxx/genie/service/prompt/strategy/NonStreamingPromptStrategy.java
@@ -189,7 +189,8 @@ public class NonStreamingPromptStrategy extends AbstractPromptExecutionStrategy 
                 SemanticSearchService semanticSearchService = SemanticSearchService.getInstance();
                 searchResults = semanticSearchService.search(
                         context.getProject(),
-                        context.getUserPrompt()
+                        context.getUserPrompt(),
+                        context.getChatModel()
                 );
 
                 if (!searchResults.isEmpty()) {

--- a/src/main/java/com/devoxx/genie/service/prompt/strategy/NonStreamingPromptStrategy.java
+++ b/src/main/java/com/devoxx/genie/service/prompt/strategy/NonStreamingPromptStrategy.java
@@ -183,9 +183,11 @@ public class NonStreamingPromptStrategy extends AbstractPromptExecutionStrategy 
             @NotNull PromptTask<PromptResult> resultTask) {
         
         threadPoolManager.getPromptExecutionPool().execute(() -> {
+            long startNanos = System.nanoTime();
+            List<SearchResult> searchResults = java.util.Collections.emptyList();
             try {
                 SemanticSearchService semanticSearchService = SemanticSearchService.getInstance();
-                List<SearchResult> searchResults = semanticSearchService.search(
+                searchResults = semanticSearchService.search(
                         context.getProject(),
                         context.getUserPrompt()
                 );
@@ -198,16 +200,20 @@ public class NonStreamingPromptStrategy extends AbstractPromptExecutionStrategy 
                 } else {
                     NotificationUtil.sendNotification(context.getProject(),
                             "No relevant files found for your search query.");
-                    resultTask.complete(PromptResult.failure(context, 
+                    resultTask.complete(PromptResult.failure(context,
                         new ExecutionException("No relevant files found")));
                 }
             } catch (Exception e) {
                 // Create a specific execution exception for semantic search errors
                 ExecutionException searchError = new ExecutionException(
-                    "Error performing semantic search", e, 
+                    "Error performing semantic search", e,
                     PromptException.ErrorSeverity.WARNING, true);
                 PromptErrorHandler.handleException(context.getProject(), searchError, context);
                 resultTask.complete(PromptResult.failure(context, searchError));
+            } finally {
+                long durationMs = (System.nanoTime() - startNanos) / 1_000_000L;
+                com.devoxx.genie.service.rag.RAGEventPublisher.publish(
+                        context.getProject(), context.getUserPrompt(), searchResults, durationMs);
             }
         });
     }

--- a/src/main/java/com/devoxx/genie/service/prompt/strategy/NonStreamingPromptStrategy.java
+++ b/src/main/java/com/devoxx/genie/service/prompt/strategy/NonStreamingPromptStrategy.java
@@ -20,7 +20,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.List;
-import java.util.Map;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -186,7 +185,7 @@ public class NonStreamingPromptStrategy extends AbstractPromptExecutionStrategy 
         threadPoolManager.getPromptExecutionPool().execute(() -> {
             try {
                 SemanticSearchService semanticSearchService = SemanticSearchService.getInstance();
-                Map<String, SearchResult> searchResults = semanticSearchService.search(
+                List<SearchResult> searchResults = semanticSearchService.search(
                         context.getProject(),
                         context.getUserPrompt()
                 );

--- a/src/main/java/com/devoxx/genie/service/rag/ChunkQualityFilter.java
+++ b/src/main/java/com/devoxx/genie/service/rag/ChunkQualityFilter.java
@@ -1,0 +1,60 @@
+package com.devoxx.genie.service.rag;
+
+/**
+ * Decides whether a freshly-split chunk carries enough information to be worth embedding and
+ * storing. The bar is intentionally low: we want to drop chunks that are dominated by
+ * structural noise (markdown table separator rows, padding-only header lines, ASCII-art
+ * dividers) while keeping every chunk that contains real prose or code — even short ones.
+ *
+ * <p>Heuristic: count distinct alphanumeric tokens of length &ge; 3. Tokens this short still
+ * carry meaning ({@code MCP}, {@code LSP}, {@code git}), so the threshold can't be raised
+ * further without losing legitimate content. Below the threshold the chunk is treated as
+ * noise — its embedding would carry little query-discriminating signal and would mostly
+ * inflate the noise floor of similarity scores.
+ *
+ * <p>This is index-time gating only; nothing downstream re-reads the dropped chunks.
+ */
+public final class ChunkQualityFilter {
+
+    /**
+     * Minimum number of distinct alphanumeric tokens (length &ge; 3) required for a chunk to
+     * be considered informative enough to embed. Calibrated against the failure mode observed
+     * in {@code agenticengineeringworkshop}: padded markdown table headers like
+     * {@code "| Field | Description |"} contain ≤2 unique tokens — well under the threshold —
+     * while even one prose sentence ("MCP is the Model Context Protocol") has 5+.
+     */
+    static final int MIN_DISTINCT_TOKENS = 5;
+
+    private ChunkQualityFilter() {} // utility
+
+    /**
+     * @return {@code true} if {@code chunk} is likely noise and should not be indexed.
+     */
+    public static boolean isLowContent(String chunk) {
+        if (chunk == null || chunk.isBlank()) return true;
+        return countDistinctMeaningfulTokens(chunk) < MIN_DISTINCT_TOKENS;
+    }
+
+    /**
+     * Count distinct lowercased alphanumeric runs of length &ge; 3. Whitespace and punctuation
+     * are token boundaries; case is folded so {@code "Field"} and {@code "field"} don't both
+     * count toward the threshold. Visible for tests.
+     */
+    static int countDistinctMeaningfulTokens(String chunk) {
+        java.util.HashSet<String> seen = new java.util.HashSet<>();
+        int n = chunk.length();
+        int start = -1;
+        for (int i = 0; i < n; i++) {
+            char c = chunk.charAt(i);
+            boolean alnum = (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9');
+            if (alnum) {
+                if (start < 0) start = i;
+            } else if (start >= 0) {
+                if (i - start >= 3) seen.add(chunk.substring(start, i).toLowerCase());
+                start = -1;
+            }
+        }
+        if (start >= 0 && n - start >= 3) seen.add(chunk.substring(start).toLowerCase());
+        return seen.size();
+    }
+}

--- a/src/main/java/com/devoxx/genie/service/rag/IndexerConstants.java
+++ b/src/main/java/com/devoxx/genie/service/rag/IndexerConstants.java
@@ -5,5 +5,19 @@ public final class IndexerConstants {
     public static final String FILE_PATH = "filePath";
     public static final String LAST_MODIFIED = "lastModified";
 
+    /**
+     * Stored on every segment so the indexer can detect — and ignore — entries written by
+     * older, buggy versions of the pipeline. Bump this when the storage format or the
+     * embedding semantics change in a non-backwards-compatible way.
+     *
+     * <p>History:
+     * <ul>
+     *   <li>(unversioned, pre-v2): embedded file paths instead of segment content — unusable for retrieval</li>
+     *   <li>v2: embed segment content; per-chunk results; metadata filter for index lookup</li>
+     * </ul>
+     */
+    public static final String EMBEDDING_SCHEMA_VERSION_KEY = "embeddingSchemaVersion";
+    public static final String CURRENT_EMBEDDING_SCHEMA_VERSION = "v2";
+
     private IndexerConstants() {} // Prevent instantiation
 }

--- a/src/main/java/com/devoxx/genie/service/rag/ProjectIndexerService.java
+++ b/src/main/java/com/devoxx/genie/service/rag/ProjectIndexerService.java
@@ -368,13 +368,21 @@ public final class ProjectIndexerService {
             String absolutePath = path.toAbsolutePath().toString();
 
             List<TextSegment> segments = new ArrayList<>(rawSegments.size());
+            int dropped = 0;
             for (TextSegment segment : rawSegments) {
+                if (ChunkQualityFilter.isLowContent(segment.text())) {
+                    dropped++;
+                    continue;
+                }
                 Metadata metadata = new Metadata();
                 metadata.put(FILE_PATH, absolutePath);
                 metadata.put(LAST_MODIFIED, lastModified);
                 metadata.put(INDEXED_AT, indexedAt);
                 metadata.put(EMBEDDING_SCHEMA_VERSION_KEY, CURRENT_EMBEDDING_SCHEMA_VERSION);
                 segments.add(new TextSegment(segment.text(), metadata));
+            }
+            if (dropped > 0) {
+                log.debug("Dropped {} low-content chunk(s) from {}", dropped, path);
             }
 
             storeSegments(segments);

--- a/src/main/java/com/devoxx/genie/service/rag/ProjectIndexerService.java
+++ b/src/main/java/com/devoxx/genie/service/rag/ProjectIndexerService.java
@@ -3,6 +3,9 @@ package com.devoxx.genie.service.rag;
 import com.devoxx.genie.model.ScanContentResult;
 import com.devoxx.genie.service.chromadb.ChromaEmbeddingService;
 import com.devoxx.genie.service.projectscanner.ProjectScannerService;
+import com.devoxx.genie.service.rag.manifest.IndexManifest;
+import com.devoxx.genie.service.rag.manifest.IndexManifestService;
+import com.devoxx.genie.service.rag.manifest.InMemoryIndexManifest;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.components.Service;
 import com.intellij.openapi.project.Project;
@@ -15,11 +18,9 @@ import dev.langchain4j.data.document.splitter.DocumentSplitters;
 import dev.langchain4j.data.embedding.Embedding;
 import dev.langchain4j.data.segment.TextSegment;
 import dev.langchain4j.model.embedding.EmbeddingModel;
-import dev.langchain4j.store.embedding.EmbeddingSearchRequest;
-import dev.langchain4j.store.embedding.filter.Filter;
-import dev.langchain4j.store.embedding.filter.MetadataFilterBuilder;
 import lombok.extern.slf4j.Slf4j;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.TestOnly;
 
 import javax.swing.*;
 import java.io.IOException;
@@ -40,17 +41,21 @@ public final class ProjectIndexerService {
     /** Chunk overlap in tokens; non-zero so a symbol straddling a boundary isn't lost. */
     static final int CHUNK_OVERLAP_TOKENS = 50;
 
-    /** Constant string used as the query for metadata-filter-only lookups. We embed it once
-     *  per (model instance) and reuse, since EmbeddingSearchRequest requires a query embedding
-     *  even when only the filter does the work. */
-    private static final String LOOKUP_PROBE_TEXT = "__devoxxgenie_lookup__";
+    /** Max segments per Ollama {@code embedAll} call. Keeps individual requests small enough
+     *  to avoid timeouts while still avoiding the N+1 cost of one-call-per-segment. */
+    static final int EMBEDDING_BATCH_SIZE = 64;
 
     private final ChromaEmbeddingService chromaEmbeddingService;
     private final ProjectScannerService projectScannerService;
 
     private DocumentSplitter documentSplitter;
-    private Embedding cachedLookupProbe;
-    private EmbeddingModel cachedLookupProbeOwner;
+
+    /**
+     * Source of truth for which files are indexed under the current schema. Defaults to a
+     * process-local in-memory manifest so tests work without filesystem setup; production
+     * flows swap in the per-project JSON-backed manifest via {@link #indexFiles}.
+     */
+    private IndexManifest manifest = new InMemoryIndexManifest();
 
     // Flag to indicate if indexing should be cancelled
     private final AtomicBoolean cancelIndexing = new AtomicBoolean(false);
@@ -85,46 +90,9 @@ public final class ProjectIndexerService {
         return documentSplitter;
     }
 
-    /**
-     * Check whether the given file already has at least one segment stored under the current
-     * schema, and that the stored mtime matches the file on disk. Uses a metadata filter on
-     * {@link IndexerConstants#FILE_PATH} rather than vector similarity — the latter only worked
-     * by accident under the pre-v2 schema that (incorrectly) embedded file paths.
-     */
-    private boolean isFileIndexed(Path filePath) {
-        try {
-            String absolutePath = filePath.toAbsolutePath().toString();
-            Filter filter = MetadataFilterBuilder.metadataKey(FILE_PATH).isEqualTo(absolutePath)
-                    .and(MetadataFilterBuilder.metadataKey(EMBEDDING_SCHEMA_VERSION_KEY)
-                            .isEqualTo(CURRENT_EMBEDDING_SCHEMA_VERSION));
-            var results = chromaEmbeddingService.getEmbeddingStore().search(EmbeddingSearchRequest.builder()
-                    .queryEmbedding(lookupProbe())
-                    .filter(filter)
-                    .maxResults(1)
-                    .minScore(0.0)
-                    .build());
-            if (results.matches().isEmpty()) {
-                return false;
-            }
-            return !hasFileChanged(filePath, results.matches().get(0).embedded().metadata());
-        } catch (Exception e) {
-            log.warn("Error checking file index status: {}", e.getMessage());
-            return false;
-        }
-    }
-
-    /**
-     * EmbeddingSearchRequest requires a non-null query embedding even when results are
-     * narrowed exclusively by metadata filter. We cache the probe embedding per embedding-model
-     * instance so the lookup cost is O(1) rather than one Ollama roundtrip per file.
-     */
-    private Embedding lookupProbe() {
-        EmbeddingModel current = chromaEmbeddingService.getEmbeddingModel();
-        if (cachedLookupProbe == null || cachedLookupProbeOwner != current) {
-            cachedLookupProbe = current.embed(LOOKUP_PROBE_TEXT).content();
-            cachedLookupProbeOwner = current;
-        }
-        return cachedLookupProbe;
+    @TestOnly
+    public void setManifest(@NotNull IndexManifest manifest) {
+        this.manifest = manifest;
     }
 
     public void indexFiles(Project project,
@@ -148,6 +116,7 @@ public final class ProjectIndexerService {
         }
 
         chromaEmbeddingService.init(project);
+        this.manifest = IndexManifestService.getInstance().forProject(project);
 
         String basePath = project.getBasePath();
         if (basePath == null) {
@@ -165,76 +134,65 @@ public final class ProjectIndexerService {
         List<Path> filesToProcess = new ArrayList<>(scanResult.getFiles());
         int totalFiles = filesToProcess.size();
 
-        for (int fileIndex = 0; fileIndex < totalFiles; fileIndex++) {
-            if (isIndexingCancelled()) {
-                log.info("Indexing cancelled after processing {} of {} files", fileIndex, totalFiles);
-                final int processedFiles = fileIndex;
+        try {
+            for (int fileIndex = 0; fileIndex < totalFiles; fileIndex++) {
+                if (isIndexingCancelled()) {
+                    log.info("Indexing cancelled after processing {} of {} files", fileIndex, totalFiles);
+                    final int processedFiles = fileIndex;
+                    SwingUtilities.invokeLater(() -> {
+                        progressBar.setValue(100);
+                        progressLabel.setText(String.format("Indexing cancelled after processing %d of %d files",
+                                processedFiles, totalFiles));
+                    });
+                    return;
+                }
+
+                Path path = filesToProcess.get(fileIndex);
+                String fileName = path.getFileName().toString();
+                int progress = (int) (((double) (fileIndex + 1) / totalFiles) * 100);
+                final int currentFileIndex = fileIndex;
+
                 SwingUtilities.invokeLater(() -> {
-                    progressBar.setValue(100);
-                    progressLabel.setText(String.format("Indexing cancelled after processing %d of %d files",
-                            processedFiles, totalFiles));
+                    progressBar.setVisible(true);
+                    progressLabel.setVisible(true);
+                    progressBar.setValue(progress);
+                    progressLabel.setText(String.format("Processing %d of %d: %s", currentFileIndex + 1, totalFiles, fileName));
                 });
-                return;
+
+                indexFile(path, forceReindex);
             }
-
-            Path path = filesToProcess.get(fileIndex);
-            String fileName = path.getFileName().toString();
-            int progress = (int) (((double) (fileIndex + 1) / totalFiles) * 100);
-            final int currentFileIndex = fileIndex;
-
-            SwingUtilities.invokeLater(() -> {
-                progressBar.setVisible(true);
-                progressLabel.setVisible(true);
-                progressBar.setValue(progress);
-                progressLabel.setText(String.format("Processing %d of %d: %s", currentFileIndex + 1, totalFiles, fileName));
-            });
-
-            indexFile(path, forceReindex);
+        } finally {
+            manifest.flush();
+            resetCancellationFlag();
         }
-
-        resetCancellationFlag();
     }
 
     /**
-     * Index a single file: skip if already up-to-date under the current schema, otherwise
-     * split, embed, and store each chunk. Exposed for tests and for future incremental flows
-     * (e.g. a {@code BulkFileListener}).
+     * Index a single file: skip if the content hash already matches what's recorded in the
+     * manifest, otherwise split, embed, and store each chunk. Exposed for tests and for
+     * future incremental flows (e.g. a {@code BulkFileListener}).
      */
     public void indexFile(Path filePath) {
         indexFile(filePath, false);
+        manifest.flush();
     }
 
     private void indexFile(Path filePath, boolean forceReindex) {
         log.debug("Indexing file: {}", filePath);
         try {
-            if (!forceReindex && isFileIndexed(filePath)) {
-                log.debug("File already indexed: {}", filePath);
+            if (!forceReindex && manifest.isCurrent(filePath)) {
+                log.debug("File already indexed (content hash matches): {}", filePath);
                 return;
             }
-            processPath(filePath);
-            log.debug("File successfully indexed: {}", filePath);
+            int segmentCount = processPath(filePath);
+            if (segmentCount > 0) {
+                manifest.markIndexed(filePath, segmentCount);
+                log.debug("File successfully indexed ({} segments): {}", segmentCount, filePath);
+            }
         } catch (Exception e) {
             log.warn("Error indexing file: {} - {}", filePath, e.getMessage());
         }
     }
-
-    private boolean hasFileChanged(Path filePath, @NotNull Metadata storedMetadata) {
-        try {
-            long currentLastModified = Files.getLastModifiedTime(filePath).toMillis();
-            if (!storedMetadata.containsKey(LAST_MODIFIED)) {
-                return true;
-            }
-            Long storedLastModified = storedMetadata.getLong(LAST_MODIFIED);
-            if (storedLastModified == null) return false;
-            return currentLastModified > storedLastModified;
-        } catch (IOException e) {
-            return true; // If we can't check, assume it changed
-        }
-    }
-
-    /** Max segments per Ollama {@code embedAll} call. Keeps individual requests small enough
-     *  to avoid timeouts while still avoiding the N+1 cost of one-call-per-segment. */
-    static final int EMBEDDING_BATCH_SIZE = 64;
 
     /**
      * Embed and store a batch of segments in one shot. The previous implementation made
@@ -268,13 +226,14 @@ public final class ProjectIndexerService {
         }
     }
 
-    private void processPath(Path path) {
+    /** Returns the number of segments stored for this file (0 if blank / unreadable). */
+    private int processPath(Path path) {
         try {
             log.debug("Processing file: {}", path);
 
             String content = Files.readString(path);
             if (content.isBlank()) {
-                return;
+                return 0;
             }
 
             Document document = Document.from(content);
@@ -294,8 +253,10 @@ public final class ProjectIndexerService {
             }
 
             storeSegments(segments);
+            return segments.size();
         } catch (IOException e) {
             log.warn("Error processing file: {}", path);
+            return 0;
         }
     }
 }

--- a/src/main/java/com/devoxx/genie/service/rag/ProjectIndexerService.java
+++ b/src/main/java/com/devoxx/genie/service/rag/ProjectIndexerService.java
@@ -18,6 +18,8 @@ import dev.langchain4j.data.document.splitter.DocumentSplitters;
 import dev.langchain4j.data.embedding.Embedding;
 import dev.langchain4j.data.segment.TextSegment;
 import dev.langchain4j.model.embedding.EmbeddingModel;
+import dev.langchain4j.store.embedding.filter.Filter;
+import dev.langchain4j.store.embedding.filter.MetadataFilterBuilder;
 import lombok.extern.slf4j.Slf4j;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.TestOnly;
@@ -27,6 +29,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -175,6 +178,63 @@ public final class ProjectIndexerService {
     public void indexFile(Path filePath) {
         indexFile(filePath, false);
         manifest.flush();
+    }
+
+    /**
+     * Re-index a set of files belonging to {@code project}. Wraps the manifest swap +
+     * per-file processing + flush in one call so callers (notably the file watcher) don't
+     * have to know about manifest plumbing. Skips files the manifest has never seen — new
+     * files require a manual full re-index so a casual edit can't bootstrap an unindexed
+     * tree of generated/binary/excluded content.
+     */
+    public void reindexFiles(@NotNull Project project, @NotNull Collection<Path> files) {
+        if (files.isEmpty()) return;
+        chromaEmbeddingService.init(project);
+        this.manifest = IndexManifestService.getInstance().forProject(project);
+        try {
+            for (Path file : files) {
+                if (!manifest.isTracked(file)) continue;
+                // Drop any existing chunks for this file before re-embedding, otherwise edits
+                // accumulate stale chunks alongside fresh ones.
+                removeChunksFromStore(file);
+                indexFile(file, true);
+            }
+        } finally {
+            manifest.flush();
+        }
+    }
+
+    /**
+     * Remove the given files from the vector store and the manifest. Called by the file
+     * watcher on delete events so the index doesn't keep returning chunks for files that
+     * no longer exist on disk.
+     */
+    public void removeFiles(@NotNull Project project, @NotNull Collection<Path> files) {
+        if (files.isEmpty()) return;
+        chromaEmbeddingService.init(project);
+        this.manifest = IndexManifestService.getInstance().forProject(project);
+        try {
+            for (Path file : files) {
+                if (!manifest.isTracked(file)) continue;
+                removeChunksFromStore(file);
+                manifest.markRemoved(file);
+            }
+        } finally {
+            manifest.flush();
+        }
+    }
+
+    private void removeChunksFromStore(@NotNull Path file) {
+        try {
+            Filter filter = MetadataFilterBuilder.metadataKey(FILE_PATH)
+                    .isEqualTo(file.toAbsolutePath().toString());
+            chromaEmbeddingService.getEmbeddingStore().removeAll(filter);
+        } catch (Exception e) {
+            // EmbeddingStore.removeAll(Filter) is a default method and a few legacy stores
+            // throw UnsupportedOperationException. Log and continue — at worst we leave stale
+            // chunks until the next full reindex.
+            log.warn("Could not remove existing chunks for {}: {}", file, e.getMessage());
+        }
     }
 
     private void indexFile(Path filePath, boolean forceReindex) {

--- a/src/main/java/com/devoxx/genie/service/rag/ProjectIndexerService.java
+++ b/src/main/java/com/devoxx/genie/service/rag/ProjectIndexerService.java
@@ -40,10 +40,17 @@ public final class ProjectIndexerService {
     /** Chunk overlap in tokens; non-zero so a symbol straddling a boundary isn't lost. */
     static final int CHUNK_OVERLAP_TOKENS = 50;
 
+    /** Constant string used as the query for metadata-filter-only lookups. We embed it once
+     *  per (model instance) and reuse, since EmbeddingSearchRequest requires a query embedding
+     *  even when only the filter does the work. */
+    private static final String LOOKUP_PROBE_TEXT = "__devoxxgenie_lookup__";
+
     private final ChromaEmbeddingService chromaEmbeddingService;
     private final ProjectScannerService projectScannerService;
 
     private DocumentSplitter documentSplitter;
+    private Embedding cachedLookupProbe;
+    private EmbeddingModel cachedLookupProbeOwner;
 
     // Flag to indicate if indexing should be cancelled
     private final AtomicBoolean cancelIndexing = new AtomicBoolean(false);
@@ -90,11 +97,8 @@ public final class ProjectIndexerService {
             Filter filter = MetadataFilterBuilder.metadataKey(FILE_PATH).isEqualTo(absolutePath)
                     .and(MetadataFilterBuilder.metadataKey(EMBEDDING_SCHEMA_VERSION_KEY)
                             .isEqualTo(CURRENT_EMBEDDING_SCHEMA_VERSION));
-            // EmbeddingSearchRequest requires a query embedding even when filtering; pick the
-            // cheapest possible probe and rely on the filter to do the work.
-            Embedding probe = chromaEmbeddingService.getEmbeddingModel().embed("__lookup__").content();
             var results = chromaEmbeddingService.getEmbeddingStore().search(EmbeddingSearchRequest.builder()
-                    .queryEmbedding(probe)
+                    .queryEmbedding(lookupProbe())
                     .filter(filter)
                     .maxResults(1)
                     .minScore(0.0)
@@ -107,6 +111,20 @@ public final class ProjectIndexerService {
             log.warn("Error checking file index status: {}", e.getMessage());
             return false;
         }
+    }
+
+    /**
+     * EmbeddingSearchRequest requires a non-null query embedding even when results are
+     * narrowed exclusively by metadata filter. We cache the probe embedding per embedding-model
+     * instance so the lookup cost is O(1) rather than one Ollama roundtrip per file.
+     */
+    private Embedding lookupProbe() {
+        EmbeddingModel current = chromaEmbeddingService.getEmbeddingModel();
+        if (cachedLookupProbe == null || cachedLookupProbeOwner != current) {
+            cachedLookupProbe = current.embed(LOOKUP_PROBE_TEXT).content();
+            cachedLookupProbeOwner = current;
+        }
+        return cachedLookupProbe;
     }
 
     public void indexFiles(Project project,
@@ -214,15 +232,40 @@ public final class ProjectIndexerService {
         }
     }
 
+    /** Max segments per Ollama {@code embedAll} call. Keeps individual requests small enough
+     *  to avoid timeouts while still avoiding the N+1 cost of one-call-per-segment. */
+    static final int EMBEDDING_BATCH_SIZE = 64;
+
     /**
-     * Embed and store a single segment. Embeds the SEGMENT CONTENT — earlier versions
-     * embedded the file path string here, which made the entire vector index useless
-     * for content-based retrieval.
+     * Embed and store a batch of segments in one shot. The previous implementation made
+     * one HTTP call to Ollama per segment, turning a 200-chunk file into 200 sequential
+     * roundtrips. Embedding in batches and using {@code addAll} on the store collapses
+     * that to {@code ceil(N / EMBEDDING_BATCH_SIZE)} calls and one store write per batch.
      */
-    private void storeSegment(@NotNull TextSegment segment) {
+    private void storeSegments(@NotNull List<TextSegment> segments) {
+        if (segments.isEmpty()) return;
         EmbeddingModel embeddingModel = chromaEmbeddingService.getEmbeddingModel();
-        Embedding embedding = embeddingModel.embed(segment.text()).content();
-        chromaEmbeddingService.getEmbeddingStore().add(embedding, segment);
+        for (int from = 0; from < segments.size(); from += EMBEDDING_BATCH_SIZE) {
+            int to = Math.min(from + EMBEDDING_BATCH_SIZE, segments.size());
+            List<TextSegment> batch = segments.subList(from, to);
+            try {
+                List<Embedding> embeddings = embeddingModel.embedAll(batch).content();
+                chromaEmbeddingService.getEmbeddingStore().addAll(embeddings, batch);
+            } catch (Exception batchEx) {
+                // Some embedding backends choke on a single bad segment and reject the whole
+                // batch. Fall back to per-segment so one malformed chunk doesn't poison the
+                // rest of the file.
+                log.warn("Batch embed failed ({}); falling back to per-segment for this batch", batchEx.getMessage());
+                for (TextSegment segment : batch) {
+                    try {
+                        Embedding embedding = embeddingModel.embed(segment.text()).content();
+                        chromaEmbeddingService.getEmbeddingStore().add(embedding, segment);
+                    } catch (Exception singleEx) {
+                        log.warn("Skipping segment that failed to embed: {}", singleEx.getMessage());
+                    }
+                }
+            }
+        }
     }
 
     private void processPath(Path path) {
@@ -235,19 +278,22 @@ public final class ProjectIndexerService {
             }
 
             Document document = Document.from(content);
-            List<TextSegment> segments = splitter().split(document);
+            List<TextSegment> rawSegments = splitter().split(document);
             long lastModified = Files.getLastModifiedTime(path).toMillis();
             long indexedAt = System.currentTimeMillis();
             String absolutePath = path.toAbsolutePath().toString();
 
-            for (TextSegment segment : segments) {
+            List<TextSegment> segments = new ArrayList<>(rawSegments.size());
+            for (TextSegment segment : rawSegments) {
                 Metadata metadata = new Metadata();
                 metadata.put(FILE_PATH, absolutePath);
                 metadata.put(LAST_MODIFIED, lastModified);
                 metadata.put(INDEXED_AT, indexedAt);
                 metadata.put(EMBEDDING_SCHEMA_VERSION_KEY, CURRENT_EMBEDDING_SCHEMA_VERSION);
-                storeSegment(new TextSegment(segment.text(), metadata));
+                segments.add(new TextSegment(segment.text(), metadata));
             }
+
+            storeSegments(segments);
         } catch (IOException e) {
             log.warn("Error processing file: {}", path);
         }

--- a/src/main/java/com/devoxx/genie/service/rag/ProjectIndexerService.java
+++ b/src/main/java/com/devoxx/genie/service/rag/ProjectIndexerService.java
@@ -14,9 +14,10 @@ import dev.langchain4j.data.document.Metadata;
 import dev.langchain4j.data.document.splitter.DocumentSplitters;
 import dev.langchain4j.data.embedding.Embedding;
 import dev.langchain4j.data.segment.TextSegment;
-import dev.langchain4j.model.ollama.OllamaEmbeddingModel;
-import dev.langchain4j.store.embedding.EmbeddingMatch;
+import dev.langchain4j.model.embedding.EmbeddingModel;
 import dev.langchain4j.store.embedding.EmbeddingSearchRequest;
+import dev.langchain4j.store.embedding.filter.Filter;
+import dev.langchain4j.store.embedding.filter.MetadataFilterBuilder;
 import lombok.extern.slf4j.Slf4j;
 import org.jetbrains.annotations.NotNull;
 
@@ -24,7 +25,6 @@ import javax.swing.*;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -34,12 +34,17 @@ import static com.devoxx.genie.service.rag.IndexerConstants.*;
 @Slf4j
 @Service
 public final class ProjectIndexerService {
-    
+
+    /** Chunk size in tokens for the recursive splitter. */
+    static final int CHUNK_SIZE_TOKENS = 500;
+    /** Chunk overlap in tokens; non-zero so a symbol straddling a boundary isn't lost. */
+    static final int CHUNK_OVERLAP_TOKENS = 50;
+
     private final ChromaEmbeddingService chromaEmbeddingService;
     private final ProjectScannerService projectScannerService;
 
     private DocumentSplitter documentSplitter;
-    
+
     // Flag to indicate if indexing should be cancelled
     private final AtomicBoolean cancelIndexing = new AtomicBoolean(false);
 
@@ -52,86 +57,52 @@ public final class ProjectIndexerService {
         this.chromaEmbeddingService = ChromaEmbeddingService.getInstance();
         this.projectScannerService = ProjectScannerService.getInstance();
     }
-    
-    /**
-     * Cancels the current indexing process if one is running.
-     * The indexing process will stop at the next file boundary.
-     */
+
     public void cancelIndexing() {
         cancelIndexing.set(true);
         log.info("Indexing cancellation requested");
     }
-    
-    /**
-     * Checks if indexing is currently being cancelled.
-     * @return true if indexing is being cancelled, false otherwise
-     */
+
     public boolean isIndexingCancelled() {
         return cancelIndexing.get();
     }
-    
-    /**
-     * Resets the cancellation flag to allow future indexing operations.
-     */
+
     public void resetCancellationFlag() {
         cancelIndexing.set(false);
     }
 
-    /**
-     * Check if a project is already indexed by searching for a unique hash in metadata.
-     *
-     * @param projectPath Path to the project directory
-     * @return true if project is indexed, false otherwise
-     */
-    private boolean isProjectIndexed(String projectPath) {
-        try {
-            // Create a unique project identifier (hash) based on path and last modified time
-            String projectHash = createProjectHash(projectPath);
-
-            OllamaEmbeddingModel embeddingModel = chromaEmbeddingService.getEmbeddingModel();
-
-            if (embeddingModel == null) {
-                log.warn("Ollama embedding model is not available");
-                return false;
-            }
-
-            // Search for the project hash in metadata
-            Embedding hashEmbedding = embeddingModel.embed(projectHash).content();
-            var results = chromaEmbeddingService.getEmbeddingStore().search(EmbeddingSearchRequest.builder()
-                    .queryEmbedding(hashEmbedding)
-                    .maxResults(1)
-                    .minScore(0.99) // High threshold for exact match
-                    .build());
-
-            return !results.matches().isEmpty();
-        } catch (Exception e) {
-            log.warn("Error checking project index status: {}", e.getMessage());
-            return false;
+    private DocumentSplitter splitter() {
+        if (documentSplitter == null) {
+            documentSplitter = DocumentSplitters.recursive(CHUNK_SIZE_TOKENS, CHUNK_OVERLAP_TOKENS);
         }
+        return documentSplitter;
     }
 
     /**
-     * Check if a file is already indexed by comparing its embedding with stored embeddings.
-     *
-     * @param filePath Path to the file
-     * @return true if file is indexed, false otherwise
+     * Check whether the given file already has at least one segment stored under the current
+     * schema, and that the stored mtime matches the file on disk. Uses a metadata filter on
+     * {@link IndexerConstants#FILE_PATH} rather than vector similarity — the latter only worked
+     * by accident under the pre-v2 schema that (incorrectly) embedded file paths.
      */
     private boolean isFileIndexed(Path filePath) {
         try {
-            String fileIdentifier = filePath.toAbsolutePath().toString();
-            Embedding fileEmbedding = chromaEmbeddingService.getEmbeddingModel().embed(fileIdentifier).content();
-            var results = chromaEmbeddingService.getEmbeddingStore().search(EmbeddingSearchRequest
-                    .builder()
-                    .queryEmbedding(fileEmbedding)
+            String absolutePath = filePath.toAbsolutePath().toString();
+            Filter filter = MetadataFilterBuilder.metadataKey(FILE_PATH).isEqualTo(absolutePath)
+                    .and(MetadataFilterBuilder.metadataKey(EMBEDDING_SCHEMA_VERSION_KEY)
+                            .isEqualTo(CURRENT_EMBEDDING_SCHEMA_VERSION));
+            // EmbeddingSearchRequest requires a query embedding even when filtering; pick the
+            // cheapest possible probe and rely on the filter to do the work.
+            Embedding probe = chromaEmbeddingService.getEmbeddingModel().embed("__lookup__").content();
+            var results = chromaEmbeddingService.getEmbeddingStore().search(EmbeddingSearchRequest.builder()
+                    .queryEmbedding(probe)
+                    .filter(filter)
                     .maxResults(1)
-                    .minScore(0.99)
+                    .minScore(0.0)
                     .build());
             if (results.matches().isEmpty()) {
                 return false;
             }
-            List<EmbeddingMatch<TextSegment>> matches = results.matches();
-            TextSegment storedSegment = matches.get(0).embedded();
-            return !hasFileChanged(filePath, storedSegment.metadata());
+            return !hasFileChanged(filePath, results.matches().get(0).embedded().metadata());
         } catch (Exception e) {
             log.warn("Error checking file index status: {}", e.getMessage());
             return false;
@@ -142,18 +113,14 @@ public final class ProjectIndexerService {
                            boolean forceReindex,
                            JProgressBar progressBar,
                            JLabel progressLabel) {
-        // Reset cancellation flag at the start of indexing
         resetCancellationFlag();
-        
-        // Initialize progress UI
+
         if (SwingUtilities.isEventDispatchThread()) {
-            // If we're already on the EDT, update directly
             progressBar.setValue(0);
             progressBar.setVisible(true);
             progressLabel.setText("Initializing indexing process...");
             progressLabel.setVisible(true);
         } else {
-            // Otherwise, use invokeLater
             SwingUtilities.invokeLater(() -> {
                 progressBar.setValue(0);
                 progressBar.setVisible(true);
@@ -161,18 +128,12 @@ public final class ProjectIndexerService {
                 progressLabel.setVisible(true);
             });
         }
-        
+
         chromaEmbeddingService.init(project);
-        documentSplitter = DocumentSplitters.recursive(500, 0);
 
         String basePath = project.getBasePath();
         if (basePath == null) {
             log.warn("Project base path is null");
-            return;
-        }
-
-        if (!forceReindex && isProjectIndexed(basePath)) {
-            log.warn("Project is already indexed, skipping indexing process");
             return;
         }
 
@@ -182,82 +143,70 @@ public final class ProjectIndexerService {
             return;
         }
 
-        // Use synchronous project scanning
         ScanContentResult scanResult = projectScannerService.scanProject(project, baseDir, Integer.MAX_VALUE, false);
         List<Path> filesToProcess = new ArrayList<>(scanResult.getFiles());
         int totalFiles = filesToProcess.size();
 
-        // Process each file sequentially
         for (int fileIndex = 0; fileIndex < totalFiles; fileIndex++) {
-            // Check if indexing has been cancelled
             if (isIndexingCancelled()) {
                 log.info("Indexing cancelled after processing {} of {} files", fileIndex, totalFiles);
-                
-                // Update UI to show cancellation
                 final int processedFiles = fileIndex;
                 SwingUtilities.invokeLater(() -> {
-                    progressBar.setValue(100); // Set to 100% to indicate completion
-                    progressLabel.setText(String.format("Indexing cancelled after processing %d of %d files", 
-                                                       processedFiles, totalFiles));
+                    progressBar.setValue(100);
+                    progressLabel.setText(String.format("Indexing cancelled after processing %d of %d files",
+                            processedFiles, totalFiles));
                 });
-                
                 return;
             }
-            
+
             Path path = filesToProcess.get(fileIndex);
             String fileName = path.getFileName().toString();
             int progress = (int) (((double) (fileIndex + 1) / totalFiles) * 100);
             final int currentFileIndex = fileIndex;
-            
-            // Update progress UI and ensure it's visible
+
             SwingUtilities.invokeLater(() -> {
                 progressBar.setVisible(true);
                 progressLabel.setVisible(true);
                 progressBar.setValue(progress);
                 progressLabel.setText(String.format("Processing %d of %d: %s", currentFileIndex + 1, totalFiles, fileName));
             });
-            
-            // Process the file without waiting for UI update to complete
-            indexSingleFile(path);
+
+            indexFile(path, forceReindex);
         }
-        
-        // Reset cancellation flag after successful completion
+
         resetCancellationFlag();
     }
 
     /**
-     * Index a single file by checking if it is already indexed and processing the content.
-     * @param filePath Path to the file to index
+     * Index a single file: skip if already up-to-date under the current schema, otherwise
+     * split, embed, and store each chunk. Exposed for tests and for future incremental flows
+     * (e.g. a {@code BulkFileListener}).
      */
-    private void indexSingleFile(Path filePath) {
+    public void indexFile(Path filePath) {
+        indexFile(filePath, false);
+    }
+
+    private void indexFile(Path filePath, boolean forceReindex) {
         log.debug("Indexing file: {}", filePath);
         try {
-            if (isFileIndexed(filePath)) {
+            if (!forceReindex && isFileIndexed(filePath)) {
                 log.debug("File already indexed: {}", filePath);
                 return;
             }
-
             processPath(filePath);
             log.debug("File successfully indexed: {}", filePath);
         } catch (Exception e) {
-            log.warn("Error indexing file: {} - {}",  filePath, e.getMessage());
+            log.warn("Error indexing file: {} - {}", filePath, e.getMessage());
         }
-    }
-
-    @NotNull
-    private String createProjectHash(String projectPath) throws IOException {
-        Path path = Paths.get(projectPath);
-        long lastModified = Files.getLastModifiedTime(path).toMillis();
-        return projectPath + "_" + lastModified;
     }
 
     private boolean hasFileChanged(Path filePath, @NotNull Metadata storedMetadata) {
         try {
             long currentLastModified = Files.getLastModifiedTime(filePath).toMillis();
-            if (!storedMetadata.containsKey("lastModified")) {
+            if (!storedMetadata.containsKey(LAST_MODIFIED)) {
                 return true;
             }
-            Long storedLastModified = storedMetadata.getLong("lastModified");
+            Long storedLastModified = storedMetadata.getLong(LAST_MODIFIED);
             if (storedLastModified == null) return false;
             return currentLastModified > storedLastModified;
         } catch (IOException e) {
@@ -265,25 +214,15 @@ public final class ProjectIndexerService {
         }
     }
 
-    @NotNull
-    private String createFileIdentifier(@NotNull Path filePath) {
-        return filePath.toAbsolutePath().toString();
-    }
-
     /**
-     * Mark a file as indexed by storing its metadata and embedding in the database.
-     *
-     * @param filePath Path to the file
-     * @param segment  Text segment containing metadata
+     * Embed and store a single segment. Embeds the SEGMENT CONTENT — earlier versions
+     * embedded the file path string here, which made the entire vector index useless
+     * for content-based retrieval.
      */
-    private void markFileAsIndexed(Path filePath, TextSegment segment) {
-        try {
-            String fileIdentifier = createFileIdentifier(filePath);
-            Embedding embedding = chromaEmbeddingService.getEmbeddingModel().embed(fileIdentifier).content();
-            chromaEmbeddingService.getEmbeddingStore().add(embedding, segment);
-        } catch (Exception e) {
-            log.warn("Error marking file as indexed: {}", e.getMessage());
-        }
+    private void storeSegment(@NotNull TextSegment segment) {
+        EmbeddingModel embeddingModel = chromaEmbeddingService.getEmbeddingModel();
+        Embedding embedding = embeddingModel.embed(segment.text()).content();
+        chromaEmbeddingService.getEmbeddingStore().add(embedding, segment);
     }
 
     private void processPath(Path path) {
@@ -296,17 +235,19 @@ public final class ProjectIndexerService {
             }
 
             Document document = Document.from(content);
-            List<TextSegment> segments = documentSplitter.split(document);
+            List<TextSegment> segments = splitter().split(document);
+            long lastModified = Files.getLastModifiedTime(path).toMillis();
+            long indexedAt = System.currentTimeMillis();
+            String absolutePath = path.toAbsolutePath().toString();
 
             for (TextSegment segment : segments) {
-                log.debug("Segment: {}", segment.text());
                 Metadata metadata = new Metadata();
-                metadata.put(FILE_PATH, path.toString());
-                metadata.put(LAST_MODIFIED, Files.getLastModifiedTime(path).toMillis());
-                metadata.put(INDEXED_AT, System.currentTimeMillis());
-                markFileAsIndexed(path, new TextSegment(segment.text(), metadata));
+                metadata.put(FILE_PATH, absolutePath);
+                metadata.put(LAST_MODIFIED, lastModified);
+                metadata.put(INDEXED_AT, indexedAt);
+                metadata.put(EMBEDDING_SCHEMA_VERSION_KEY, CURRENT_EMBEDDING_SCHEMA_VERSION);
+                storeSegment(new TextSegment(segment.text(), metadata));
             }
-
         } catch (IOException e) {
             log.warn("Error processing file: {}", path);
         }

--- a/src/main/java/com/devoxx/genie/service/rag/ProjectIndexerService.java
+++ b/src/main/java/com/devoxx/genie/service/rag/ProjectIndexerService.java
@@ -14,6 +14,8 @@ import com.intellij.openapi.vfs.VirtualFile;
 import dev.langchain4j.data.document.Document;
 import dev.langchain4j.data.document.DocumentSplitter;
 import dev.langchain4j.data.document.Metadata;
+import dev.langchain4j.data.document.splitter.DocumentByLineSplitter;
+import dev.langchain4j.data.document.splitter.DocumentByParagraphSplitter;
 import dev.langchain4j.data.document.splitter.DocumentSplitters;
 import dev.langchain4j.data.embedding.Embedding;
 import dev.langchain4j.data.segment.TextSegment;
@@ -91,11 +93,47 @@ public final class ProjectIndexerService {
         cancelIndexing.set(false);
     }
 
-    private synchronized DocumentSplitter splitter() {
+    /** Cached default (recursive) splitter — used for source code and unknown file types. */
+    private synchronized DocumentSplitter defaultSplitter() {
         if (documentSplitter == null) {
             documentSplitter = DocumentSplitters.recursive(CHUNK_SIZE_TOKENS, CHUNK_OVERLAP_TOKENS);
         }
         return documentSplitter;
+    }
+
+    /**
+     * Pick a splitter appropriate to the file's content type. Real wins come from honoring
+     * obvious natural boundaries:
+     * <ul>
+     *   <li>Markdown: split on paragraphs first so headers, code blocks, and bullet lists stay
+     *       together when they fit. Falls back to line/word for any single paragraph over the
+     *       chunk-size budget.</li>
+     *   <li>Source code: line splitting respects statement boundaries better than the generic
+     *       recursive separator order does for code (which prefers paragraph breaks, then
+     *       newlines, then sentence punctuation — the last of which is wrong for code).</li>
+     *   <li>Everything else: the default recursive splitter.</li>
+     * </ul>
+     * Per-language AST chunking is Phase 3; this is a cheap, library-only first pass.
+     */
+    DocumentSplitter splitterFor(@NotNull Path path) {
+        String ext = extensionOf(path);
+        return switch (ext) {
+            case "md", "mdx", "markdown" ->
+                    new DocumentByParagraphSplitter(CHUNK_SIZE_TOKENS, CHUNK_OVERLAP_TOKENS,
+                            defaultSplitter());
+            case "java", "kt", "kts", "py", "js", "mjs", "cjs", "ts", "tsx", "jsx",
+                 "go", "rs", "cpp", "cc", "cxx", "hpp", "h", "c", "php", "rb", "scala" ->
+                    new DocumentByLineSplitter(CHUNK_SIZE_TOKENS, CHUNK_OVERLAP_TOKENS,
+                            defaultSplitter());
+            default -> defaultSplitter();
+        };
+    }
+
+    private static String extensionOf(@NotNull Path path) {
+        String name = path.getFileName().toString();
+        int dot = name.lastIndexOf('.');
+        if (dot < 0 || dot == name.length() - 1) return "";
+        return name.substring(dot + 1).toLowerCase();
     }
 
     @TestOnly
@@ -324,7 +362,7 @@ public final class ProjectIndexerService {
             }
 
             Document document = Document.from(content);
-            List<TextSegment> rawSegments = splitter().split(document);
+            List<TextSegment> rawSegments = splitterFor(path).split(document);
             long lastModified = Files.getLastModifiedTime(path).toMillis();
             long indexedAt = System.currentTimeMillis();
             String absolutePath = path.toAbsolutePath().toString();

--- a/src/main/java/com/devoxx/genie/service/rag/ProjectIndexerService.java
+++ b/src/main/java/com/devoxx/genie/service/rag/ProjectIndexerService.java
@@ -48,6 +48,11 @@ public final class ProjectIndexerService {
      *  to avoid timeouts while still avoiding the N+1 cost of one-call-per-segment. */
     static final int EMBEDDING_BATCH_SIZE = 64;
 
+    /** Number of files processed in parallel during bulk indexing. Conservative default —
+     *  Ollama serializes embed requests by default and the embedding model also competes
+     *  for CPU, so going above 4 typically regresses throughput. */
+    static final int INDEXING_PARALLELISM = 2;
+
     private final ChromaEmbeddingService chromaEmbeddingService;
     private final ProjectScannerService projectScannerService;
 
@@ -86,7 +91,7 @@ public final class ProjectIndexerService {
         cancelIndexing.set(false);
     }
 
-    private DocumentSplitter splitter() {
+    private synchronized DocumentSplitter splitter() {
         if (documentSplitter == null) {
             documentSplitter = DocumentSplitters.recursive(CHUNK_SIZE_TOKENS, CHUNK_OVERLAP_TOKENS);
         }
@@ -137,34 +142,56 @@ public final class ProjectIndexerService {
         List<Path> filesToProcess = new ArrayList<>(scanResult.getFiles());
         int totalFiles = filesToProcess.size();
 
-        try {
-            for (int fileIndex = 0; fileIndex < totalFiles; fileIndex++) {
-                if (isIndexingCancelled()) {
-                    log.info("Indexing cancelled after processing {} of {} files", fileIndex, totalFiles);
-                    final int processedFiles = fileIndex;
-                    SwingUtilities.invokeLater(() -> {
-                        progressBar.setValue(100);
-                        progressLabel.setText(String.format("Indexing cancelled after processing %d of %d files",
-                                processedFiles, totalFiles));
-                    });
-                    return;
-                }
-
-                Path path = filesToProcess.get(fileIndex);
-                String fileName = path.getFileName().toString();
-                int progress = (int) (((double) (fileIndex + 1) / totalFiles) * 100);
-                final int currentFileIndex = fileIndex;
-
-                SwingUtilities.invokeLater(() -> {
-                    progressBar.setVisible(true);
-                    progressLabel.setVisible(true);
-                    progressBar.setValue(progress);
-                    progressLabel.setText(String.format("Processing %d of %d: %s", currentFileIndex + 1, totalFiles, fileName));
+        // Bounded parallel pool: a handful of file-processing threads share access to the
+        // batched embedAll / Chroma writes. We still cap progress + cancellation checks at the
+        // file boundary, since per-file work is the meaningful unit.
+        java.util.concurrent.ExecutorService pool = java.util.concurrent.Executors.newFixedThreadPool(
+                INDEXING_PARALLELISM,
+                r -> {
+                    Thread t = new Thread(r, "DevoxxGenie-Indexer");
+                    t.setDaemon(true);
+                    return t;
                 });
-
-                indexFile(path, forceReindex);
+        java.util.concurrent.atomic.AtomicInteger processedCount = new java.util.concurrent.atomic.AtomicInteger();
+        try {
+            java.util.List<java.util.concurrent.Future<?>> futures = new java.util.ArrayList<>(totalFiles);
+            for (Path path : filesToProcess) {
+                futures.add(pool.submit(() -> {
+                    if (isIndexingCancelled()) return;
+                    indexFile(path, forceReindex);
+                    int done = processedCount.incrementAndGet();
+                    int progress = (int) (((double) done / totalFiles) * 100);
+                    String fileName = path.getFileName().toString();
+                    SwingUtilities.invokeLater(() -> {
+                        progressBar.setVisible(true);
+                        progressLabel.setVisible(true);
+                        progressBar.setValue(progress);
+                        progressLabel.setText(String.format("Processing %d of %d: %s", done, totalFiles, fileName));
+                    });
+                }));
+            }
+            for (java.util.concurrent.Future<?> f : futures) {
+                if (isIndexingCancelled()) break;
+                try {
+                    f.get();
+                } catch (java.util.concurrent.ExecutionException ee) {
+                    log.warn("Indexer task failed: {}", ee.getCause() == null ? ee.getMessage() : ee.getCause().getMessage());
+                } catch (InterruptedException ie) {
+                    Thread.currentThread().interrupt();
+                    break;
+                }
+            }
+            if (isIndexingCancelled()) {
+                int processed = processedCount.get();
+                log.info("Indexing cancelled after processing {} of {} files", processed, totalFiles);
+                SwingUtilities.invokeLater(() -> {
+                    progressBar.setValue(100);
+                    progressLabel.setText(String.format("Indexing cancelled after processing %d of %d files",
+                            processed, totalFiles));
+                });
             }
         } finally {
+            pool.shutdownNow();
             manifest.flush();
             resetCancellationFlag();
         }

--- a/src/main/java/com/devoxx/genie/service/rag/QueryExpansionFuser.java
+++ b/src/main/java/com/devoxx/genie/service/rag/QueryExpansionFuser.java
@@ -1,0 +1,89 @@
+package com.devoxx.genie.service.rag;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+
+/**
+ * Combines retrieval results from multiple paraphrased variants of a single user query into
+ * one ranked list via Reciprocal Rank Fusion (RRF, k=60). Pure logic, no I/O, no langchain4j
+ * coupling — so it can be unit-tested deterministically.
+ *
+ * <p>The fix this targets: meta-style user queries ("where do we discuss X?", "list me all
+ * content about Y") don't embed near content-style chunks, so single-query retrieval surfaces
+ * topically-adjacent boilerplate. Running N paraphrases in parallel and RRF-fusing pushes
+ * results that score well across several variants above noise that only scored well on the
+ * original phrasing.
+ *
+ * <p>RRF formula: each item's score is the sum over input lists of {@code 1 / (k + rank)},
+ * where rank is 1-based and k=60 (the value used in the standard RRF paper and by
+ * {@code dev.langchain4j.rag.content.aggregator.ReciprocalRankFuser}).
+ *
+ * @see <a href="https://learn.microsoft.com/en-us/azure/search/hybrid-search-ranking">RRF
+ *      ranking</a>
+ */
+public final class QueryExpansionFuser {
+
+    /** RRF k-constant; 60 is the standard value used across the literature. */
+    static final int RRF_K = 60;
+
+    private QueryExpansionFuser() {} // utility
+
+    /**
+     * Issue one retrieval per query variant and fuse the results.
+     *
+     * @param variants    the queries to issue (must be non-empty; the user's original query
+     *                    must be one of them so the unexpanded baseline is preserved)
+     * @param retrieve    function that performs the actual per-variant retrieval. Called once
+     *                    per variant; ordering of returned results is treated as rank order.
+     * @param maxResults  upper bound on the fused list size; the {@code maxResults} highest
+     *                    RRF-scored unique results are returned
+     * @return RRF-ranked, deduplicated list of {@link SearchResult}s, descending by fused score
+     */
+    public static @NotNull List<SearchResult> expandAndFuse(
+            @NotNull Collection<String> variants,
+            @NotNull Function<String, List<SearchResult>> retrieve,
+            int maxResults) {
+        if (variants.isEmpty() || maxResults <= 0) return List.of();
+
+        // Two parallel maps keyed by (filePath, content) so chunks that match across variants
+        // accumulate score. Using LinkedHashMap preserves insertion order which gives us a
+        // stable tiebreaker when scores tie.
+        Map<DedupKey, Double> scores = new LinkedHashMap<>();
+        Map<DedupKey, SearchResult> chosen = new LinkedHashMap<>();
+
+        for (String variant : variants) {
+            List<SearchResult> hits = retrieve.apply(variant);
+            if (hits == null) continue;
+            for (int i = 0; i < hits.size(); i++) {
+                SearchResult hit = hits.get(i);
+                DedupKey key = DedupKey.of(hit);
+                int rank = i + 1;
+                scores.merge(key, 1.0 / (RRF_K + rank), Double::sum);
+                chosen.putIfAbsent(key, hit);
+            }
+        }
+
+        return scores.entrySet().stream()
+                .sorted(Map.Entry.<DedupKey, Double>comparingByValue().reversed())
+                .limit(maxResults)
+                .map(e -> chosen.get(e.getKey()))
+                .collect(java.util.stream.Collectors.toCollection(ArrayList::new));
+    }
+
+    /**
+     * Deduplication key for {@link SearchResult}. {@code filePath} alone is too coarse — a
+     * file's distinct chunks all match — and the original {@code score} is variant-specific
+     * so it can't be part of the key. Pair {@code filePath} with the chunk text.
+     */
+    private record DedupKey(String filePath, String content) {
+        static DedupKey of(@NotNull SearchResult r) {
+            return new DedupKey(r.filePath(), r.content());
+        }
+    }
+}

--- a/src/main/java/com/devoxx/genie/service/rag/RAGEventPublisher.java
+++ b/src/main/java/com/devoxx/genie/service/rag/RAGEventPublisher.java
@@ -1,0 +1,100 @@
+package com.devoxx.genie.service.rag;
+
+import com.devoxx.genie.model.rag.RAGLogMessage;
+import com.devoxx.genie.service.chromadb.ChromaEmbeddingService;
+import com.devoxx.genie.ui.settings.DevoxxGenieStateService;
+import com.devoxx.genie.ui.topic.AppTopics;
+import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.project.Project;
+import com.intellij.util.messages.MessageBus;
+import lombok.extern.slf4j.Slf4j;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.List;
+
+/**
+ * Publishes RAG retrieval events to the unified log panel and to slf4j. Replaces the
+ * single "Found N relevant project files" notification — which told you that something
+ * happened but not what — with a structured event carrying the query, configured
+ * thresholds, and one entry per matched chunk (path, score, content preview).
+ *
+ * <p>Subscribers receive {@link RAGLogMessage}s via {@link AppTopics#RAG_LOG_MSG}.
+ */
+@Slf4j
+public final class RAGEventPublisher {
+
+    /** Max characters of chunk text shown inline in the log panel; full text stays in the prompt. */
+    public static final int PREVIEW_MAX_CHARS = 400;
+
+    private RAGEventPublisher() {}
+
+    /**
+     * Publish a completed RAG retrieval. Safe to call from any thread; falls back to
+     * a debug-level log line if the message bus is unavailable (e.g. headless tests).
+     */
+    public static void publish(@Nullable Project project,
+                               @NotNull String query,
+                               @NotNull List<SearchResult> results,
+                               long durationMs) {
+        DevoxxGenieStateService state = DevoxxGenieStateService.getInstance();
+
+        RAGLogMessage.RAGLogMessageBuilder builder = RAGLogMessage.builder()
+                .projectLocationHash(project != null ? project.getLocationHash() : null)
+                .query(query)
+                .embeddingModel(safeEmbeddingModelName())
+                .minScore(state != null ? state.getIndexerMinScore() : null)
+                .maxResults(state != null ? state.getIndexerMaxResults() : null)
+                .durationMs(durationMs);
+
+        for (SearchResult r : results) {
+            String content = r.content() != null ? r.content() : "";
+            String preview = content.length() > PREVIEW_MAX_CHARS
+                    ? content.substring(0, PREVIEW_MAX_CHARS) + "…"
+                    : content;
+            builder.hit(RAGLogMessage.Hit.builder()
+                    .filePath(r.filePath())
+                    .score(r.score())
+                    .preview(preview)
+                    .chunkLength(content.length())
+                    .build());
+        }
+
+        RAGLogMessage message = builder.build();
+
+        // slf4j first — survives headless tests and idea.log searches ("RAG retrieval" grep).
+        log.info("RAG retrieval: query=\"{}\" hits={} duration={}ms",
+                summarizeQuery(query), results.size(), durationMs);
+        for (SearchResult r : results) {
+            log.info("RAG hit  score={}  file={}", formatScore(r.score()), r.filePath());
+        }
+
+        try {
+            // syncPublisher returns a proxy that broadcasts to all subscribers on the topic.
+            // Guard for tests where ApplicationManager isn't initialised.
+            if (ApplicationManager.getApplication() == null) return;
+            MessageBus bus = ApplicationManager.getApplication().getMessageBus();
+            if (bus == null) return;
+            bus.syncPublisher(AppTopics.RAG_LOG_MSG).onRAGLoggingMessage(message);
+        } catch (Exception e) {
+            log.debug("Could not publish RAG event to message bus: {}", e.getMessage());
+        }
+    }
+
+    private static String safeEmbeddingModelName() {
+        try {
+            return ChromaEmbeddingService.EMBEDDING_MODEL_NAME;
+        } catch (Throwable t) {
+            return null;
+        }
+    }
+
+    private static String summarizeQuery(@NotNull String query) {
+        String oneLine = query.replace('\n', ' ').replace('\r', ' ').trim();
+        return oneLine.length() > 120 ? oneLine.substring(0, 117) + "..." : oneLine;
+    }
+
+    private static String formatScore(@Nullable Double score) {
+        return score == null ? "n/a" : String.format("%.3f", score);
+    }
+}

--- a/src/main/java/com/devoxx/genie/service/rag/RAGLoggingMessage.java
+++ b/src/main/java/com/devoxx/genie/service/rag/RAGLoggingMessage.java
@@ -1,0 +1,8 @@
+package com.devoxx.genie.service.rag;
+
+import com.devoxx.genie.model.rag.RAGLogMessage;
+
+/** Listener interface for RAG retrieval events published to {@code AppTopics.RAG_LOG_MSG}. */
+public interface RAGLoggingMessage {
+    void onRAGLoggingMessage(RAGLogMessage message);
+}

--- a/src/main/java/com/devoxx/genie/service/rag/SearchResult.java
+++ b/src/main/java/com/devoxx/genie/service/rag/SearchResult.java
@@ -1,4 +1,11 @@
 package com.devoxx.genie.service.rag;
 
-public record SearchResult(Double score, String segment) {
+/**
+ * A single semantic-search hit: which chunk matched the query, where it came from, and how well.
+ *
+ * @param filePath absolute path of the source file the chunk was extracted from
+ * @param score    similarity score (0.0–1.0) returned by the vector store
+ * @param content  the chunk text as it was embedded and stored (NOT the full file contents)
+ */
+public record SearchResult(String filePath, Double score, String content) {
 }

--- a/src/main/java/com/devoxx/genie/service/rag/SemanticSearchService.java
+++ b/src/main/java/com/devoxx/genie/service/rag/SemanticSearchService.java
@@ -6,14 +6,22 @@ import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.components.Service;
 import com.intellij.openapi.project.Project;
 import dev.langchain4j.data.embedding.Embedding;
+import dev.langchain4j.model.chat.ChatModel;
+import dev.langchain4j.rag.query.Query;
+import dev.langchain4j.rag.query.transformer.ExpandingQueryTransformer;
 import dev.langchain4j.store.embedding.EmbeddingSearchRequest;
+import lombok.extern.slf4j.Slf4j;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedHashSet;
 import java.util.List;
 
 import static com.devoxx.genie.service.rag.IndexerConstants.FILE_PATH;
 
+@Slf4j
 @Service
 public final class SemanticSearchService {
 
@@ -31,16 +39,60 @@ public final class SemanticSearchService {
     }
 
     /**
-     * Search the project's vector index for chunks semantically similar to the query.
-     *
-     * <p>Returns one {@link SearchResult} per matching chunk (so multiple chunks from the same
-     * file are preserved). Results are ordered by descending score.
+     * Single-query search — kept for callers that don't have a chat model available
+     * (find-command, integration tests). Equivalent to
+     * {@link #search(Project, String, ChatModel)} with a null model.
      */
     public @NotNull List<SearchResult> search(Project project, String query) {
+        return search(project, query, null);
+    }
+
+    /**
+     * Search the project's vector index for chunks semantically similar to the query.
+     *
+     * <p>When {@code chatModel} is non-null AND query expansion is enabled in settings, the
+     * query is first paraphrased into N variants via langchain4j's {@link
+     * ExpandingQueryTransformer}; each variant is retrieved independently and the results
+     * are fused via Reciprocal Rank Fusion ({@link QueryExpansionFuser}). This addresses
+     * meta-style user queries ("where do we discuss X?") which embed near boilerplate rather
+     * than near the content the user actually wants.
+     *
+     * <p>When expansion is disabled or unavailable, falls back to single-query embedding +
+     * store lookup — identical to the previous behavior.
+     *
+     * <p>Returns one {@link SearchResult} per matching chunk (so multiple chunks from the
+     * same file are preserved). Results are ordered by descending score.
+     */
+    public @NotNull List<SearchResult> search(Project project, String query, @Nullable ChatModel chatModel) {
         embeddingService.init(project);
 
-        Embedding queryEmbedding = embeddingService.getEmbeddingModel().embed(query).content();
+        if (chatModel != null && Boolean.TRUE.equals(stateService.getRagQueryExpansionEnabled())) {
+            return searchWithExpansion(query, chatModel);
+        }
+        return singleQuerySearch(query);
+    }
 
+    private @NotNull List<SearchResult> searchWithExpansion(String query, @NotNull ChatModel chatModel) {
+        int n = stateService.getRagQueryExpansionN() == null ? 3 : stateService.getRagQueryExpansionN();
+        LinkedHashSet<String> variants = new LinkedHashSet<>();
+        variants.add(query); // keep the original as the unexpanded baseline
+        try {
+            ExpandingQueryTransformer expander = new ExpandingQueryTransformer(chatModel, n);
+            Collection<Query> expanded = expander.transform(Query.from(query));
+            expanded.forEach(q -> variants.add(q.text()));
+        } catch (Exception e) {
+            // If the LLM call fails (timeout, key, format), fall back to the original alone
+            // rather than aborting the whole prompt. The single-query baseline is still useful.
+            log.warn("Query expansion failed ({}); falling back to original query", e.getMessage());
+        }
+        return QueryExpansionFuser.expandAndFuse(
+                variants,
+                this::singleQuerySearch,
+                stateService.getIndexerMaxResults());
+    }
+
+    private @NotNull List<SearchResult> singleQuerySearch(@NotNull String query) {
+        Embedding queryEmbedding = embeddingService.getEmbeddingModel().embed(query).content();
         EmbeddingSearchRequest request = EmbeddingSearchRequest.builder()
                 .queryEmbedding(queryEmbedding)
                 .minScore(stateService.getIndexerMinScore())

--- a/src/main/java/com/devoxx/genie/service/rag/SemanticSearchService.java
+++ b/src/main/java/com/devoxx/genie/service/rag/SemanticSearchService.java
@@ -9,8 +9,8 @@ import dev.langchain4j.data.embedding.Embedding;
 import dev.langchain4j.store.embedding.EmbeddingSearchRequest;
 import org.jetbrains.annotations.NotNull;
 
-import java.util.HashMap;
-import java.util.Map;
+import java.util.ArrayList;
+import java.util.List;
 
 import static com.devoxx.genie.service.rag.IndexerConstants.FILE_PATH;
 
@@ -26,25 +26,20 @@ public final class SemanticSearchService {
     }
 
     public SemanticSearchService() {
-        this.embeddingService = ApplicationManager.getApplication()
-                .getService(ChromaEmbeddingService.class);
-        this.stateService = ApplicationManager.getApplication()
-                .getService(DevoxxGenieStateService.class);
+        this.embeddingService = ChromaEmbeddingService.getInstance();
+        this.stateService = DevoxxGenieStateService.getInstance();
     }
 
     /**
-     * Search code snippets based on a query string.
-     * @param query Search query
-     * @return Map of search results with file paths as keys
+     * Search the project's vector index for chunks semantically similar to the query.
+     *
+     * <p>Returns one {@link SearchResult} per matching chunk (so multiple chunks from the same
+     * file are preserved). Results are ordered by descending score.
      */
-    public @NotNull Map<String, SearchResult> search(Project project, String query) {
-        // Task-209: analytics emission happens at the caller (MessageCreationService) where
-        // the LanguageModel context is available, so provider_type reflects the actual model.
+    public @NotNull List<SearchResult> search(Project project, String query) {
         embeddingService.init(project);
 
         Embedding queryEmbedding = embeddingService.getEmbeddingModel().embed(query).content();
-
-        Map<String, SearchResult> results = new HashMap<>();
 
         EmbeddingSearchRequest request = EmbeddingSearchRequest.builder()
                 .queryEmbedding(queryEmbedding)
@@ -52,12 +47,13 @@ public final class SemanticSearchService {
                 .maxResults(stateService.getIndexerMaxResults())
                 .build();
 
+        List<SearchResult> results = new ArrayList<>();
         embeddingService.getEmbeddingStore().search(request)
                 .matches()
-                .forEach(match ->
-                        results.put(match.embedded().metadata().getString(FILE_PATH),
-                                new SearchResult(match.score(), match.embedded().text())));
-
+                .forEach(match -> {
+                    String filePath = match.embedded().metadata().getString(FILE_PATH);
+                    results.add(new SearchResult(filePath, match.score(), match.embedded().text()));
+                });
         return results;
     }
 }

--- a/src/main/java/com/devoxx/genie/service/rag/cli/RagCli.java
+++ b/src/main/java/com/devoxx/genie/service/rag/cli/RagCli.java
@@ -1,0 +1,190 @@
+package com.devoxx.genie.service.rag.cli;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.Strictness;
+import java.io.StringReader;
+import dev.langchain4j.data.embedding.Embedding;
+import dev.langchain4j.model.embedding.EmbeddingModel;
+import dev.langchain4j.model.ollama.OllamaEmbeddingModel;
+import dev.langchain4j.store.embedding.EmbeddingSearchRequest;
+import dev.langchain4j.store.embedding.chroma.ChromaEmbeddingStore;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.util.LinkedHashSet;
+import java.util.Locale;
+import java.util.Set;
+
+/**
+ * Standalone diagnostic CLI for the project's RAG store. Talks to the same ChromaDB and Ollama
+ * the plugin uses, but bypasses the IntelliJ service layer so it can run from {@code gradle
+ * ragQuery}.
+ *
+ * <p>Subcommands:
+ * <ul>
+ *   <li>{@code query <collection> <text> [topN=10]} — embed and search; prints rank/score/path/snippet</li>
+ *   <li>{@code list <collection> [substringFilter]} — print distinct file paths in a collection</li>
+ * </ul>
+ *
+ * <p>Env overrides: {@code DEVOXXGENIE_CHROMA_URL} (default {@code http://localhost:8000}),
+ * {@code DEVOXXGENIE_OLLAMA_URL} (default {@code http://localhost:11434}),
+ * {@code DEVOXXGENIE_EMBED_MODEL} (default {@code nomic-embed-text}).
+ */
+public final class RagCli {
+
+    private static final String DEFAULT_CHROMA_URL = "http://localhost:8000";
+    private static final String DEFAULT_OLLAMA_URL = "http://localhost:11434";
+    private static final String DEFAULT_EMBED_MODEL = "nomic-embed-text";
+
+    private RagCli() {}
+
+    public static void main(String[] args) throws Exception {
+        if (args.length == 0) { printUsage(); System.exit(2); }
+        String cmd = args[0].toLowerCase(Locale.ROOT);
+        switch (cmd) {
+            case "query" -> runQuery(args);
+            case "list"  -> runList(args);
+            default -> { printUsage(); System.exit(2); }
+        }
+    }
+
+    // ---------------- query ----------------
+
+    private static void runQuery(String[] args) {
+        if (args.length < 3) { printUsage(); System.exit(2); }
+        String collection = args[1];
+        String text = args[2];
+        int topN = args.length >= 4 ? Integer.parseInt(args[3]) : 10;
+
+        EmbeddingModel embedder = OllamaEmbeddingModel.builder()
+                .baseUrl(env("DEVOXXGENIE_OLLAMA_URL", DEFAULT_OLLAMA_URL))
+                .modelName(env("DEVOXXGENIE_EMBED_MODEL", DEFAULT_EMBED_MODEL))
+                .build();
+
+        ChromaEmbeddingStore store = ChromaEmbeddingStore.builder()
+                .baseUrl(env("DEVOXXGENIE_CHROMA_URL", DEFAULT_CHROMA_URL))
+                .collectionName(collection)
+                .build();
+
+        Embedding q = embedder.embed(text).content();
+        var results = store.search(EmbeddingSearchRequest.builder()
+                .queryEmbedding(q)
+                .maxResults(topN)
+                .build()).matches();
+
+        System.out.printf("Query: %s%nCollection: %s%nTop %d results:%n%n", text, collection, results.size());
+        int rank = 0;
+        for (var m : results) {
+            rank++;
+            String path = m.embedded().metadata().getString("filePath");
+            String snippet = oneLine(m.embedded().text(), 200);
+            System.out.printf("[%2d] score=%.4f  %s%n     %s%n%n",
+                    rank, m.score(), path != null ? path : "(unknown)", snippet);
+        }
+    }
+
+    // ---------------- list ----------------
+
+    private static void runList(String[] args) throws Exception {
+        if (args.length < 2) { printUsage(); System.exit(2); }
+        String collection = args[1];
+        String filter = args.length >= 3 ? args[2].toLowerCase(Locale.ROOT) : null;
+
+        String chroma = env("DEVOXXGENIE_CHROMA_URL", DEFAULT_CHROMA_URL);
+        // ChromaDB's HTTP server rejects HTTP/2 with "Invalid HTTP request received"; pin to 1.1.
+        HttpClient http = HttpClient.newBuilder().version(HttpClient.Version.HTTP_1_1).build();
+
+        // Resolve collection name -> UUID (Chroma v1 API).
+        HttpResponse<String> meta = http.send(
+                HttpRequest.newBuilder(URI.create(chroma + "/api/v1/collections/" + collection)).GET().build(),
+                HttpResponse.BodyHandlers.ofString());
+        if (meta.statusCode() != 200) {
+            System.err.println("Collection not found: " + collection + " (HTTP " + meta.statusCode() + ")");
+            System.err.println("Body: " + meta.body());
+            System.exit(1);
+        }
+        JsonElement metaEl = parseLenient(meta.body());
+        if (!metaEl.isJsonObject() || metaEl.getAsJsonObject().get("id") == null) {
+            System.err.println("Unexpected metadata response for collection " + collection + ":");
+            System.err.println(meta.body());
+            System.exit(1);
+        }
+        String uuid = metaEl.getAsJsonObject().get("id").getAsString();
+
+        // Page through entries; print unique filePaths.
+        int limit = 1000;
+        int offset = 0;
+        Set<String> unique = new LinkedHashSet<>();
+        while (true) {
+            String body = "{\"limit\":" + limit + ",\"offset\":" + offset + ",\"include\":[\"metadatas\"]}";
+            HttpResponse<String> resp = http.send(
+                    HttpRequest.newBuilder(URI.create(chroma + "/api/v1/collections/" + uuid + "/get"))
+                            .header("Content-Type", "application/json")
+                            .POST(HttpRequest.BodyPublishers.ofString(body))
+                            .build(),
+                    HttpResponse.BodyHandlers.ofString());
+            JsonElement respEl = parseLenient(resp.body());
+            if (!respEl.isJsonObject()) {
+                System.err.println("Unexpected /get response (HTTP " + resp.statusCode() + "):");
+                System.err.println(resp.body().length() > 500 ? resp.body().substring(0, 500) + "…" : resp.body());
+                System.exit(1);
+            }
+            JsonObject obj = respEl.getAsJsonObject();
+            JsonElement metasEl = obj.get("metadatas");
+            if (metasEl == null || metasEl.isJsonNull()) break;
+            JsonArray metas = metasEl.getAsJsonArray();
+            if (metas.isEmpty()) break;
+            for (JsonElement el : metas) {
+                if (el == null || el.isJsonNull()) continue;
+                JsonElement fp = el.getAsJsonObject().get("filePath");
+                if (fp == null || fp.isJsonNull()) continue;
+                String path = fp.getAsString();
+                if (filter == null || path.toLowerCase(Locale.ROOT).contains(filter)) {
+                    unique.add(path);
+                }
+            }
+            if (metas.size() < limit) break;
+            offset += limit;
+        }
+        unique.forEach(System.out::println);
+        System.err.printf("%n%d unique file%s%n", unique.size(), unique.size() == 1 ? "" : "s");
+    }
+
+    // ---------------- helpers ----------------
+
+    private static JsonElement parseLenient(String body) {
+        JsonReader r = new JsonReader(new StringReader(body));
+        r.setStrictness(Strictness.LENIENT);
+        return JsonParser.parseReader(r);
+    }
+
+    private static String env(String key, String fallback) {
+        String v = System.getenv(key);
+        return v == null || v.isBlank() ? fallback : v;
+    }
+
+    private static String oneLine(String s, int max) {
+        if (s == null) return "";
+        String flat = s.replaceAll("\\s+", " ").trim();
+        return flat.length() <= max ? flat : flat.substring(0, max) + "…";
+    }
+
+    private static void printUsage() {
+        System.err.println("""
+                Usage:
+                  ragQuery query <collection> <text> [topN=10]
+                  ragQuery list  <collection> [substring]
+
+                Env:
+                  DEVOXXGENIE_CHROMA_URL   (default http://localhost:8000)
+                  DEVOXXGENIE_OLLAMA_URL   (default http://localhost:11434)
+                  DEVOXXGENIE_EMBED_MODEL  (default nomic-embed-text)
+                """);
+    }
+}

--- a/src/main/java/com/devoxx/genie/service/rag/manifest/InMemoryIndexManifest.java
+++ b/src/main/java/com/devoxx/genie/service/rag/manifest/InMemoryIndexManifest.java
@@ -24,6 +24,11 @@ public class InMemoryIndexManifest implements IndexManifest {
     protected final ConcurrentMap<String, IndexManifestEntry> entries = new ConcurrentHashMap<>();
 
     @Override
+    public boolean isTracked(@NotNull Path file) {
+        return entries.containsKey(file.toAbsolutePath().toString());
+    }
+
+    @Override
     public boolean isCurrent(@NotNull Path file) {
         String key = file.toAbsolutePath().toString();
         IndexManifestEntry entry = entries.get(key);

--- a/src/main/java/com/devoxx/genie/service/rag/manifest/InMemoryIndexManifest.java
+++ b/src/main/java/com/devoxx/genie/service/rag/manifest/InMemoryIndexManifest.java
@@ -1,0 +1,80 @@
+package com.devoxx.genie.service.rag.manifest;
+
+import com.devoxx.genie.service.rag.IndexerConstants;
+import lombok.extern.slf4j.Slf4j;
+import org.jetbrains.annotations.NotNull;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.HexFormat;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+/**
+ * Volatile, process-local manifest. Used by tests and as the default when no Project
+ * context is available. Concrete persistent implementations subclass this and override
+ * {@link #flush()} (and load their state in their constructor).
+ */
+@Slf4j
+public class InMemoryIndexManifest implements IndexManifest {
+
+    protected final ConcurrentMap<String, IndexManifestEntry> entries = new ConcurrentHashMap<>();
+
+    @Override
+    public boolean isCurrent(@NotNull Path file) {
+        String key = file.toAbsolutePath().toString();
+        IndexManifestEntry entry = entries.get(key);
+        if (entry == null) return false;
+        if (!IndexerConstants.CURRENT_EMBEDDING_SCHEMA_VERSION.equals(entry.schemaVersion())) {
+            return false;
+        }
+        String currentHash = sha1OrNull(file);
+        return currentHash != null && currentHash.equals(entry.contentHash());
+    }
+
+    @Override
+    public void markIndexed(@NotNull Path file, int segmentCount) {
+        String key = file.toAbsolutePath().toString();
+        String hash = sha1OrNull(file);
+        if (hash == null) {
+            log.debug("Skipping manifest entry for unreadable file: {}", file);
+            return;
+        }
+        long lastModified;
+        try {
+            lastModified = Files.getLastModifiedTime(file).toMillis();
+        } catch (IOException e) {
+            lastModified = 0L;
+        }
+        entries.put(key, new IndexManifestEntry(
+                hash,
+                lastModified,
+                System.currentTimeMillis(),
+                segmentCount,
+                IndexerConstants.CURRENT_EMBEDDING_SCHEMA_VERSION));
+        onMutated();
+    }
+
+    @Override
+    public void markRemoved(@NotNull Path file) {
+        if (entries.remove(file.toAbsolutePath().toString()) != null) {
+            onMutated();
+        }
+    }
+
+    /** Hook for persistent subclasses; called after every mutation. Default is no-op. */
+    protected void onMutated() {}
+
+    static String sha1OrNull(@NotNull Path file) {
+        try {
+            MessageDigest md = MessageDigest.getInstance("SHA-1");
+            byte[] bytes = Files.readAllBytes(file);
+            return HexFormat.of().formatHex(md.digest(bytes));
+        } catch (IOException | NoSuchAlgorithmException e) {
+            return null;
+        }
+    }
+}

--- a/src/main/java/com/devoxx/genie/service/rag/manifest/IndexManifest.java
+++ b/src/main/java/com/devoxx/genie/service/rag/manifest/IndexManifest.java
@@ -1,0 +1,29 @@
+package com.devoxx.genie.service.rag.manifest;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.nio.file.Path;
+
+/**
+ * Source of truth for "which files in this project are currently indexed under the active
+ * embedding schema." Replaces the earlier reliance on probing the vector store with a fake
+ * query to figure out whether a file had been processed.
+ *
+ * <p>Compared to mtime-only change detection, the manifest also stores a content hash so
+ * branch switches, git operations, or formatter-driven re-saves that touch mtime without
+ * changing the actual bytes do not trigger spurious re-indexing.
+ */
+public interface IndexManifest {
+
+    /** True iff {@code file} is recorded and its content hash matches what's on disk. */
+    boolean isCurrent(@NotNull Path file);
+
+    /** Record that {@code file} has been indexed; computes and stores its current content hash. */
+    void markIndexed(@NotNull Path file, int segmentCount);
+
+    /** Drop {@code file} from the manifest (e.g. file deleted). */
+    void markRemoved(@NotNull Path file);
+
+    /** Persist any in-memory state. No-op for in-memory implementations. */
+    default void flush() {}
+}

--- a/src/main/java/com/devoxx/genie/service/rag/manifest/IndexManifest.java
+++ b/src/main/java/com/devoxx/genie/service/rag/manifest/IndexManifest.java
@@ -18,6 +18,11 @@ public interface IndexManifest {
     /** True iff {@code file} is recorded and its content hash matches what's on disk. */
     boolean isCurrent(@NotNull Path file);
 
+    /** True iff {@code file} is recorded at all, regardless of whether its hash is still current.
+     *  Used by the file watcher to scope auto-reindex to files the user has explicitly indexed
+     *  before — new files require a manual full index so the watcher can't accidentally bootstrap. */
+    boolean isTracked(@NotNull Path file);
+
     /** Record that {@code file} has been indexed; computes and stores its current content hash. */
     void markIndexed(@NotNull Path file, int segmentCount);
 

--- a/src/main/java/com/devoxx/genie/service/rag/manifest/IndexManifestEntry.java
+++ b/src/main/java/com/devoxx/genie/service/rag/manifest/IndexManifestEntry.java
@@ -1,0 +1,24 @@
+package com.devoxx.genie.service.rag.manifest;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * One row of the per-project index manifest.
+ *
+ * @param contentHash    hex SHA-1 of the file's bytes when it was indexed
+ * @param lastModified   file's {@code lastModifiedTime} in millis when it was indexed (debug-only signal)
+ * @param indexedAt      wall-clock time the entry was written
+ * @param segmentCount   how many chunks the file was split into
+ * @param schemaVersion  embedding schema version under which the file was indexed
+ */
+public record IndexManifestEntry(
+        @JsonProperty("contentHash") String contentHash,
+        @JsonProperty("lastModified") long lastModified,
+        @JsonProperty("indexedAt") long indexedAt,
+        @JsonProperty("segmentCount") int segmentCount,
+        @JsonProperty("schemaVersion") String schemaVersion
+) {
+    @JsonCreator
+    public IndexManifestEntry {}
+}

--- a/src/main/java/com/devoxx/genie/service/rag/manifest/IndexManifestService.java
+++ b/src/main/java/com/devoxx/genie/service/rag/manifest/IndexManifestService.java
@@ -1,0 +1,45 @@
+package com.devoxx.genie.service.rag.manifest;
+
+import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.application.PathManager;
+import com.intellij.openapi.components.Service;
+import com.intellij.openapi.project.Project;
+import org.jetbrains.annotations.NotNull;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+/**
+ * Hands out the {@link IndexManifest} for a given project, caching one per
+ * {@code project.getLocationHash()}. Manifests live alongside the per-project ChromaDB
+ * volume — both under {@code {systemPath}/DevoxxGenie/} — so a clean re-index can be
+ * performed by simply wiping that directory.
+ */
+@Service
+public final class IndexManifestService {
+
+    private final ConcurrentMap<String, IndexManifest> perProject = new ConcurrentHashMap<>();
+
+    @NotNull
+    public static IndexManifestService getInstance() {
+        return ApplicationManager.getApplication().getService(IndexManifestService.class);
+    }
+
+    @NotNull
+    public IndexManifest forProject(@NotNull Project project) {
+        return perProject.computeIfAbsent(project.getLocationHash(),
+                hash -> new JsonFileIndexManifest(manifestPath(hash)));
+    }
+
+    /** Visible for tests that want to swap in an {@link InMemoryIndexManifest}. */
+    public void overrideForProject(@NotNull Project project, @NotNull IndexManifest manifest) {
+        perProject.put(project.getLocationHash(), manifest);
+    }
+
+    public static Path manifestPath(@NotNull String projectLocationHash) {
+        return Paths.get(PathManager.getSystemPath(), "DevoxxGenie",
+                "index-manifest-" + projectLocationHash + ".json");
+    }
+}

--- a/src/main/java/com/devoxx/genie/service/rag/manifest/JsonFileIndexManifest.java
+++ b/src/main/java/com/devoxx/genie/service/rag/manifest/JsonFileIndexManifest.java
@@ -1,0 +1,74 @@
+package com.devoxx.genie.service.rag.manifest;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import lombok.extern.slf4j.Slf4j;
+import org.jetbrains.annotations.NotNull;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * JSON-backed manifest persisted to the IDE's plugin data dir. Loads its state once on
+ * construction; flushes lazily — mutations set a dirty flag and the actual disk write
+ * happens on {@link #flush()}. Indexing pipelines should call {@code flush()} when a
+ * batch completes; auto-reindex listeners should call it after their debounce fires.
+ */
+@Slf4j
+public class JsonFileIndexManifest extends InMemoryIndexManifest {
+
+    private static final ObjectMapper JSON = new ObjectMapper()
+            .enable(SerializationFeature.INDENT_OUTPUT);
+    private static final TypeReference<Map<String, IndexManifestEntry>> MAP_TYPE = new TypeReference<>() {};
+
+    private final Path storagePath;
+    private final AtomicBoolean dirty = new AtomicBoolean(false);
+
+    public JsonFileIndexManifest(@NotNull Path storagePath) {
+        this.storagePath = storagePath;
+        loadFromDisk();
+    }
+
+    @Override
+    protected void onMutated() {
+        dirty.set(true);
+    }
+
+    @Override
+    public void flush() {
+        if (!dirty.getAndSet(false)) return;
+        try {
+            Files.createDirectories(storagePath.getParent());
+            // Snapshot to a plain Map so the serialized form is stable across JVM impls.
+            Map<String, IndexManifestEntry> snapshot = Map.copyOf(entries);
+            // Atomic write via tmp + move.
+            Path tmp = storagePath.resolveSibling(storagePath.getFileName().toString() + ".tmp");
+            JSON.writeValue(tmp.toFile(), snapshot);
+            try {
+                Files.move(tmp, storagePath,
+                        java.nio.file.StandardCopyOption.REPLACE_EXISTING,
+                        java.nio.file.StandardCopyOption.ATOMIC_MOVE);
+            } catch (java.nio.file.AtomicMoveNotSupportedException ignored) {
+                Files.move(tmp, storagePath, java.nio.file.StandardCopyOption.REPLACE_EXISTING);
+            }
+        } catch (IOException e) {
+            log.warn("Failed to flush index manifest to {}: {}", storagePath, e.getMessage());
+            // Mark dirty again so a future flush retries.
+            dirty.set(true);
+        }
+    }
+
+    private void loadFromDisk() {
+        if (!Files.exists(storagePath)) return;
+        try {
+            Map<String, IndexManifestEntry> loaded = JSON.readValue(storagePath.toFile(), MAP_TYPE);
+            entries.putAll(loaded);
+        } catch (IOException e) {
+            log.warn("Failed to load index manifest from {}; starting fresh: {}", storagePath, e.getMessage());
+        }
+    }
+}

--- a/src/main/java/com/devoxx/genie/service/rag/validator/ChromeDBValidator.java
+++ b/src/main/java/com/devoxx/genie/service/rag/validator/ChromeDBValidator.java
@@ -1,5 +1,6 @@
 package com.devoxx.genie.service.rag.validator;
 
+import com.devoxx.genie.service.chromadb.ChromaDockerService;
 import com.devoxx.genie.ui.settings.DevoxxGenieStateService;
 import com.devoxx.genie.util.DockerUtil;
 import com.github.dockerjava.api.DockerClient;
@@ -63,7 +64,7 @@ public class ChromeDBValidator implements Validator {
                 return false;
             }
 
-            this.message = "ChromaDB v0.6.2 is running";
+            this.message = "ChromaDB v" + ChromaDockerService.CHROMA_VERSION + " is running";
             return true;
 
         } catch (Exception e) {

--- a/src/main/java/com/devoxx/genie/service/rag/watcher/RAGFileWatcher.java
+++ b/src/main/java/com/devoxx/genie/service/rag/watcher/RAGFileWatcher.java
@@ -1,0 +1,194 @@
+package com.devoxx.genie.service.rag.watcher;
+
+import com.devoxx.genie.service.rag.ProjectIndexerService;
+import com.devoxx.genie.service.rag.manifest.IndexManifest;
+import com.devoxx.genie.service.rag.manifest.IndexManifestService;
+import com.devoxx.genie.ui.settings.DevoxxGenieStateService;
+import com.intellij.openapi.Disposable;
+import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.components.Service;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.util.Disposer;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.openapi.vfs.VirtualFileManager;
+import com.intellij.openapi.vfs.newvfs.BulkFileListener;
+import com.intellij.openapi.vfs.newvfs.events.VFileContentChangeEvent;
+import com.intellij.openapi.vfs.newvfs.events.VFileCreateEvent;
+import com.intellij.openapi.vfs.newvfs.events.VFileDeleteEvent;
+import com.intellij.openapi.vfs.newvfs.events.VFileEvent;
+import com.intellij.openapi.vfs.newvfs.events.VFileMoveEvent;
+import com.intellij.util.messages.MessageBusConnection;
+import lombok.extern.slf4j.Slf4j;
+import org.jetbrains.annotations.NotNull;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Listens to VFS changes for one project and re-embeds any tracked file the user saves.
+ * Two design choices to keep the user out of harm's way:
+ *
+ * <ul>
+ *   <li><b>Debounced</b> ({@link #DEBOUNCE_MILLIS}ms): rapid edits coalesce into one
+ *       reindex pass so Ctrl+S-on-every-line doesn't hammer Ollama.</li>
+ *   <li><b>Tracked-only</b>: a file is only auto-reindexed if it appears in the manifest.
+ *       Auto-indexing brand-new files would mean a stray "save" in a generated/binary tree
+ *       could silently bootstrap an enormous unintended index. The user must run the
+ *       initial "Index Files" action; the watcher then keeps that set fresh.</li>
+ * </ul>
+ *
+ * <p>Project-level service: created lazily on first {@link #getInstance} call and disposed
+ * with the project. The {@code postStartupActivity} extension wires it up at project open.
+ */
+@Slf4j
+@Service(Service.Level.PROJECT)
+public final class RAGFileWatcher implements Disposable {
+
+    /** Quiet period after the last change before reindexing fires. */
+    static final long DEBOUNCE_MILLIS = 2_000;
+
+    private final Project project;
+    /** Cached at construction so the scheduler thread doesn't need to hit a static lookup. */
+    private final ProjectIndexerService indexer;
+    private final ScheduledExecutorService scheduler =
+            Executors.newSingleThreadScheduledExecutor(r -> {
+                Thread t = new Thread(r, "DevoxxGenie-RAG-Watcher");
+                t.setDaemon(true);
+                return t;
+            });
+    private final Set<Path> pendingChanges = new HashSet<>();
+    private final Set<Path> pendingDeletes = new HashSet<>();
+    private final Object pendingLock = new Object();
+
+    private MessageBusConnection connection;
+    private ScheduledFuture<?> pendingFlush;
+
+    public RAGFileWatcher(@NotNull Project project) {
+        this(project, ProjectIndexerService.getInstance());
+    }
+
+    /** Visible for tests. */
+    RAGFileWatcher(@NotNull Project project, @NotNull ProjectIndexerService indexer) {
+        this.project = project;
+        this.indexer = indexer;
+        start();
+    }
+
+    public static RAGFileWatcher getInstance(@NotNull Project project) {
+        return project.getService(RAGFileWatcher.class);
+    }
+
+    private void start() {
+        connection = project.getMessageBus().connect(this);
+        connection.subscribe(VirtualFileManager.VFS_CHANGES, new BulkFileListener() {
+            @Override
+            public void after(@NotNull List<? extends @NotNull VFileEvent> events) {
+                if (!isRagOn()) return;
+                handleEvents(events);
+            }
+        });
+        log.debug("RAG file watcher started for {}", project.getName());
+    }
+
+    private boolean isRagOn() {
+        DevoxxGenieStateService s = DevoxxGenieStateService.getInstance();
+        return Boolean.TRUE.equals(s.getRagEnabled());
+    }
+
+    /** Visible for tests. */
+    void handleEvents(@NotNull List<? extends VFileEvent> events) {
+        String basePath = project.getBasePath();
+        if (basePath == null) return;
+
+        IndexManifest manifest = IndexManifestService.getInstance().forProject(project);
+
+        List<Path> changes = new ArrayList<>();
+        List<Path> deletes = new ArrayList<>();
+        for (VFileEvent event : events) {
+            Path path = pathOf(event);
+            if (path == null) continue;
+            if (!path.toString().startsWith(basePath)) continue;
+            if (!manifest.isTracked(path)) continue;
+
+            if (event instanceof VFileDeleteEvent || event instanceof VFileMoveEvent) {
+                deletes.add(path);
+            } else if (event instanceof VFileContentChangeEvent || event instanceof VFileCreateEvent) {
+                changes.add(path);
+            }
+        }
+
+        if (changes.isEmpty() && deletes.isEmpty()) return;
+
+        synchronized (pendingLock) {
+            pendingChanges.addAll(changes);
+            pendingDeletes.addAll(deletes);
+            // A delete supersedes any pending change for the same path.
+            pendingChanges.removeAll(deletes);
+
+            if (pendingFlush != null) pendingFlush.cancel(false);
+            pendingFlush = scheduler.schedule(this::flush, DEBOUNCE_MILLIS, TimeUnit.MILLISECONDS);
+        }
+    }
+
+    /** Visible for tests. Runs the indexer on the scheduler thread directly — that thread is
+     *  already a background daemon, so there's no point hopping to the IntelliJ pool. */
+    void flush() {
+        Set<Path> toReindex;
+        Set<Path> toDelete;
+        synchronized (pendingLock) {
+            toReindex = new HashSet<>(pendingChanges);
+            toDelete = new HashSet<>(pendingDeletes);
+            pendingChanges.clear();
+            pendingDeletes.clear();
+        }
+        if (toReindex.isEmpty() && toDelete.isEmpty()) return;
+
+        try {
+            if (!toDelete.isEmpty()) {
+                log.info("RAG watcher removing {} deleted file(s) from index", toDelete.size());
+                indexer.removeFiles(project, toDelete);
+            }
+            if (!toReindex.isEmpty()) {
+                log.info("RAG watcher re-indexing {} changed file(s)", toReindex.size());
+                indexer.reindexFiles(project, toReindex);
+            }
+        } catch (Exception e) {
+            log.warn("RAG watcher flush failed: {}", e.getMessage());
+        }
+    }
+
+    private static Path pathOf(@NotNull VFileEvent event) {
+        VirtualFile file = event.getFile();
+        String s = file != null ? file.getPath() : event.getPath();
+        if (s == null) return null;
+        try {
+            return Paths.get(s);
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    @Override
+    public void dispose() {
+        synchronized (pendingLock) {
+            if (pendingFlush != null) {
+                pendingFlush.cancel(false);
+                pendingFlush = null;
+            }
+            pendingChanges.clear();
+            pendingDeletes.clear();
+        }
+        scheduler.shutdownNow();
+        if (connection != null) {
+            Disposer.dispose(connection);
+        }
+    }
+}

--- a/src/main/java/com/devoxx/genie/ui/component/InputSwitch.java
+++ b/src/main/java/com/devoxx/genie/ui/component/InputSwitch.java
@@ -77,8 +77,8 @@ public class InputSwitch extends JBPanel<InputSwitch> {
         public SwitchButton() {
             setPreferredSize(new Dimension(35, 20));
             setBackground(new JBColor(
-                    new Color(255, 165, 0),  // light theme
-                    new Color(255, 140, 0).brighter()  // dark theme
+                    new Color(76, 175, 80),   // light theme — Material green 500
+                    new Color(102, 187, 106)  // dark theme   — Material green 400
             ));
             setForeground(Color.WHITE);
             setCursor(new Cursor(Cursor.HAND_CURSOR));
@@ -146,8 +146,8 @@ public class InputSwitch extends JBPanel<InputSwitch> {
 
             int textY = (height - fm.getHeight()) / 2 + fm.getAscent();
 
-            // Draw text with contrasting color
-            g2.setColor(selected ? Color.WHITE : Color.GRAY);
+            // Draw text with contrasting color (black on the green "on" track for readability)
+            g2.setColor(selected ? Color.BLACK : Color.GRAY);
             g2.drawString(text, textX, textY);
         }
 
@@ -186,7 +186,7 @@ public class InputSwitch extends JBPanel<InputSwitch> {
     private class MyActionListener implements ActionListener {
         @Override
         public void actionPerformed(ActionEvent ae) {
-            if (isSelected()) {
+            if (selected) {
                 int endLocation = switchButton.getWidth() - switchButton.getHeight() + 2;
                 if (location < endLocation) {
                     location += SPEED;

--- a/src/main/java/com/devoxx/genie/ui/panel/log/AgentMcpLogPanel.java
+++ b/src/main/java/com/devoxx/genie/ui/panel/log/AgentMcpLogPanel.java
@@ -4,8 +4,10 @@ import com.devoxx.genie.model.activity.ActivityMessage;
 import com.devoxx.genie.model.activity.ActivitySource;
 import com.devoxx.genie.model.agent.AgentType;
 import com.devoxx.genie.model.mcp.MCPMessage;
+import com.devoxx.genie.model.rag.RAGLogMessage;
 import com.devoxx.genie.service.activity.ActivityLoggingMessage;
 import com.devoxx.genie.service.mcp.MCPLoggingMessage;
+import com.devoxx.genie.service.rag.RAGLoggingMessage;
 import com.devoxx.genie.ui.topic.AppTopics;
 import com.devoxx.genie.ui.util.NotificationUtil;
 import com.devoxx.genie.util.MessageBusUtil;
@@ -47,7 +49,7 @@ import java.util.function.Function;
  * Double-click a log entry to open full content in a new editor tab.
  */
 @Slf4j
-public class AgentMcpLogPanel extends SimpleToolWindowPanel implements ActivityLoggingMessage, MCPLoggingMessage, Disposable {
+public class AgentMcpLogPanel extends SimpleToolWindowPanel implements ActivityLoggingMessage, MCPLoggingMessage, RAGLoggingMessage, Disposable {
 
     private static final int DEFAULT_MAX_LOG_ENTRIES = 1000;
     private static final int BATCH_SIZE = 20;
@@ -69,8 +71,8 @@ public class AgentMcpLogPanel extends SimpleToolWindowPanel implements ActivityL
     private static final DateTimeFormatter TIME_FORMATTER = DateTimeFormatter.ofPattern("HH:mm:ss.SSS");
     private static final ObjectMapper JSON_MAPPER = new ObjectMapper().enable(SerializationFeature.INDENT_OUTPUT);
 
-    enum LogSource { MCP, AGENT }
-    enum LogFilter { ALL, MCP_ONLY, AGENT_ONLY }
+    enum LogSource { MCP, AGENT, RAG }
+    enum LogFilter { ALL, MCP_ONLY, AGENT_ONLY, RAG_ONLY }
 
     record LogEntry(
         String timestamp,
@@ -133,6 +135,7 @@ public class AgentMcpLogPanel extends SimpleToolWindowPanel implements ActivityL
                 MessageBusUtil.connect(project, connection -> {
                     MessageBusUtil.subscribe(connection, AppTopics.ACTIVITY_LOG_MSG, this);
                     MessageBusUtil.subscribe(connection, AppTopics.MCP_TRAFFIC_MSG, this);
+                    MessageBusUtil.subscribe(connection, AppTopics.RAG_LOG_MSG, this);
                     Disposer.register(this, connection);
                 }));
     }
@@ -197,6 +200,7 @@ public class AgentMcpLogPanel extends SimpleToolWindowPanel implements ActivityL
                 case ALL        -> "Show All";
                 case MCP_ONLY   -> "Show MCP Only";
                 case AGENT_ONLY -> "Show Agents Only";
+                case RAG_ONLY   -> "Show RAG Only";
             });
         }
 
@@ -206,6 +210,7 @@ public class AgentMcpLogPanel extends SimpleToolWindowPanel implements ActivityL
             group.add(filterAction("Show All",          LogFilter.ALL));
             group.add(filterAction("Show MCP Only",     LogFilter.MCP_ONLY));
             group.add(filterAction("Show Agents Only",  LogFilter.AGENT_ONLY));
+            group.add(filterAction("Show RAG Only",     LogFilter.RAG_ONLY));
             return group;
         }
 
@@ -235,6 +240,7 @@ public class AgentMcpLogPanel extends SimpleToolWindowPanel implements ActivityL
             case ALL -> true;
             case MCP_ONLY -> e.source() == LogSource.MCP;
             case AGENT_ONLY -> e.source() == LogSource.AGENT;
+            case RAG_ONLY -> e.source() == LogSource.RAG;
         };
     }
 
@@ -305,6 +311,111 @@ public class AgentMcpLogPanel extends SimpleToolWindowPanel implements ActivityL
                 content
         );
         addToPending(entry);
+    }
+
+    /**
+     * Receives RAG retrieval events. Each event describes one semantic search: the query,
+     * configured thresholds, and the list of matched chunks with their scores and a preview.
+     */
+    @Override
+    public void onRAGLoggingMessage(RAGLogMessage message) {
+        if (message == null || isPaused) {
+            return;
+        }
+        String hash = message.getProjectLocationHash();
+        if (hash != null && !hash.equals(project.getLocationHash())) {
+            return;
+        }
+        LogEntry entry = new LogEntry(
+                LocalDateTime.now().format(TIME_FORMATTER),
+                LogSource.RAG,
+                null,
+                formatRagRow(message),
+                formatRagForClipboard(message),
+                formatRagFullContent(message)
+        );
+        addToPending(entry);
+    }
+
+    private static @NotNull String formatRagRow(@NotNull RAGLogMessage m) {
+        StringBuilder sb = new StringBuilder();
+        int hitCount = m.getHits() == null ? 0 : m.getHits().size();
+        sb.append("🔎 RAG: \"").append(summarize(m.getQuery(), 80))
+          .append("\" → ").append(hitCount).append(" hit").append(hitCount == 1 ? "" : "s")
+          .append(" (").append(m.getDurationMs()).append("ms");
+        if (m.getMinScore() != null && m.getMaxResults() != null) {
+            sb.append(", minScore=").append(String.format("%.2f", m.getMinScore()))
+              .append(", topK=").append(m.getMaxResults());
+        }
+        sb.append(")");
+        if (hitCount > 0) {
+            int shown = Math.min(hitCount, INLINE_PREVIEW_MAX_LINES - 1);
+            for (int i = 0; i < shown; i++) {
+                RAGLogMessage.Hit h = m.getHits().get(i);
+                sb.append('\n').append("  • ").append(formatScore(h.getScore()))
+                  .append("  ").append(filenameOf(h.getFilePath()))
+                  .append("  — ").append(summarize(h.getPreview(), INLINE_PREVIEW_MAX_LINE_LEN - 40));
+            }
+            if (hitCount > shown) {
+                sb.append('\n').append("  … (").append(hitCount - shown).append(" more hits)");
+            }
+        }
+        return sb.toString();
+    }
+
+    private static @NotNull String formatRagForClipboard(@NotNull RAGLogMessage m) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("RAG retrieval — query: ").append(m.getQuery() == null ? "" : m.getQuery().replace('\n', ' '))
+          .append(" (").append(m.getDurationMs()).append("ms");
+        if (m.getMinScore() != null) sb.append(", minScore=").append(m.getMinScore());
+        if (m.getMaxResults() != null) sb.append(", topK=").append(m.getMaxResults());
+        sb.append(")");
+        if (m.getHits() != null) {
+            for (RAGLogMessage.Hit h : m.getHits()) {
+                sb.append('\n').append("    [").append(formatScore(h.getScore())).append("] ")
+                  .append(h.getFilePath());
+            }
+        }
+        return sb.toString();
+    }
+
+    private static @NotNull String formatRagFullContent(@NotNull RAGLogMessage m) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("=== RAG Retrieval ===\n");
+        sb.append("Query: ").append(m.getQuery()).append("\n");
+        if (m.getEmbeddingModel() != null) sb.append("Embedding model: ").append(m.getEmbeddingModel()).append("\n");
+        if (m.getMinScore() != null) sb.append("Min score: ").append(m.getMinScore()).append("\n");
+        if (m.getMaxResults() != null) sb.append("Top-K (max results): ").append(m.getMaxResults()).append("\n");
+        sb.append("Duration: ").append(m.getDurationMs()).append(" ms\n");
+        int hitCount = m.getHits() == null ? 0 : m.getHits().size();
+        sb.append("Hits: ").append(hitCount).append("\n\n");
+        if (hitCount > 0) {
+            for (int i = 0; i < m.getHits().size(); i++) {
+                RAGLogMessage.Hit h = m.getHits().get(i);
+                sb.append("--- Hit ").append(i + 1).append(" / ").append(hitCount).append(" ---\n");
+                sb.append("File:   ").append(h.getFilePath()).append("\n");
+                sb.append("Score:  ").append(formatScore(h.getScore())).append("\n");
+                sb.append("Chunk length: ").append(h.getChunkLength()).append(" chars\n");
+                sb.append("Preview:\n").append(h.getPreview() == null ? "" : h.getPreview()).append("\n\n");
+            }
+        }
+        return sb.toString();
+    }
+
+    private static @NotNull String filenameOf(String path) {
+        if (path == null) return "(unknown)";
+        int slash = Math.max(path.lastIndexOf('/'), path.lastIndexOf('\\'));
+        return slash >= 0 ? path.substring(slash + 1) : path;
+    }
+
+    private static @NotNull String summarize(String text, int max) {
+        if (text == null) return "";
+        String oneLine = text.replace('\n', ' ').replace('\r', ' ').trim();
+        return oneLine.length() > max ? oneLine.substring(0, max - 1) + "…" : oneLine;
+    }
+
+    private static @NotNull String formatScore(Double score) {
+        return score == null ? "n/a" : String.format("%.3f", score);
     }
 
     private void addToPending(LogEntry entry) {

--- a/src/main/java/com/devoxx/genie/ui/panel/log/AgentMcpLogPanel.java
+++ b/src/main/java/com/devoxx/genie/ui/panel/log/AgentMcpLogPanel.java
@@ -102,10 +102,14 @@ public class AgentMcpLogPanel extends SimpleToolWindowPanel implements ActivityL
         super(true);
         this.project = project;
 
+        // Track viewport width so cells never paint beyond the tool window's clip rect.
+        // Without this, a single long RAG hit preview (or run_command line) forces the JList
+        // wider than its viewport, and every JCEF-driven repaint during LLM streaming
+        // re-paints that oversized area — visible as IDE-wide flicker.
         logList = new JBList<>(logListModel) {
             @Override
             public boolean getScrollableTracksViewportWidth() {
-                return false;
+                return true;
             }
         };
         logList.setCellRenderer(new CombinedLogEntryRenderer());
@@ -127,6 +131,7 @@ public class AgentMcpLogPanel extends SimpleToolWindowPanel implements ActivityL
 
         JBScrollPane scrollPane = new JBScrollPane(logList);
         scrollPane.setBorder(JBUI.Borders.empty());
+        scrollPane.setHorizontalScrollBarPolicy(ScrollPaneConstants.HORIZONTAL_SCROLLBAR_NEVER);
         setContent(scrollPane);
 
         setupToolbar();
@@ -151,6 +156,11 @@ public class AgentMcpLogPanel extends SimpleToolWindowPanel implements ActivityL
         actionGroup.add(new AnAction("Clear Logs", "Clear all log entries",
                 IconLoader.getIcon("/actions/gc.svg", AgentMcpLogPanel.class)) {
             @Override
+            public @NotNull ActionUpdateThread getActionUpdateThread() {
+                return ActionUpdateThread.EDT;
+            }
+
+            @Override
             public void actionPerformed(@NotNull AnActionEvent e) {
                 clearLogs();
             }
@@ -158,6 +168,11 @@ public class AgentMcpLogPanel extends SimpleToolWindowPanel implements ActivityL
 
         actionGroup.add(new ToggleAction("Pause", "Pause log collection",
                 IconLoader.getIcon("/actions/pause.svg", AgentMcpLogPanel.class)) {
+            @Override
+            public @NotNull ActionUpdateThread getActionUpdateThread() {
+                return ActionUpdateThread.EDT;
+            }
+
             @Override
             public boolean isSelected(@NotNull AnActionEvent e) {
                 return isPaused;
@@ -168,11 +183,19 @@ public class AgentMcpLogPanel extends SimpleToolWindowPanel implements ActivityL
                 isPaused = state;
                 e.getPresentation().setText(isPaused ? "Resume" : "Pause");
                 e.getPresentation().setDescription(isPaused ? "Resume log collection" : "Pause log collection");
+                e.getPresentation().setIcon(IconLoader.getIcon(
+                        isPaused ? "/actions/resume.svg" : "/actions/pause.svg",
+                        AgentMcpLogPanel.class));
             }
         });
 
         actionGroup.add(new AnAction("Copy All Logs", "Copy all log entries to clipboard",
                 IconLoader.getIcon("/actions/copy.svg", AgentMcpLogPanel.class)) {
+            @Override
+            public @NotNull ActionUpdateThread getActionUpdateThread() {
+                return ActionUpdateThread.EDT;
+            }
+
             @Override
             public void actionPerformed(@NotNull AnActionEvent e) {
                 copyLogsToClipboard();
@@ -181,6 +204,11 @@ public class AgentMcpLogPanel extends SimpleToolWindowPanel implements ActivityL
 
         actionGroup.add(new AnAction("Settings", "Configure log retention",
                 IconLoader.getIcon("/general/settings.svg", AgentMcpLogPanel.class)) {
+            @Override
+            public @NotNull ActionUpdateThread getActionUpdateThread() {
+                return ActionUpdateThread.EDT;
+            }
+
             @Override
             public void actionPerformed(@NotNull AnActionEvent e) {
                 showSettingsDialog();
@@ -193,6 +221,11 @@ public class AgentMcpLogPanel extends SimpleToolWindowPanel implements ActivityL
     }
 
     private class FilterComboBoxAction extends ComboBoxAction {
+
+        @Override
+        public @NotNull ActionUpdateThread getActionUpdateThread() {
+            return ActionUpdateThread.EDT;
+        }
 
         @Override
         public void update(@NotNull AnActionEvent e) {
@@ -338,10 +371,15 @@ public class AgentMcpLogPanel extends SimpleToolWindowPanel implements ActivityL
     }
 
     private static @NotNull String formatRagRow(@NotNull RAGLogMessage m) {
+        // Single-line summary. The multi-line bullet list of hits used to be inlined here,
+        // but the resulting tall variable-height JList cells caused continuous repaint of the
+        // tool window (visible as IDE-wide flicker) while MCP/Agent rows — always single-line —
+        // were fine. Full per-hit detail is still available via the hover tooltip and the
+        // double-click "open in editor" view.
         StringBuilder sb = new StringBuilder();
         int hitCount = m.getHits() == null ? 0 : m.getHits().size();
-        sb.append("🔎 RAG: \"").append(summarize(m.getQuery(), 80))
-          .append("\" → ").append(hitCount).append(" hit").append(hitCount == 1 ? "" : "s")
+        sb.append("RAG: \"").append(summarize(m.getQuery(), 80))
+          .append("\" -> ").append(hitCount).append(" hit").append(hitCount == 1 ? "" : "s")
           .append(" (").append(m.getDurationMs()).append("ms");
         if (m.getMinScore() != null && m.getMaxResults() != null) {
             sb.append(", minScore=").append(String.format("%.2f", m.getMinScore()))
@@ -349,16 +387,17 @@ public class AgentMcpLogPanel extends SimpleToolWindowPanel implements ActivityL
         }
         sb.append(")");
         if (hitCount > 0) {
-            int shown = Math.min(hitCount, INLINE_PREVIEW_MAX_LINES - 1);
+            sb.append("  [");
+            int shown = Math.min(hitCount, 4);
             for (int i = 0; i < shown; i++) {
+                if (i > 0) sb.append(", ");
                 RAGLogMessage.Hit h = m.getHits().get(i);
-                sb.append('\n').append("  • ").append(formatScore(h.getScore()))
-                  .append("  ").append(filenameOf(h.getFilePath()))
-                  .append("  — ").append(summarize(h.getPreview(), INLINE_PREVIEW_MAX_LINE_LEN - 40));
+                sb.append(filenameOf(h.getFilePath())).append(' ').append(formatScore(h.getScore()));
             }
             if (hitCount > shown) {
-                sb.append('\n').append("  … (").append(hitCount - shown).append(" more hits)");
+                sb.append(", +").append(hitCount - shown).append(" more");
             }
+            sb.append(']');
         }
         return sb.toString();
     }
@@ -763,7 +802,11 @@ public class AgentMcpLogPanel extends SimpleToolWindowPanel implements ActivityL
             JLabel label = (JLabel) super.getListCellRendererComponent(list, value, index, isSelected, cellHasFocus);
 
             if (value instanceof LogEntry entry && !isSelected) {
-                String sourceTag = entry.source() == LogSource.MCP ? "[MCP] " : "[AGT] ";
+                String sourceTag = switch (entry.source()) {
+                    case MCP   -> "[MCP] ";
+                    case AGENT -> "[AGT] ";
+                    case RAG   -> "[RAG] ";
+                };
                 String badge = currentFilter == LogFilter.ALL ? sourceTag : "";
                 String plain = entry.timestamp() + " " + badge + entry.message();
                 label.setText(toHtmlRow(plain));

--- a/src/main/java/com/devoxx/genie/ui/settings/DevoxxGenieStateService.java
+++ b/src/main/java/com/devoxx/genie/ui/settings/DevoxxGenieStateService.java
@@ -254,6 +254,8 @@ public final class DevoxxGenieStateService implements PersistentStateComponent<D
     // Agent mode settings
     private Boolean agentModeEnabled = false;
     private Integer agentMaxToolCalls = AGENT_MAX_TOOL_CALLS;
+    /** Wall-clock cap for an entire agent/MCP conversation; safety net against silent hangs. */
+    private Integer agentMaxExecutionTimeSeconds = AGENT_MAX_EXECUTION_SECONDS;
     private Boolean agentAutoApproveReadOnly = false;
     private Boolean agentWriteApprovalRequired = true;
     private Boolean agentDebugLogsEnabled = false;

--- a/src/main/java/com/devoxx/genie/ui/settings/DevoxxGenieStateService.java
+++ b/src/main/java/com/devoxx/genie/ui/settings/DevoxxGenieStateService.java
@@ -256,6 +256,17 @@ public final class DevoxxGenieStateService implements PersistentStateComponent<D
     private Integer agentMaxToolCalls = AGENT_MAX_TOOL_CALLS;
     /** Wall-clock cap for an entire agent/MCP conversation; safety net against silent hangs. */
     private Integer agentMaxExecutionTimeSeconds = AGENT_MAX_EXECUTION_SECONDS;
+
+    // RAG retrieval-quality settings
+    /**
+     * When true, the user's prompt is paraphrased into multiple variants by the current chat
+     * model before semantic search; per-variant results are fused via Reciprocal Rank Fusion.
+     * Trades one extra LLM call (latency + cost) for substantially better retrieval on
+     * meta-style queries ("where do we discuss X?", "list me all content about Y").
+     */
+    private Boolean ragQueryExpansionEnabled = false;
+    /** Number of paraphrased variants to generate per query when expansion is enabled. */
+    private Integer ragQueryExpansionN = 3;
     private Boolean agentAutoApproveReadOnly = false;
     private Boolean agentWriteApprovalRequired = true;
     private Boolean agentDebugLogsEnabled = false;

--- a/src/main/java/com/devoxx/genie/ui/settings/rag/RAGSettingsComponent.java
+++ b/src/main/java/com/devoxx/genie/ui/settings/rag/RAGSettingsComponent.java
@@ -193,15 +193,29 @@ public class RAGSettingsComponent extends AbstractSettingsComponent {
         addSection(panel, gbc, RAG_SETTINGS_SECTION_TITLE);
         addSettingRow(panel, gbc, "Chroma DB port", leftAligned(portIndexer));
         addSettingRow(panel, gbc, "Minimum score", leftAligned(minScoreField));
-        addSettingRow(panel, gbc, "Set the minimum score threshold for semantic search results. A lower value will include more results.");
+        addHelpText(panel, gbc, "Set the minimum score threshold for semantic search results. A lower value will include more results.");
         addSettingRow(panel, gbc, "Maximum results", leftAligned(maxResultsSpinner));
-        addSettingRow(panel, gbc, "How many results do you want to include in prompt window context?");
+        addHelpText(panel, gbc, "How many results do you want to include in prompt window context?");
 
         addSettingRow(panel, gbc, "Query expansion", leftAligned(queryExpansionCheckBox));
-        addSettingRow(panel, gbc, "Paraphrase the query into multiple variants and fuse the per-variant results " +
+        addHelpText(panel, gbc, "Paraphrase the query into multiple variants and fuse the per-variant results " +
                 "(Reciprocal Rank Fusion). Improves retrieval on meta-style questions such as " +
                 "\"where do we discuss X?\" at the cost of one extra LLM call per RAG search.");
         addSettingRow(panel, gbc, "Number of variants", leftAligned(queryExpansionVariantsSpinner));
+    }
+
+    /**
+     * Add a wrapping help-text row under a setting. Uses the same HTML-with-100%-width trick
+     * as {@link #addInfoLabel} so the text wraps to fit the dialog width instead of overflowing.
+     * Styled with the IDE's context-help foreground so it visually reads as secondary text.
+     */
+    private void addHelpText(@NotNull JPanel panel, @NotNull GridBagConstraints gbc, @NotNull String text) {
+        JBLabel helpLabel = new JBLabel("<html><body style='width: 100%;'>" + text + "</body></html>");
+        helpLabel.setForeground(UIUtil.getContextHelpForeground());
+        gbc.gridwidth = 2;
+        gbc.gridx = 0;
+        panel.add(helpLabel, gbc);
+        gbc.gridy++;
     }
 
     /**

--- a/src/main/java/com/devoxx/genie/ui/settings/rag/RAGSettingsComponent.java
+++ b/src/main/java/com/devoxx/genie/ui/settings/rag/RAGSettingsComponent.java
@@ -191,17 +191,28 @@ public class RAGSettingsComponent extends AbstractSettingsComponent {
 
     private void addRAGSettingsSection(JPanel panel, GridBagConstraints gbc) {
         addSection(panel, gbc, RAG_SETTINGS_SECTION_TITLE);
-        addSettingRow(panel, gbc, "Chroma DB port", portIndexer);
-        addSettingRow(panel, gbc, "Minimum score", minScoreField);
+        addSettingRow(panel, gbc, "Chroma DB port", leftAligned(portIndexer));
+        addSettingRow(panel, gbc, "Minimum score", leftAligned(minScoreField));
         addSettingRow(panel, gbc, "Set the minimum score threshold for semantic search results. A lower value will include more results.");
-        addSettingRow(panel, gbc, "Maximum results", maxResultsSpinner);
+        addSettingRow(panel, gbc, "Maximum results", leftAligned(maxResultsSpinner));
         addSettingRow(panel, gbc, "How many results do you want to include in prompt window context?");
 
-        addSettingRow(panel, gbc, "Query expansion", queryExpansionCheckBox);
+        addSettingRow(panel, gbc, "Query expansion", leftAligned(queryExpansionCheckBox));
         addSettingRow(panel, gbc, "Paraphrase the query into multiple variants and fuse the per-variant results " +
                 "(Reciprocal Rank Fusion). Improves retrieval on meta-style questions such as " +
                 "\"where do we discuss X?\" at the cost of one extra LLM call per RAG search.");
-        addSettingRow(panel, gbc, "Number of variants", queryExpansionVariantsSpinner);
+        addSettingRow(panel, gbc, "Number of variants", leftAligned(queryExpansionVariantsSpinner));
+    }
+
+    /**
+     * Wrap a spinner/checkbox in a left-aligned FlowLayout panel so it keeps its natural
+     * width when the enclosing column uses {@code GridBagConstraints.HORIZONTAL} fill. Without
+     * this, JSpinner stretches to fill the whole column and the digits become hard to spot.
+     */
+    private static @NotNull JComponent leftAligned(@NotNull JComponent component) {
+        JPanel wrapper = new JPanel(new FlowLayout(FlowLayout.LEFT, 0, 0));
+        wrapper.add(component);
+        return wrapper;
     }
 
     private void addIndexedProjectsSection(JPanel panel, GridBagConstraints gbc) {

--- a/src/main/java/com/devoxx/genie/ui/settings/rag/RAGSettingsComponent.java
+++ b/src/main/java/com/devoxx/genie/ui/settings/rag/RAGSettingsComponent.java
@@ -50,6 +50,17 @@ public class RAGSettingsComponent extends AbstractSettingsComponent {
     @Getter
     private final JSpinner minScoreField = new JSpinner(new SpinnerNumberModel(stateService.getIndexerMinScore().doubleValue(), 0.0d, 1.0d, 0.01d));
 
+    @Getter
+    private final JBCheckBox queryExpansionCheckBox = new JBCheckBox(
+            "Enable LLM query expansion (one extra LLM call per RAG search)",
+            Boolean.TRUE.equals(stateService.getRagQueryExpansionEnabled()));
+
+    @Getter
+    private final JBIntSpinner queryExpansionVariantsSpinner = new JBIntSpinner(
+            new UINumericRange(
+                    stateService.getRagQueryExpansionN() == null ? 3 : stateService.getRagQueryExpansionN(),
+                    1, 10));
+
     private final Project project;
     private JButton startIndexButton;
     private final JButton actionButton = new JButton();
@@ -95,6 +106,8 @@ public class RAGSettingsComponent extends AbstractSettingsComponent {
                 startIndexButton.setVisible(false);
             }
         });
+        // Variants spinner is only meaningful when query expansion is on.
+        queryExpansionCheckBox.addActionListener(e -> updateComponentsEnabled());
     }
 
     private void addProgressSection(@NotNull JPanel panel, @NotNull GridBagConstraints gbc) {
@@ -183,6 +196,12 @@ public class RAGSettingsComponent extends AbstractSettingsComponent {
         addSettingRow(panel, gbc, "Set the minimum score threshold for semantic search results. A lower value will include more results.");
         addSettingRow(panel, gbc, "Maximum results", maxResultsSpinner);
         addSettingRow(panel, gbc, "How many results do you want to include in prompt window context?");
+
+        addSettingRow(panel, gbc, "Query expansion", queryExpansionCheckBox);
+        addSettingRow(panel, gbc, "Paraphrase the query into multiple variants and fuse the per-variant results " +
+                "(Reciprocal Rank Fusion). Improves retrieval on meta-style questions such as " +
+                "\"where do we discuss X?\" at the cost of one extra LLM call per RAG search.");
+        addSettingRow(panel, gbc, "Number of variants", queryExpansionVariantsSpinner);
     }
 
     private void addIndexedProjectsSection(JPanel panel, GridBagConstraints gbc) {
@@ -386,6 +405,9 @@ public class RAGSettingsComponent extends AbstractSettingsComponent {
         minScoreField.setEnabled(enabled);
         actionButton.setEnabled(enabled);
         collectionsTable.setEnabled(enabled);
+        queryExpansionCheckBox.setEnabled(enabled);
+        // Variants spinner is doubly-gated: master switch + the expansion sub-switch.
+        queryExpansionVariantsSpinner.setEnabled(enabled && queryExpansionCheckBox.isSelected());
     }
 
     private void setupTable() {

--- a/src/main/java/com/devoxx/genie/ui/settings/rag/RAGSettingsComponent.java
+++ b/src/main/java/com/devoxx/genie/ui/settings/rag/RAGSettingsComponent.java
@@ -177,16 +177,13 @@ public class RAGSettingsComponent extends AbstractSettingsComponent {
     }
 
     private void addInfoLabel(@NotNull JPanel panel, GridBagConstraints gbc) {
-        JBLabel infoLabel = new JBLabel("<html><body style='width: 100%;'>" +
-                "Retrieval-augmented Generation (RAG) leverages semantic search to find relevant code<BR>" +
-                "based on your queries.<BR>" +
-                "The indexer uses the \"Scan & Copy Project\" settings to exclude specific directories,<BR>" +
-                "files, and extensions, and stores the indexed files in a local ChromaDB vector database." +
-                "</body></html>");
-        infoLabel.setForeground(UIUtil.getContextHelpForeground());
-        infoLabel.setBorder(JBUI.Borders.emptyBottom(10));
-        panel.add(infoLabel, gbc);
-        gbc.gridy++;
+        // Use the wrapping help-text component for the same width-constrained behaviour as the
+        // per-setting help rows; explicit line breaks not needed since JTextArea word-wraps.
+        addHelpText(panel, gbc,
+                "Retrieval-augmented Generation (RAG) leverages semantic search to find relevant code " +
+                "based on your queries. The indexer uses the \"Scan & Copy Project\" settings to " +
+                "exclude specific directories, files, and extensions, and stores the indexed files in " +
+                "a local ChromaDB vector database.");
     }
 
     private void addRAGSettingsSection(JPanel panel, GridBagConstraints gbc) {
@@ -205,17 +202,32 @@ public class RAGSettingsComponent extends AbstractSettingsComponent {
     }
 
     /**
-     * Add a wrapping help-text row under a setting. Uses the same HTML-with-100%-width trick
-     * as {@link #addInfoLabel} so the text wraps to fit the dialog width instead of overflowing.
-     * Styled with the IDE's context-help foreground so it visually reads as secondary text.
+     * Add a wrapping help-text row under a setting. JLabel doesn't word-wrap reliably even
+     * with the HTML-and-100%-width trick (BasicHTML computes preferred width from the full
+     * text, so the dialog grows to fit). A non-editable JTextArea styled like a label DOES
+     * wrap natively when the layout gives it a constrained width, so use that.
      */
     private void addHelpText(@NotNull JPanel panel, @NotNull GridBagConstraints gbc, @NotNull String text) {
-        JBLabel helpLabel = new JBLabel("<html><body style='width: 100%;'>" + text + "</body></html>");
-        helpLabel.setForeground(UIUtil.getContextHelpForeground());
+        JTextArea helpArea = new JTextArea(text);
+        helpArea.setLineWrap(true);
+        helpArea.setWrapStyleWord(true);
+        helpArea.setEditable(false);
+        helpArea.setFocusable(false);
+        helpArea.setOpaque(false);
+        helpArea.setBorder(null);
+        helpArea.setFont(UIManager.getFont("Label.font"));
+        helpArea.setForeground(UIUtil.getContextHelpForeground());
+        // (0, ...) preferred width — let the GridBag column dictate width; height grows as needed
+        helpArea.setPreferredSize(null);
+        helpArea.setMinimumSize(new Dimension(0, 0));
+
         gbc.gridwidth = 2;
         gbc.gridx = 0;
-        panel.add(helpLabel, gbc);
+        gbc.fill = GridBagConstraints.HORIZONTAL;
+        gbc.weightx = 1.0;
+        panel.add(helpArea, gbc);
         gbc.gridy++;
+        gbc.weightx = 0;
     }
 
     /**

--- a/src/main/java/com/devoxx/genie/ui/settings/rag/RAGSettingsConfigurable.java
+++ b/src/main/java/com/devoxx/genie/ui/settings/rag/RAGSettingsConfigurable.java
@@ -54,6 +54,10 @@ public class RAGSettingsConfigurable implements Configurable {
         isModified |= ragSettingsComponent.getPortIndexer().getNumber() != stateService.getIndexerPort();
         isModified |= ragSettingsComponent.getMaxResultsSpinner().getNumber() != stateService.getIndexerMaxResults();
         isModified |= ragSettingsComponent.getMinScoreField().getValue() != stateService.getIndexerMinScore();
+        isModified |= ragSettingsComponent.getQueryExpansionCheckBox().isSelected()
+                != Boolean.TRUE.equals(stateService.getRagQueryExpansionEnabled());
+        int storedN = stateService.getRagQueryExpansionN() == null ? 3 : stateService.getRagQueryExpansionN();
+        isModified |= ragSettingsComponent.getQueryExpansionVariantsSpinner().getNumber() != storedN;
 
         return isModified;
     }
@@ -72,6 +76,8 @@ public class RAGSettingsConfigurable implements Configurable {
         stateService.setIndexerPort(ragSettingsComponent.getPortIndexer().getNumber());
         stateService.setIndexerMinScore((Double) ragSettingsComponent.getMinScoreField().getValue());
         stateService.setIndexerMaxResults(ragSettingsComponent.getMaxResultsSpinner().getNumber());
+        stateService.setRagQueryExpansionEnabled(ragSettingsComponent.getQueryExpansionCheckBox().isSelected());
+        stateService.setRagQueryExpansionN(ragSettingsComponent.getQueryExpansionVariantsSpinner().getNumber());
 
         // Re-arm the feature-enablement analytics snapshot (task-209).
         com.devoxx.genie.service.analytics.DevoxxGenieSettingsChangedTopic.notifySettingsChanged();
@@ -93,5 +99,9 @@ public class RAGSettingsConfigurable implements Configurable {
         ragSettingsComponent.getPortIndexer().setNumber(stateService.getIndexerPort());
         ragSettingsComponent.getMinScoreField().setValue(stateService.getIndexerMinScore());
         ragSettingsComponent.getMaxResultsSpinner().setNumber(stateService.getIndexerMaxResults());
+        ragSettingsComponent.getQueryExpansionCheckBox().setSelected(
+                Boolean.TRUE.equals(stateService.getRagQueryExpansionEnabled()));
+        ragSettingsComponent.getQueryExpansionVariantsSpinner().setNumber(
+                stateService.getRagQueryExpansionN() == null ? 3 : stateService.getRagQueryExpansionN());
     }
 }

--- a/src/main/java/com/devoxx/genie/ui/settings/rag/RAGSettingsHandler.java
+++ b/src/main/java/com/devoxx/genie/ui/settings/rag/RAGSettingsHandler.java
@@ -3,6 +3,7 @@ package com.devoxx.genie.ui.settings.rag;
 import com.devoxx.genie.chatmodel.local.ollama.OllamaModelService;
 import com.devoxx.genie.service.chromadb.ChromaDBManager;
 import com.devoxx.genie.service.chromadb.ChromaDBStatusCallback;
+import com.devoxx.genie.service.chromadb.ChromaDockerService;
 import com.devoxx.genie.service.rag.RagValidatorService;
 import com.devoxx.genie.service.rag.validator.ValidationActionType;
 import com.devoxx.genie.service.rag.validator.ValidationResult;
@@ -11,6 +12,7 @@ import com.devoxx.genie.service.rag.validator.ValidatorType;
 import com.devoxx.genie.ui.panel.ValidatorsPanel;
 import com.devoxx.genie.ui.util.NotificationUtil;
 import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.application.ModalityState;
 import com.intellij.openapi.progress.ProgressIndicator;
 import com.intellij.openapi.progress.Task;
 import com.intellij.openapi.project.Project;
@@ -18,6 +20,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import javax.swing.*;
+import java.awt.Container;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.io.IOException;
@@ -48,6 +51,8 @@ public class RAGSettingsHandler implements ActionListener {
             return;
         }
 
+        // ModalityState.any() so this runs even when invoked from background callbacks
+        // while the Settings dialog is open (otherwise the EDT defers it until close).
         ApplicationManager.getApplication().invokeLater(() -> {
             try {
                 validationInProgress = true;
@@ -71,7 +76,7 @@ public class RAGSettingsHandler implements ActionListener {
                     performValidation();
                 }
             }
-        });
+        }, ModalityState.any());
     }
 
     public void handleValidationAction(@Nullable ValidatorStatus status) {
@@ -109,7 +114,14 @@ public class RAGSettingsHandler implements ActionListener {
         ValidationActionType action = (ValidationActionType) button.getClientProperty("action");
 
         if (validatorType == ValidatorType.CHROMADB) {
-            handleChromaDBAction(action);
+            // For the Pull Image action we replace the button with an inline progress widget
+            // so the user has immediate visible feedback in the panel — the IDE's background-
+            // task spinner alone is too easy to miss for a multi-minute pull.
+            if (action == ValidationActionType.PULL_CHROMA_DB) {
+                pullChromaDBImage(button);
+            } else {
+                handleChromaDBAction(action);
+            }
         } else if (validatorType == ValidatorType.NOMIC) {
             handleNomicAction(action);
         }
@@ -137,13 +149,13 @@ public class RAGSettingsHandler implements ActionListener {
                     ApplicationManager.getApplication().invokeLater(() -> {
                         NotificationUtil.sendNotification(project, "Nomic Embed model pulled successfully");
                         performValidation();
-                    });
+                    }, ModalityState.any());
                 } catch (IOException e) {
                     ApplicationManager.getApplication().invokeLater(() -> {
                         NotificationUtil.sendNotification(project, "Failed to pull Nomic Embed model: " +
                                 e.getMessage());
                         performValidation();
-                    });
+                    }, ModalityState.any());
                 } finally {
                     validationInProgress = false;
                 }
@@ -153,57 +165,142 @@ public class RAGSettingsHandler implements ActionListener {
 
     private void handleChromaDBAction(@NotNull ValidationActionType action) {
         switch (action) {
-            case PULL_CHROMA_DB -> pullChromaDBImage();
+            // PULL_CHROMA_DB is handled in actionPerformed (it needs the source button to
+            // render inline progress). Anything reaching this method without that context
+            // falls back to the no-UI variant.
+            case PULL_CHROMA_DB -> pullChromaDBImageFallback();
             case START_CHROMA_DB -> startChromaDB();
             default -> NotificationUtil.sendNotification(project,
                     "Unknown action requested for ChromaDB");
         }
     }
 
-    private void pullChromaDBImage() {
-        new Task.Backgroundable(project, "Pulling ChromaDB Image") {
-            @Override
-            public void run(@NotNull ProgressIndicator indicator) {
-                chromaDBManager.pullChromaDockerImage(project, new ChromaDBStatusCallback() {
-                    @Override
-                    public void onSuccess() {
-                        ApplicationManager.getApplication().invokeLater(() -> {
-                            NotificationUtil.sendNotification(project,
-                                    "ChromaDB image pulled successfully");
-                            performValidation();
-                        });
-                    }
-
-                    @Override
-                    public void onError(String message) {
-                        ApplicationManager.getApplication().invokeLater(() -> {
-                            NotificationUtil.sendNotification(project,
-                                    "Failed to pull ChromaDB image: " + message);
-                            performValidation();
-                        });
-                    }
-                });
+    /**
+     * Pull the ChromaDB image, replacing the source button with an inline indeterminate
+     * progress bar + status label so the user has immediate, visible feedback inside the
+     * RAG settings panel (the IDE's background-task spinner alone is too easy to miss).
+     * The widgets are discarded on completion when {@link #performValidation()} rebuilds
+     * the validator panel from scratch.
+     */
+    private void pullChromaDBImage(@NotNull JButton sourceButton) {
+        Container parent = sourceButton.getParent();
+        if (parent == null) {
+            pullChromaDBImageFallback();
+            return;
+        }
+        int buttonIndex = -1;
+        for (int i = 0; i < parent.getComponentCount(); i++) {
+            if (parent.getComponent(i) == sourceButton) {
+                buttonIndex = i;
+                break;
             }
-        }.queue();
+        }
+        if (buttonIndex < 0) {
+            pullChromaDBImageFallback();
+            return;
+        }
+
+        JProgressBar bar = new JProgressBar();
+        bar.setIndeterminate(true);
+        bar.setPreferredSize(new java.awt.Dimension(120, sourceButton.getPreferredSize().height));
+        JLabel statusLabel = new JLabel("Starting pull…");
+
+        JPanel progressPanel = new JPanel();
+        progressPanel.setLayout(new BoxLayout(progressPanel, BoxLayout.X_AXIS));
+        progressPanel.add(statusLabel);
+        progressPanel.add(Box.createHorizontalStrut(8));
+        progressPanel.add(bar);
+
+        parent.remove(buttonIndex);
+        parent.add(progressPanel, buttonIndex);
+        parent.revalidate();
+        parent.repaint();
+
+        // Why we bypass chromaDBManager.pullChromaDockerImage here: that path wraps the work
+        // in ProgressManager.run(new Task.Backgroundable(...)), whose BackgroundableProcessIndicator
+        // setup needs an EDT pass — and the IntelliJ Settings dialog holds modal context, so
+        // that EDT work is deferred until Apply/OK is pressed. Net result: clicking "Pull
+        // Image" inside Settings looked frozen until the user pressed Apply.
+        //
+        // The inline widget below is our visible feedback, so we don't need the status-bar
+        // Backgroundable indicator at all. Direct pooled-thread submission + ModalityState.any()
+        // for the EDT updates sidesteps the modal-deferral entirely.
+        ChromaDockerService dockerService = ApplicationManager.getApplication()
+                .getService(ChromaDockerService.class);
+        java.util.function.Consumer<String> progressListener = status ->
+                ApplicationManager.getApplication().invokeLater(
+                        () -> statusLabel.setText(status), ModalityState.any());
+
+        ChromaDBStatusCallback callback = new ChromaDBStatusCallback() {
+            @Override
+            public void onSuccess() {
+                ApplicationManager.getApplication().invokeLater(() -> {
+                    NotificationUtil.sendNotification(project, "ChromaDB image pulled successfully");
+                    performValidation();
+                }, ModalityState.any());
+            }
+
+            @Override
+            public void onError(String message) {
+                ApplicationManager.getApplication().invokeLater(() -> {
+                    NotificationUtil.sendNotification(project, "Failed to pull ChromaDB image: " + message);
+                    performValidation();
+                }, ModalityState.any());
+            }
+        };
+
+        ApplicationManager.getApplication().executeOnPooledThread(() -> {
+            try {
+                dockerService.pullChromaDockerImage(callback, null, progressListener);
+                callback.onSuccess();
+            } catch (Exception e) {
+                callback.onError(e.getMessage());
+            }
+        });
+    }
+
+    /** Fallback when the source button isn't laid out where we expect — just delegate to the
+     *  service and rely on the background-task spinner + completion notification. */
+    private void pullChromaDBImageFallback() {
+        NotificationUtil.sendNotification(project,
+                "Pulling ChromaDB image — see IDE status bar for progress.");
+        chromaDBManager.pullChromaDockerImage(project, new ChromaDBStatusCallback() {
+            @Override
+            public void onSuccess() {
+                ApplicationManager.getApplication().invokeLater(() -> {
+                    NotificationUtil.sendNotification(project, "ChromaDB image pulled successfully");
+                    performValidation();
+                }, ModalityState.any());
+            }
+
+            @Override
+            public void onError(String message) {
+                ApplicationManager.getApplication().invokeLater(() -> {
+                    NotificationUtil.sendNotification(project, "Failed to pull ChromaDB image: " + message);
+                    performValidation();
+                }, ModalityState.any());
+            }
+        });
     }
 
     private void startChromaDB() {
-        new Task.Backgroundable(project, "Starting ChromaDB") {
+        // Immediate confirmation balloon — the actual work runs under a background Task whose
+        // progress only shows in the status-bar spinner, which is easy to miss. Without this,
+        // a first-time pull (~500 MB) makes the button look broken for several minutes.
+        NotificationUtil.sendNotification(project,
+                "Starting ChromaDB — first run pulls the Docker image (may take a few minutes). " +
+                        "Watch the IDE status bar for progress.");
+        chromaDBManager.startChromaDB(project, new ChromaDBStatusCallback() {
             @Override
-            public void run(@NotNull ProgressIndicator indicator) {
-                chromaDBManager.startChromaDB(project, new ChromaDBStatusCallback() {
-                    @Override
-                    public void onSuccess() {
-                        refreshValidationState("ChromaDB started successfully");
-                    }
-
-                    @Override
-                    public void onError(String message) {
-                        refreshValidationState("Failed to start ChromaDB: " + message);
-                    }
-                });
+            public void onSuccess() {
+                refreshValidationState("ChromaDB started successfully");
             }
-        }.queue();
+
+            @Override
+            public void onError(String message) {
+                refreshValidationState("Failed to start ChromaDB: " + message);
+            }
+        });
     }
 
     private void refreshValidationState(String notification) {
@@ -215,6 +312,6 @@ public class RAGSettingsHandler implements ActionListener {
             } finally {
                 validationInProgress = false; // Reset flag
             }
-        });
+        }, ModalityState.any());
     }
 }

--- a/src/main/java/com/devoxx/genie/ui/settings/rag/table/ButtonEditor.java
+++ b/src/main/java/com/devoxx/genie/ui/settings/rag/table/ButtonEditor.java
@@ -9,6 +9,7 @@ import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.ui.Messages;
 import com.intellij.ui.table.JBTable;
+import lombok.extern.slf4j.Slf4j;
 
 import javax.swing.*;
 import javax.swing.table.DefaultTableModel;
@@ -16,6 +17,7 @@ import java.awt.*;
 import java.io.IOException;
 import java.util.List;
 
+@Slf4j
 public class ButtonEditor extends DefaultCellEditor {
 
     private static final String DELETE_LABEL = "Delete";
@@ -153,9 +155,12 @@ public class ButtonEditor extends DefaultCellEditor {
                     collectionsTable.repaint();
                 }
             } catch (IOException e) {
-                // Don't show error during startup
-                NotificationUtil.sendNotification(project,
-                        "Failed to load collections: " + e.getMessage());
+                // ChromaDB unreachable is the common case here (container not running, wrong
+                // port, etc.) — the validator panel ("ChromaDB is not running" + Start button)
+                // already tells the user this. Surfacing it again as a balloon would just be
+                // noise, and {@code safeLoadCollections} is called on settings-panel open AND
+                // after each indexing run, so the duplicate was firing every time.
+                log.debug("Failed to load Chroma collections (panel will show validator error): {}", e.getMessage());
             }
         });
     }

--- a/src/main/java/com/devoxx/genie/ui/topic/AppTopics.java
+++ b/src/main/java/com/devoxx/genie/ui/topic/AppTopics.java
@@ -2,6 +2,7 @@ package com.devoxx.genie.ui.topic;
 
 import com.devoxx.genie.service.activity.ActivityLoggingMessage;
 import com.devoxx.genie.service.mcp.MCPLoggingMessage;
+import com.devoxx.genie.service.rag.RAGLoggingMessage;
 import com.devoxx.genie.ui.listener.*;
 import com.devoxx.genie.ui.settings.appearance.AppearanceSettingsEvents;
 import com.intellij.util.messages.Topic;
@@ -56,5 +57,8 @@ public class AppTopics {
 
     public static final Topic<ActivityLoggingMessage> ACTIVITY_LOG_MSG =
             Topic.create("activityLoggingMessage", ActivityLoggingMessage.class);
+
+    public static final Topic<RAGLoggingMessage> RAG_LOG_MSG =
+            Topic.create("ragLoggingMessage", RAGLoggingMessage.class);
 
 }

--- a/src/main/java/com/devoxx/genie/ui/window/AgentMcpLogToolWindowFactory.java
+++ b/src/main/java/com/devoxx/genie/ui/window/AgentMcpLogToolWindowFactory.java
@@ -29,7 +29,8 @@ public class AgentMcpLogToolWindowFactory implements ToolWindowFactory {
     public boolean shouldBeAvailable(@NotNull Project project) {
         DevoxxGenieStateService s = DevoxxGenieStateService.getInstance();
         boolean hasCliTools = s.getCliTools() != null && !s.getCliTools().isEmpty();
-        return Boolean.TRUE.equals(s.getAgentModeEnabled()) || MCPService.isMCPEnabled() || hasCliTools;
+        boolean ragOn = Boolean.TRUE.equals(s.getRagEnabled()) || Boolean.TRUE.equals(s.getRagActivated());
+        return Boolean.TRUE.equals(s.getAgentModeEnabled()) || MCPService.isMCPEnabled() || hasCliTools || ragOn;
     }
 
     @Override

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -647,6 +647,7 @@
         <projectService serviceImplementation="com.devoxx.genie.service.ExternalPromptService"/>
         <projectService serviceImplementation="com.devoxx.genie.service.ExternalTaskService"/>
         <projectService serviceImplementation="com.devoxx.genie.service.spec.SpecService"/>
+        <projectService serviceImplementation="com.devoxx.genie.service.rag.watcher.RAGFileWatcher"/>
         <projectService serviceImplementation="com.devoxx.genie.service.spec.BacklogConfigService"/>
         <projectService serviceImplementation="com.devoxx.genie.service.spec.SpecTaskRunnerService"/>
         <projectService serviceImplementation="com.devoxx.genie.service.security.SecurityScannerService"/>

--- a/src/test/java/com/devoxx/genie/service/MessageCreationServiceTest.java
+++ b/src/test/java/com/devoxx/genie/service/MessageCreationServiceTest.java
@@ -83,9 +83,11 @@ class MessageCreationServiceTest {
     void setUp() {
         messageCreationService = new MessageCreationService();
 
-        // Set up common stubs that many tests will need
+        // Set up common stubs that many tests will need. Keep the default user prompt long
+        // enough to clear MessageCreationService.RAG_MIN_QUERY_LENGTH so existing tests that
+        // exercise the RAG path don't suddenly skip retrieval.
         lenient().when(mockChatMessageContext.getProject()).thenReturn(mockProject);
-        lenient().when(mockChatMessageContext.getUserPrompt()).thenReturn("Test prompt");
+        lenient().when(mockChatMessageContext.getUserPrompt()).thenReturn("How does the test prompt feature work?");
         lenient().when(mockChatMessageContext.getLanguageModel()).thenReturn(mockLanguageModel);
     }
 
@@ -635,6 +637,90 @@ class MessageCreationServiceTest {
             assertEquals(2, contents.size());
             assertInstanceOf(TextContent.class, contents.get(0));
             assertInstanceOf(ImageContent.class, contents.get(1));
+        }
+    }
+
+    @Test
+    void shortFollowUpQueriesSkipRag() {
+        // "more?" is the kind of follow-up that should reuse the prior turn's context
+        // instead of triggering a fresh RAG retrieval — both for prompt-cache reasons and
+        // to avoid pointless Ollama embed calls.
+        when(mockChatMessageContext.getFilesContext()).thenReturn(null);
+        when(mockChatMessageContext.getEditorInfo()).thenReturn(mockEditorInfo);
+        when(mockEditorInfo.getSelectedText()).thenReturn(null);
+        when(mockEditorInfo.getSelectedFiles()).thenReturn(null);
+        when(mockChatMessageContext.getUserPrompt()).thenReturn("more?");
+
+        try (MockedStatic<DevoxxGenieStateService> stateServiceMockedStatic = Mockito.mockStatic(DevoxxGenieStateService.class);
+             MockedStatic<ChatMessageContextUtil> chatMessageContextUtilMockedStatic = Mockito.mockStatic(ChatMessageContextUtil.class);
+             MockedStatic<FileListManager> fileListManagerMockedStatic = Mockito.mockStatic(FileListManager.class);
+             MockedStatic<SemanticSearchService> semanticSearchServiceMockedStatic = Mockito.mockStatic(SemanticSearchService.class)) {
+
+            stateServiceMockedStatic.when(DevoxxGenieStateService::getInstance).thenReturn(mockStateService);
+            chatMessageContextUtilMockedStatic.when(() -> ChatMessageContextUtil.isOpenAIo1Model(any())).thenReturn(false);
+            fileListManagerMockedStatic.when(FileListManager::getInstance).thenReturn(mockFileListManager);
+            semanticSearchServiceMockedStatic.when(SemanticSearchService::getInstance).thenReturn(mockSemanticSearchService);
+
+            when(mockStateService.getRagActivated()).thenReturn(true);
+            when(mockFileListManager.getImageFiles(any(Project.class), any())).thenReturn(Collections.emptyList());
+
+            messageCreationService.addUserMessageToContext(mockChatMessageContext);
+
+            verify(mockSemanticSearchService, never()).search(any(), any());
+            // Long enough queries must still trigger RAG — sanity-check the threshold isn't reversed.
+            assertTrue(MessageCreationService.shouldRunRagFor("This is a meaningful question about the codebase"));
+            assertFalse(MessageCreationService.shouldRunRagFor("more?"));
+            assertFalse(MessageCreationService.shouldRunRagFor("why?"));
+            assertFalse(MessageCreationService.shouldRunRagFor("explain"));
+            assertFalse(MessageCreationService.shouldRunRagFor(""));
+            assertFalse(MessageCreationService.shouldRunRagFor(null));
+        }
+    }
+
+    @Test
+    void ragContextIsPlacedImmediatelyBeforeUserPromptForCacheFriendliness() {
+        // Prompt-cache providers cache the stable prefix; the previous code injected
+        // varying RAG output near the top, defeating that cache.
+        when(mockChatMessageContext.getFilesContext()).thenReturn(null);
+        when(mockChatMessageContext.getEditorInfo()).thenReturn(mockEditorInfo);
+        when(mockEditorInfo.getSelectedText()).thenReturn(null);
+        when(mockEditorInfo.getSelectedFiles()).thenReturn(null);
+        when(mockChatMessageContext.getUserPrompt()).thenReturn("Where is the AuthService defined and how is it wired?");
+
+        List<SearchResult> hits = List.of(new SearchResult("/abs/AuthService.java", 0.93, "needle-RAG-content"));
+
+        try (MockedStatic<DevoxxGenieStateService> stateServiceMockedStatic = Mockito.mockStatic(DevoxxGenieStateService.class);
+             MockedStatic<ChatMessageContextUtil> chatMessageContextUtilMockedStatic = Mockito.mockStatic(ChatMessageContextUtil.class);
+             MockedStatic<FileListManager> fileListManagerMockedStatic = Mockito.mockStatic(FileListManager.class);
+             MockedStatic<SemanticSearchService> semanticSearchServiceMockedStatic = Mockito.mockStatic(SemanticSearchService.class)) {
+
+            stateServiceMockedStatic.when(DevoxxGenieStateService::getInstance).thenReturn(mockStateService);
+            chatMessageContextUtilMockedStatic.when(() -> ChatMessageContextUtil.isOpenAIo1Model(any())).thenReturn(false);
+            fileListManagerMockedStatic.when(FileListManager::getInstance).thenReturn(mockFileListManager);
+            semanticSearchServiceMockedStatic.when(SemanticSearchService::getInstance).thenReturn(mockSemanticSearchService);
+
+            when(mockStateService.getRagActivated()).thenReturn(true);
+            when(mockSemanticSearchService.search(any(), any())).thenReturn(hits);
+            when(mockFileListManager.getImageFiles(any(Project.class), any())).thenReturn(Collections.emptyList());
+
+            ArgumentCaptor<UserMessage> captor = ArgumentCaptor.forClass(UserMessage.class);
+            doNothing().when(mockChatMessageContext).setUserMessage(captor.capture());
+
+            messageCreationService.addUserMessageToContext(mockChatMessageContext);
+
+            String prompt = captor.getValue().singleText();
+            int ragIdx = prompt.indexOf("<SemanticContext>");
+            int userIdx = prompt.indexOf("<UserPrompt>");
+            assertTrue(ragIdx >= 0, "RAG context must be present");
+            assertTrue(userIdx >= 0, "UserPrompt must be present");
+            assertTrue(ragIdx < userIdx,
+                    "SemanticContext must appear BEFORE the UserPrompt block (so it's adjacent above the question)");
+            // Nothing between SemanticContext closing tag and UserPrompt opening tag — that
+            // adjacency is what improves local-model grounding.
+            int ragCloseEnd = prompt.indexOf("</SemanticContext>") + "</SemanticContext>".length();
+            String between = prompt.substring(ragCloseEnd, userIdx).trim();
+            assertEquals("", between,
+                    "no content should be injected between </SemanticContext> and <UserPrompt>");
         }
     }
 

--- a/src/test/java/com/devoxx/genie/service/MessageCreationServiceTest.java
+++ b/src/test/java/com/devoxx/genie/service/MessageCreationServiceTest.java
@@ -223,15 +223,17 @@ class MessageCreationServiceTest {
         when(mockEditorInfo.getSelectedText()).thenReturn(null);
         when(mockEditorInfo.getSelectedFiles()).thenReturn(null);
 
-        Map<String, SearchResult> searchResults = new HashMap<>();
-        searchResults.put("testFile.java", new SearchResult(0.95, "test content"));
+        // Two chunks from the same file — must both appear in the prompt; the old Map-keyed-by-path
+        // representation silently collapsed them, hiding retrieval recall problems.
+        List<SearchResult> searchResults = List.of(
+                new SearchResult("/abs/testFile.java", 0.95, "alpha chunk text"),
+                new SearchResult("/abs/testFile.java", 0.91, "beta chunk text")
+        );
 
         try (MockedStatic<DevoxxGenieStateService> stateServiceMockedStatic = Mockito.mockStatic(DevoxxGenieStateService.class);
              MockedStatic<ChatMessageContextUtil> chatMessageContextUtilMockedStatic = Mockito.mockStatic(ChatMessageContextUtil.class);
              MockedStatic<FileListManager> fileListManagerMockedStatic = Mockito.mockStatic(FileListManager.class);
              MockedStatic<SemanticSearchService> semanticSearchServiceMockedStatic = Mockito.mockStatic(SemanticSearchService.class);
-             MockedStatic<Files> filesMockedStatic = Mockito.mockStatic(Files.class);
-             MockedStatic<Paths> pathsMockedStatic = Mockito.mockStatic(Paths.class);
              MockedStatic<NotificationUtil> notificationUtilMockedStatic = Mockito.mockStatic(NotificationUtil.class)) {
 
             stateServiceMockedStatic.when(DevoxxGenieStateService::getInstance).thenReturn(mockStateService);
@@ -243,15 +245,23 @@ class MessageCreationServiceTest {
             when(mockFileListManager.getImageFiles(any(Project.class), any())).thenReturn(Collections.emptyList());
             when(mockSemanticSearchService.search(any(), any())).thenReturn(searchResults);
 
-            Path mockPath = mock(Path.class);
-            pathsMockedStatic.when(() -> Paths.get(anyString())).thenReturn(mockPath);
-            filesMockedStatic.when(() -> Files.readString(any(Path.class))).thenReturn("File content");
+            // Capture the assembled UserMessage so we can assert what landed in the prompt.
+            ArgumentCaptor<UserMessage> messageCaptor = ArgumentCaptor.forClass(UserMessage.class);
+            doNothing().when(mockChatMessageContext).setUserMessage(messageCaptor.capture());
 
             messageCreationService.addUserMessageToContext(mockChatMessageContext);
 
             verify(mockChatMessageContext).setSemanticReferences(anyList());
             verify(mockChatMessageContext).setUserMessage(any(UserMessage.class));
             notificationUtilMockedStatic.verify(() -> NotificationUtil.sendNotification(any(), anyString()));
+
+            String prompt = messageCaptor.getValue().singleText();
+            assertTrue(prompt.contains("alpha chunk text"),
+                    "prompt must embed the actual chunk text returned by the vector store");
+            assertTrue(prompt.contains("beta chunk text"),
+                    "second chunk from the same file must not be silently dropped");
+            assertTrue(prompt.contains("```java"),
+                    "code fence language should be inferred from the file extension (.java)");
         }
     }
 
@@ -630,9 +640,10 @@ class MessageCreationServiceTest {
 
     @Test
     void testExtractFileReferences() {
-        Map<String, SearchResult> searchResults = new HashMap<>();
-        searchResults.put("file1.java", new SearchResult(0.95, "content1"));
-        searchResults.put("file2.java", new SearchResult(0.85, "content2"));
+        List<SearchResult> searchResults = List.of(
+                new SearchResult("file1.java", 0.95, "content1"),
+                new SearchResult("file2.java", 0.85, "content2")
+        );
 
         List<SemanticFile> result = MessageCreationService.extractFileReferences(searchResults);
 

--- a/src/test/java/com/devoxx/genie/service/MessageCreationServiceTest.java
+++ b/src/test/java/com/devoxx/genie/service/MessageCreationServiceTest.java
@@ -245,7 +245,7 @@ class MessageCreationServiceTest {
 
             when(mockStateService.getRagActivated()).thenReturn(true);
             when(mockFileListManager.getImageFiles(any(Project.class), any())).thenReturn(Collections.emptyList());
-            when(mockSemanticSearchService.search(any(), any())).thenReturn(searchResults);
+            when(mockSemanticSearchService.search(any(), any(), any())).thenReturn(searchResults);
 
             // Capture the assembled UserMessage so we can assert what landed in the prompt.
             ArgumentCaptor<UserMessage> messageCaptor = ArgumentCaptor.forClass(UserMessage.class);
@@ -666,7 +666,7 @@ class MessageCreationServiceTest {
 
             messageCreationService.addUserMessageToContext(mockChatMessageContext);
 
-            verify(mockSemanticSearchService, never()).search(any(), any());
+            verify(mockSemanticSearchService, never()).search(any(), any(), any());
             // Long enough queries must still trigger RAG — sanity-check the threshold isn't reversed.
             assertTrue(MessageCreationService.shouldRunRagFor("This is a meaningful question about the codebase"));
             assertFalse(MessageCreationService.shouldRunRagFor("more?"));
@@ -700,7 +700,7 @@ class MessageCreationServiceTest {
             semanticSearchServiceMockedStatic.when(SemanticSearchService::getInstance).thenReturn(mockSemanticSearchService);
 
             when(mockStateService.getRagActivated()).thenReturn(true);
-            when(mockSemanticSearchService.search(any(), any())).thenReturn(hits);
+            when(mockSemanticSearchService.search(any(), any(), any())).thenReturn(hits);
             when(mockFileListManager.getImageFiles(any(Project.class), any())).thenReturn(Collections.emptyList());
 
             ArgumentCaptor<UserMessage> captor = ArgumentCaptor.forClass(UserMessage.class);

--- a/src/test/java/com/devoxx/genie/service/prompt/response/nonstreaming/NonStreamingPromptExecutionServiceTest.java
+++ b/src/test/java/com/devoxx/genie/service/prompt/response/nonstreaming/NonStreamingPromptExecutionServiceTest.java
@@ -193,6 +193,81 @@ class NonStreamingPromptExecutionServiceTest {
         }
     }
 
+    // ---------- Hang/timeout reproduction (issue: MCP-enabled prompts had no wall-clock cap) ----------
+
+    /** Simple prompt: caller's per-request timeout wins. */
+    @Test
+    void resolveTimeoutSeconds_simplePrompt_returnsRequestedTimeout() {
+        assertThat(NonStreamingPromptExecutionService.resolveTimeoutSeconds(45, false, 999))
+                .isEqualTo(45L);
+    }
+
+    /** Simple prompt with null/non-positive request falls back to the simple-prompt default (60s). */
+    @Test
+    void resolveTimeoutSeconds_simplePrompt_nullRequested_returnsDefault60() {
+        assertThat(NonStreamingPromptExecutionService.resolveTimeoutSeconds(null, false, 999))
+                .isEqualTo(60L);
+        assertThat(NonStreamingPromptExecutionService.resolveTimeoutSeconds(0, false, 999))
+                .isEqualTo(60L);
+    }
+
+    /** Agent/MCP: agent cap is used regardless of the (short) per-request timeout. */
+    @Test
+    void resolveTimeoutSeconds_agentOrMcp_returnsAgentCap() {
+        assertThat(NonStreamingPromptExecutionService.resolveTimeoutSeconds(45, true, 240))
+                .isEqualTo(240L);
+    }
+
+    /** Agent/MCP with null/non-positive cap falls back to AGENT_MAX_EXECUTION_SECONDS (300). */
+    @Test
+    void resolveTimeoutSeconds_agentOrMcp_nullCap_returnsDefault300() {
+        assertThat(NonStreamingPromptExecutionService.resolveTimeoutSeconds(45, true, null))
+                .isEqualTo(300L);
+        assertThat(NonStreamingPromptExecutionService.resolveTimeoutSeconds(45, true, 0))
+                .isEqualTo(300L);
+    }
+
+    /**
+     * Demonstrates the fix at the JDK-API level: applying the resolved timeout via {@code orTimeout}
+     * makes a hanging future terminate. The bug was that MCP/agent flows skipped {@code orTimeout}
+     * entirely; the production fix unconditionally calls {@code orTimeout(resolveTimeoutSeconds(...), SECONDS)}.
+     */
+    @Test
+    void orTimeout_appliedToMcpAgentFlow_terminatesHangingFuture() throws Exception {
+        long capSeconds = NonStreamingPromptExecutionService.resolveTimeoutSeconds(
+                /* requested */ 60, /* isAgentOrMcp */ true, /* cap */ 1);
+        assertThat(capSeconds).isEqualTo(1L);
+
+        // Dedicated executor so we can shutdownNow() and interrupt the sleeping worker;
+        // CompletableFuture#cancel doesn't propagate interrupts to its supplier.
+        java.util.concurrent.ExecutorService exec = java.util.concurrent.Executors.newSingleThreadExecutor(r -> {
+            Thread t = new Thread(r, "test-hang-worker");
+            t.setDaemon(true);
+            return t;
+        });
+        try {
+            CompletableFuture<String> hanging = CompletableFuture.supplyAsync(() -> {
+                try { Thread.sleep(30_000); }
+                catch (InterruptedException ignored) { Thread.currentThread().interrupt(); }
+                return "should never see this";
+            }, exec);
+
+            long start = System.nanoTime();
+            CompletableFuture<String> guarded = hanging.orTimeout(capSeconds, java.util.concurrent.TimeUnit.SECONDS);
+            Throwable err = null;
+            try { guarded.get(5, java.util.concurrent.TimeUnit.SECONDS); }
+            catch (java.util.concurrent.ExecutionException e) { err = e.getCause(); }
+            long elapsedMs = (System.nanoTime() - start) / 1_000_000;
+
+            assertThat(err).isInstanceOf(java.util.concurrent.TimeoutException.class);
+            // Should fire close to the cap, well before the 30s hang would complete.
+            assertThat(elapsedMs).isLessThan(3_000L);
+        } finally {
+            exec.shutdownNow();
+            exec.awaitTermination(5, java.util.concurrent.TimeUnit.SECONDS);
+        }
+    }
+
     @Test
     void cancelExecutingQuery_withCompletedFuture_doesNotCancel() {
         CompletableFuture<ChatResponse> completedFuture = CompletableFuture.completedFuture(null);

--- a/src/test/java/com/devoxx/genie/service/rag/ChunkQualityFilterTest.java
+++ b/src/test/java/com/devoxx/genie/service/rag/ChunkQualityFilterTest.java
@@ -1,0 +1,84 @@
+package com.devoxx.genie.service.rag;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ChunkQualityFilterTest {
+
+    // ---- Empty / blank ----------------------------------------------------------------------
+
+    @Test
+    void isLowContent_nullOrBlank_returnsTrue() {
+        assertThat(ChunkQualityFilter.isLowContent(null)).isTrue();
+        assertThat(ChunkQualityFilter.isLowContent("")).isTrue();
+        assertThat(ChunkQualityFilter.isLowContent("   \t\n  ")).isTrue();
+    }
+
+    // ---- Padded markdown table headers (the actual failure mode from agenticengineeringworkshop)
+
+    @Test
+    void isLowContent_paddedTableHeader_isFiltered() {
+        // Real example from the failing query — header row padded out to ~250 chars
+        String chunk = "| Field                      | Description                                                                                                                                                                                                                                                                                |";
+        assertThat(ChunkQualityFilter.isLowContent(chunk)).isTrue();
+    }
+
+    @Test
+    void isLowContent_minimalTableSeparator_isFiltered() {
+        assertThat(ChunkQualityFilter.isLowContent("| Field | Description |")).isTrue();
+    }
+
+    @Test
+    void isLowContent_repeatedSameWord_isFiltered() {
+        // Repetition doesn't add distinct tokens; should be treated as noise even at length
+        assertThat(ChunkQualityFilter.isLowContent("Field Field Field Field Field")).isTrue();
+    }
+
+    @Test
+    void isLowContent_caseFolded_repeatedSameWord_isFiltered() {
+        // "Field" / "field" should fold to one token, not two
+        assertThat(ChunkQualityFilter.isLowContent("Field field Field field Field")).isTrue();
+    }
+
+    // ---- Real prose / code (must pass through) ---------------------------------------------
+
+    @Test
+    void isLowContent_shortMcpSentence_passes() {
+        // Even a single sentence about MCP should be kept — distinct tokens: MCP, the, Model,
+        // Context, Protocol = 5 (note: "is" is < 3 chars and excluded)
+        assertThat(ChunkQualityFilter.isLowContent("MCP is the Model Context Protocol")).isFalse();
+    }
+
+    @Test
+    void isLowContent_codeSnippet_passes() {
+        String code = """
+                public static void main(String[] args) {
+                    System.out.println("hello world");
+                }
+                """;
+        assertThat(ChunkQualityFilter.isLowContent(code)).isFalse();
+    }
+
+    @Test
+    void isLowContent_richTableRow_passes() {
+        // A row that actually carries information (multiple unique field values) should pass
+        String chunk = "| PreToolUse | hookSpecificOutput | permissionDecision (allow/deny/ask/defer), permissionDecisionReason |";
+        assertThat(ChunkQualityFilter.isLowContent(chunk)).isFalse();
+    }
+
+    // ---- Token-counting helper -------------------------------------------------------------
+
+    @Test
+    void countDistinctMeaningfulTokens_ignoresShortAndFoldsCase() {
+        // "is" (2 chars) excluded; "MCP" (3) included; case-folded so duplicates collapse
+        assertThat(ChunkQualityFilter.countDistinctMeaningfulTokens("MCP is mcp Mcp"))
+                .isEqualTo(1);
+    }
+
+    @Test
+    void countDistinctMeaningfulTokens_splitsOnPunctuationAndWhitespace() {
+        assertThat(ChunkQualityFilter.countDistinctMeaningfulTokens("alpha,beta;gamma|delta"))
+                .isEqualTo(4);
+    }
+}

--- a/src/test/java/com/devoxx/genie/service/rag/QueryExpansionFuserTest.java
+++ b/src/test/java/com/devoxx/genie/service/rag/QueryExpansionFuserTest.java
@@ -1,0 +1,120 @@
+package com.devoxx.genie.service.rag;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class QueryExpansionFuserTest {
+
+    private static SearchResult hit(String path, double score, String content) {
+        return new SearchResult(path, score, content);
+    }
+
+    // ---- Behavior ---------------------------------------------------------------------------
+
+    @Test
+    void expandAndFuse_singleVariant_returnsRetrievedOrder() {
+        SearchResult a = hit("/a", 0.9, "alpha");
+        SearchResult b = hit("/b", 0.8, "beta");
+        SearchResult c = hit("/c", 0.7, "gamma");
+
+        List<SearchResult> fused = QueryExpansionFuser.expandAndFuse(
+                List.of("q"),
+                q -> List.of(a, b, c),
+                10);
+
+        assertThat(fused).containsExactly(a, b, c);
+    }
+
+    @Test
+    void expandAndFuse_resultAppearingInMultipleVariants_outranksSingletons() {
+        // /shared appears mid-rank in two variants; /onlyA only top-ranked in variant 1.
+        // RRF: /shared = 1/(60+2) + 1/(60+2) ≈ 0.0323; /onlyA = 1/(60+1) ≈ 0.0164.
+        SearchResult shared = hit("/shared", 0.7, "common");
+        SearchResult onlyA = hit("/onlyA", 0.95, "uniqueA");
+        SearchResult onlyB = hit("/onlyB", 0.95, "uniqueB");
+
+        List<SearchResult> fused = QueryExpansionFuser.expandAndFuse(
+                List.of("q1", "q2"),
+                q -> q.equals("q1") ? List.of(onlyA, shared) : List.of(onlyB, shared),
+                10);
+
+        assertThat(fused.get(0)).isEqualTo(shared);
+        assertThat(fused).containsExactlyInAnyOrder(shared, onlyA, onlyB);
+    }
+
+    @Test
+    void expandAndFuse_dedupOnFilePathAndContent_notFilePathAlone() {
+        // Same filePath, different chunks — must NOT collapse: distinct chunks of the same
+        // file are independently relevant evidence
+        SearchResult chunkA = hit("/file.md", 0.9, "chunk A text");
+        SearchResult chunkB = hit("/file.md", 0.9, "chunk B text");
+
+        List<SearchResult> fused = QueryExpansionFuser.expandAndFuse(
+                List.of("q"),
+                q -> List.of(chunkA, chunkB),
+                10);
+
+        assertThat(fused).containsExactly(chunkA, chunkB);
+    }
+
+    @Test
+    void expandAndFuse_dedupOnIdenticalHit_keepsFirstOccurrence() {
+        // Same (filePath, content) returned across variants → one entry; score accumulates
+        SearchResult dup = hit("/file.md", 0.9, "same chunk");
+
+        List<SearchResult> fused = QueryExpansionFuser.expandAndFuse(
+                List.of("q1", "q2", "q3"),
+                q -> List.of(dup),
+                10);
+
+        assertThat(fused).hasSize(1);
+        assertThat(fused.get(0)).isEqualTo(dup);
+    }
+
+    @Test
+    void expandAndFuse_respectsMaxResults() {
+        SearchResult a = hit("/a", 0.9, "alpha");
+        SearchResult b = hit("/b", 0.8, "beta");
+        SearchResult c = hit("/c", 0.7, "gamma");
+
+        List<SearchResult> fused = QueryExpansionFuser.expandAndFuse(
+                List.of("q"),
+                q -> List.of(a, b, c),
+                2);
+
+        assertThat(fused).hasSize(2).containsExactly(a, b);
+    }
+
+    // ---- Guard clauses ---------------------------------------------------------------------
+
+    @Test
+    void expandAndFuse_emptyVariants_returnsEmpty() {
+        AtomicInteger calls = new AtomicInteger();
+        List<SearchResult> fused = QueryExpansionFuser.expandAndFuse(
+                List.of(),
+                q -> { calls.incrementAndGet(); return List.of(); },
+                10);
+        assertThat(fused).isEmpty();
+        assertThat(calls.get()).isZero();
+    }
+
+    @Test
+    void expandAndFuse_nonPositiveMaxResults_returnsEmpty() {
+        assertThat(QueryExpansionFuser.expandAndFuse(List.of("q"), q -> List.of(hit("/a", 1.0, "x")), 0))
+                .isEmpty();
+    }
+
+    @Test
+    void expandAndFuse_retrieverReturnsNull_isTolerated() {
+        SearchResult a = hit("/a", 0.9, "alpha");
+        List<SearchResult> fused = QueryExpansionFuser.expandAndFuse(
+                List.of("good", "bad"),
+                q -> q.equals("good") ? List.of(a) : null,
+                10);
+        assertThat(fused).containsExactly(a);
+    }
+}

--- a/src/test/java/com/devoxx/genie/service/rag/RAGEventPublisherTest.java
+++ b/src/test/java/com/devoxx/genie/service/rag/RAGEventPublisherTest.java
@@ -1,0 +1,120 @@
+package com.devoxx.genie.service.rag;
+
+import com.devoxx.genie.model.rag.RAGLogMessage;
+import com.devoxx.genie.ui.settings.DevoxxGenieStateService;
+import com.devoxx.genie.ui.topic.AppTopics;
+import com.intellij.openapi.application.Application;
+import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.project.Project;
+import com.intellij.util.messages.MessageBus;
+import com.intellij.util.messages.MessageBusConnection;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class RAGEventPublisherTest {
+
+    private MockedStatic<ApplicationManager> applicationManagerStatic;
+    private MockedStatic<DevoxxGenieStateService> stateServiceStatic;
+    private Application application;
+    private MessageBus messageBus;
+    private final List<RAGLogMessage> publishedMessages = new ArrayList<>();
+
+    @BeforeEach
+    void setUp() {
+        applicationManagerStatic = Mockito.mockStatic(ApplicationManager.class);
+        stateServiceStatic = Mockito.mockStatic(DevoxxGenieStateService.class);
+
+        application = mock(Application.class);
+        messageBus = mock(MessageBus.class);
+        DevoxxGenieStateService stateService = mock(DevoxxGenieStateService.class);
+        MessageBusConnection connection = mock(MessageBusConnection.class);
+
+        applicationManagerStatic.when(ApplicationManager::getApplication).thenReturn(application);
+        when(application.getMessageBus()).thenReturn(messageBus);
+        when(messageBus.connect()).thenReturn(connection);
+
+        stateServiceStatic.when(DevoxxGenieStateService::getInstance).thenReturn(stateService);
+        when(stateService.getIndexerMinScore()).thenReturn(0.7);
+        when(stateService.getIndexerMaxResults()).thenReturn(10);
+
+        // Capture whatever is published — we use a fake RAGLoggingMessage as the syncPublisher proxy.
+        RAGLoggingMessage capturing = publishedMessages::add;
+        when(messageBus.syncPublisher(AppTopics.RAG_LOG_MSG)).thenReturn(capturing);
+    }
+
+    @AfterEach
+    void tearDown() {
+        applicationManagerStatic.close();
+        stateServiceStatic.close();
+    }
+
+    @Test
+    void publishCarriesQueryHitsAndDurationToSubscribers() {
+        Project project = mock(Project.class);
+        when(project.getLocationHash()).thenReturn("PROJECT_HASH");
+
+        List<SearchResult> results = List.of(
+                new SearchResult("/abs/Foo.java", 0.91, "alpha chunk text"),
+                new SearchResult("/abs/Bar.java", 0.82, "beta chunk text")
+        );
+
+        RAGEventPublisher.publish(project, "How does authentication work?", results, 137L);
+
+        assertThat(publishedMessages).hasSize(1);
+        RAGLogMessage m = publishedMessages.get(0);
+        assertThat(m.getProjectLocationHash()).isEqualTo("PROJECT_HASH");
+        assertThat(m.getQuery()).isEqualTo("How does authentication work?");
+        assertThat(m.getDurationMs()).isEqualTo(137L);
+        assertThat(m.getMinScore()).isEqualTo(0.7);
+        assertThat(m.getMaxResults()).isEqualTo(10);
+        assertThat(m.getHits()).hasSize(2);
+        assertThat(m.getHits()).extracting(RAGLogMessage.Hit::getFilePath)
+                .containsExactly("/abs/Foo.java", "/abs/Bar.java");
+        assertThat(m.getHits().get(0).getPreview()).isEqualTo("alpha chunk text");
+        assertThat(m.getHits().get(0).getChunkLength()).isEqualTo("alpha chunk text".length());
+    }
+
+    @Test
+    void publishTruncatesPreviewsToProtectPanelMemory() {
+        Project project = mock(Project.class);
+        when(project.getLocationHash()).thenReturn("PROJECT_HASH");
+
+        StringBuilder huge = new StringBuilder();
+        huge.append("x".repeat(RAGEventPublisher.PREVIEW_MAX_CHARS + 200));
+        List<SearchResult> results = List.of(new SearchResult("/abs/Huge.java", 0.95, huge.toString()));
+
+        RAGEventPublisher.publish(project, "huge chunk", results, 10L);
+
+        assertThat(publishedMessages).hasSize(1);
+        RAGLogMessage.Hit hit = publishedMessages.get(0).getHits().get(0);
+        assertThat(hit.getPreview().length())
+                .as("preview must be truncated to PREVIEW_MAX_CHARS (+1 ellipsis); full text stays in the prompt")
+                .isEqualTo(RAGEventPublisher.PREVIEW_MAX_CHARS + 1);
+        assertThat(hit.getChunkLength())
+                .as("chunkLength reflects the original full chunk size, not the truncated preview")
+                .isEqualTo(huge.length());
+    }
+
+    @Test
+    void publishWithEmptyResultsStillEmitsAnEventSoLogShowsZeroHits() {
+        Project project = mock(Project.class);
+        when(project.getLocationHash()).thenReturn("PROJECT_HASH");
+
+        RAGEventPublisher.publish(project, "no matches expected", List.of(), 12L);
+
+        assertThat(publishedMessages).hasSize(1);
+        assertThat(publishedMessages.get(0).getHits()).isEmpty();
+    }
+}

--- a/src/test/java/com/devoxx/genie/service/rag/SemanticSearchServiceTest.java
+++ b/src/test/java/com/devoxx/genie/service/rag/SemanticSearchServiceTest.java
@@ -183,6 +183,73 @@ class SemanticSearchServiceTest {
                 .isGreaterThan(afterFirst);
     }
 
+    @Test
+    void indexingUsesBatchedEmbedAllNotOneCallPerSegment(@TempDir Path tmp) throws IOException {
+        Path file = tmp.resolve("Big.java");
+        // Build content large enough that the recursive splitter produces several chunks.
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < 600; i++) {
+            sb.append("public class Foo").append(i).append(" { /* line ").append(i)
+                    .append(" of many */ void m").append(i).append("() {} }\n");
+        }
+        Files.writeString(file, sb.toString());
+
+        CountingEmbeddingModel counter = new CountingEmbeddingModel();
+        when(mockChromaService.getEmbeddingModel()).thenReturn(counter);
+
+        new ProjectIndexerService().indexFile(file);
+
+        // One single embed() call is allowed for the cached isFileIndexed metadata-filter probe;
+        // every segment must go through embedAll.
+        assertThat(counter.singleEmbedCalls)
+                .as("at most one single-embed call (the cached lookup probe); segments must NOT use per-segment embeds")
+                .isLessThanOrEqualTo(1);
+        assertThat(counter.embedAllCalls)
+                .as("at least one batched embedAll call expected")
+                .isGreaterThan(0);
+        assertThat(counter.totalSegmentsEmbedded)
+                .as("every segment should be embedded, but in batches")
+                .isGreaterThan(1);
+        assertThat(counter.embedAllCalls)
+                .as("with batch size %d and many segments, embedAll calls should be far fewer than total segments",
+                        ProjectIndexerService.EMBEDDING_BATCH_SIZE)
+                .isLessThan(counter.totalSegmentsEmbedded);
+    }
+
+    /** Counts how the embedding model is called. */
+    private static final class CountingEmbeddingModel implements EmbeddingModel {
+        int singleEmbedCalls = 0;
+        int embedAllCalls = 0;
+        int totalSegmentsEmbedded = 0;
+        private final DeterministicHashEmbeddingModel delegate = new DeterministicHashEmbeddingModel();
+
+        @Override
+        public Response<Embedding> embed(String text) {
+            singleEmbedCalls++;
+            totalSegmentsEmbedded++;
+            return delegate.embed(text);
+        }
+
+        @Override
+        public Response<Embedding> embed(TextSegment segment) {
+            singleEmbedCalls++;
+            totalSegmentsEmbedded++;
+            return delegate.embed(segment);
+        }
+
+        @Override
+        public Response<List<Embedding>> embedAll(List<TextSegment> textSegments) {
+            embedAllCalls++;
+            totalSegmentsEmbedded += textSegments.size();
+            return delegate.embedAll(textSegments);
+        }
+
+        @Override
+        public int dimension() {
+            return delegate.dimension();
+        }
+    }
+
     /** Probe the in-memory store via a no-op search; embedAll on the InMemoryEmbeddingStore exposes no count. */
     private int storedEntryCount() {
         Embedding probe = embeddingModel.embed("__probe__").content();

--- a/src/test/java/com/devoxx/genie/service/rag/SemanticSearchServiceTest.java
+++ b/src/test/java/com/devoxx/genie/service/rag/SemanticSearchServiceTest.java
@@ -1,0 +1,251 @@
+package com.devoxx.genie.service.rag;
+
+import com.devoxx.genie.service.chromadb.ChromaEmbeddingService;
+import com.devoxx.genie.ui.settings.DevoxxGenieStateService;
+import com.intellij.openapi.application.Application;
+import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.project.Project;
+import dev.langchain4j.data.embedding.Embedding;
+import dev.langchain4j.data.segment.TextSegment;
+import dev.langchain4j.model.embedding.EmbeddingModel;
+import dev.langchain4j.model.output.Response;
+import dev.langchain4j.store.embedding.EmbeddingStore;
+import dev.langchain4j.store.embedding.inmemory.InMemoryEmbeddingStore;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * End-to-end reproducer for the indexing→retrieval pipeline.
+ *
+ * <p>Before the v2 fix, {@code ProjectIndexerService.markFileAsIndexed} embedded the absolute
+ * <em>file path</em> string rather than the chunk content, so a query for content that
+ * appeared inside a file could never match — the vector store only held path embeddings.
+ * The first test in this class is the canary for that bug: it indexes a temp file whose
+ * content contains a unique phrase, then asserts a query for that phrase returns the chunk.
+ * It fails on the pre-v2 code and passes on the fixed code.
+ */
+class SemanticSearchServiceTest {
+
+    private MockedStatic<ApplicationManager> applicationManagerStatic;
+    private MockedStatic<ChromaEmbeddingService> chromaServiceStatic;
+    private MockedStatic<DevoxxGenieStateService> stateServiceStatic;
+
+    private ChromaEmbeddingService mockChromaService;
+    private DevoxxGenieStateService mockStateService;
+    private Project mockProject;
+    private Application mockApplication;
+
+    private EmbeddingStore<TextSegment> store;
+    private EmbeddingModel embeddingModel;
+
+    @BeforeEach
+    void setUp() {
+        applicationManagerStatic = Mockito.mockStatic(ApplicationManager.class);
+        chromaServiceStatic = Mockito.mockStatic(ChromaEmbeddingService.class);
+        stateServiceStatic = Mockito.mockStatic(DevoxxGenieStateService.class);
+
+        mockApplication = mock(Application.class);
+        mockProject = mock(Project.class);
+        mockChromaService = mock(ChromaEmbeddingService.class);
+        mockStateService = mock(DevoxxGenieStateService.class);
+
+        applicationManagerStatic.when(ApplicationManager::getApplication).thenReturn(mockApplication);
+
+        // Both services use static getInstance(); route them to our mocks.
+        chromaServiceStatic.when(ChromaEmbeddingService::getInstance).thenReturn(mockChromaService);
+        stateServiceStatic.when(DevoxxGenieStateService::getInstance).thenReturn(mockStateService);
+
+        // SemanticSearchService.getInstance() goes through ApplicationManager — let it build
+        // a real instance backed by the mocked dependencies above.
+        lenient().when(mockApplication.getService(SemanticSearchService.class))
+                .thenAnswer(inv -> new SemanticSearchService());
+
+        // Fresh in-memory store and embedding model per test.
+        store = new InMemoryEmbeddingStore<>();
+        embeddingModel = new DeterministicHashEmbeddingModel();
+
+        when(mockChromaService.getEmbeddingStore()).thenReturn(store);
+        when(mockChromaService.getEmbeddingModel()).thenReturn(embeddingModel);
+        // init(Project) is a no-op for the in-memory store.
+        Mockito.doNothing().when(mockChromaService).init(any());
+
+        // Default search knobs: same as production defaults so the test exercises realistic config.
+        when(mockStateService.getIndexerMinScore()).thenReturn(0.7);
+        when(mockStateService.getIndexerMaxResults()).thenReturn(10);
+    }
+
+    @AfterEach
+    void tearDown() {
+        applicationManagerStatic.close();
+        chromaServiceStatic.close();
+        stateServiceStatic.close();
+    }
+
+    @Test
+    void indexedChunkContentIsRetrievableByContentQuery(@TempDir Path tmp) throws IOException {
+        Path file = tmp.resolve("Auth.java");
+        String uniquePhrase = "the secret needle xyzzy123 plugh-frobozz marker";
+        Files.writeString(file, "package x;\nclass Auth { /* " + uniquePhrase + " */ void m() {} }\n");
+
+        ProjectIndexerService indexer = new ProjectIndexerService();
+        indexer.indexFile(file);
+
+        // Use the exact stored chunk text as the query: under the deterministic hash model,
+        // identical text → identical vector → cosine similarity 1.0, well above the 0.7 threshold.
+        List<SearchResult> hits = SemanticSearchService.getInstance().search(mockProject,
+                "package x;\nclass Auth { /* " + uniquePhrase + " */ void m() {} }");
+
+        assertThat(hits)
+                .as("search() must return the chunk; pre-v2 code embedded the file PATH and so could never match content")
+                .isNotEmpty();
+        assertThat(hits.get(0).content())
+                .as("returned chunk should carry the original segment text, not the file path")
+                .contains(uniquePhrase);
+        assertThat(hits.get(0).filePath()).isEqualTo(file.toAbsolutePath().toString());
+        assertThat(hits.get(0).score()).isGreaterThanOrEqualTo(0.99);
+    }
+
+    @Test
+    void searchReturnsAllMatchingChunksNotJustOnePerFile() throws IOException {
+        // Store two segments from the same file. Pre-v2 code returned a Map<filePath, ...>
+        // which silently dropped duplicates.
+        String absPath = "/fake/Same.java";
+        TextSegment seg1 = TextSegment.from("alpha-content-1", metadata(absPath));
+        TextSegment seg2 = TextSegment.from("beta-content-2", metadata(absPath));
+        store.add(embeddingModel.embed(seg1.text()).content(), seg1);
+        store.add(embeddingModel.embed(seg2.text()).content(), seg2);
+
+        // Lower min score so we get both hits even when only one is an exact match.
+        when(mockStateService.getIndexerMinScore()).thenReturn(0.0);
+
+        List<SearchResult> hits = SemanticSearchService.getInstance().search(mockProject, "alpha-content-1");
+
+        assertThat(hits)
+                .as("both chunks from the same file should be present; old Map-keyed-by-path silently collapsed them")
+                .hasSize(2);
+        assertThat(hits).extracting(SearchResult::content)
+                .containsExactlyInAnyOrder("alpha-content-1", "beta-content-2");
+    }
+
+    @Test
+    void reindexingUnchangedFileIsANoOp(@TempDir Path tmp) throws IOException {
+        Path file = tmp.resolve("Same.java");
+        Files.writeString(file, "class Same { /* unique-marker-9876 */ }\n");
+
+        ProjectIndexerService indexer = new ProjectIndexerService();
+        indexer.indexFile(file);
+        int afterFirst = storedEntryCount();
+        assertThat(afterFirst).as("first index pass should produce at least one segment").isGreaterThan(0);
+
+        indexer.indexFile(file);
+        int afterSecond = storedEntryCount();
+
+        assertThat(afterSecond)
+                .as("re-indexing an unchanged file must not duplicate segments — isFileIndexed should detect the existing entries via metadata filter")
+                .isEqualTo(afterFirst);
+    }
+
+    @Test
+    void reindexingPicksUpFilesWithUpdatedMtime(@TempDir Path tmp) throws IOException {
+        Path file = tmp.resolve("Edited.java");
+        Files.writeString(file, "class Edited { /* v1 */ }\n");
+
+        ProjectIndexerService indexer = new ProjectIndexerService();
+        indexer.indexFile(file);
+        int afterFirst = storedEntryCount();
+
+        // Rewrite with newer mtime; the embedded content changes too.
+        Files.writeString(file, "class Edited { /* v2 with brand new content */ }\n");
+        Files.setLastModifiedTime(file, java.nio.file.attribute.FileTime.fromMillis(System.currentTimeMillis() + 5_000));
+
+        indexer.indexFile(file);
+        int afterSecond = storedEntryCount();
+
+        assertThat(afterSecond)
+                .as("a file whose mtime advanced must be re-embedded (added to the index again)")
+                .isGreaterThan(afterFirst);
+    }
+
+    /** Probe the in-memory store via a no-op search; embedAll on the InMemoryEmbeddingStore exposes no count. */
+    private int storedEntryCount() {
+        Embedding probe = embeddingModel.embed("__probe__").content();
+        return store.search(dev.langchain4j.store.embedding.EmbeddingSearchRequest.builder()
+                        .queryEmbedding(probe)
+                        .maxResults(Integer.MAX_VALUE)
+                        .minScore(0.0)
+                        .build())
+                .matches().size();
+    }
+
+    private static dev.langchain4j.data.document.Metadata metadata(String absolutePath) {
+        dev.langchain4j.data.document.Metadata m = new dev.langchain4j.data.document.Metadata();
+        m.put(IndexerConstants.FILE_PATH, absolutePath);
+        m.put(IndexerConstants.LAST_MODIFIED, 0L);
+        m.put(IndexerConstants.INDEXED_AT, 0L);
+        m.put(IndexerConstants.EMBEDDING_SCHEMA_VERSION_KEY, IndexerConstants.CURRENT_EMBEDDING_SCHEMA_VERSION);
+        return m;
+    }
+
+    /**
+     * Deterministic, hash-derived embedding model: same text → identical unit vector,
+     * different text → uncorrelated unit vectors. Lets us write content-vs-content
+     * assertions without depending on a real embedder (no Ollama, no network).
+     */
+    private static final class DeterministicHashEmbeddingModel implements EmbeddingModel {
+
+        private static final int DIM = 128;
+
+        @Override
+        public Response<List<Embedding>> embedAll(List<TextSegment> textSegments) {
+            List<Embedding> out = new ArrayList<>(textSegments.size());
+            for (TextSegment segment : textSegments) {
+                out.add(embedString(segment.text()));
+            }
+            return Response.from(out);
+        }
+
+        @Override
+        public int dimension() {
+            return DIM;
+        }
+
+        private static Embedding embedString(String text) {
+            // Seed with a stable 64-bit derivation of the string so the JVM's hashCode
+            // perturbation policy doesn't make the test flaky across runs.
+            long seed = 1469598103934665603L;
+            for (int i = 0; i < text.length(); i++) {
+                seed ^= text.charAt(i);
+                seed *= 1099511628211L;
+            }
+            Random r = new Random(seed);
+            float[] vec = new float[DIM];
+            double norm = 0;
+            for (int i = 0; i < DIM; i++) {
+                vec[i] = r.nextFloat() * 2f - 1f;
+                norm += vec[i] * vec[i];
+            }
+            norm = Math.sqrt(norm);
+            for (int i = 0; i < DIM; i++) {
+                vec[i] /= (float) norm;
+            }
+            return Embedding.from(vec);
+        }
+    }
+}

--- a/src/test/java/com/devoxx/genie/service/rag/SemanticSearchServiceTest.java
+++ b/src/test/java/com/devoxx/genie/service/rag/SemanticSearchServiceTest.java
@@ -184,6 +184,29 @@ class SemanticSearchServiceTest {
     }
 
     @Test
+    void splitterIsChosenByFileExtension(@TempDir Path tmp) {
+        ProjectIndexerService indexer = new ProjectIndexerService();
+
+        // Source code gets a line-based splitter — statement boundaries beat the recursive
+        // default's preference for sentence punctuation.
+        assertThat(indexer.splitterFor(tmp.resolve("Auth.java")))
+                .as("source code should route to DocumentByLineSplitter")
+                .isInstanceOf(dev.langchain4j.data.document.splitter.DocumentByLineSplitter.class);
+
+        // Unknown extensions return the cached default splitter — same instance every call.
+        var unknown1 = indexer.splitterFor(tmp.resolve("config.toml"));
+        var unknown2 = indexer.splitterFor(tmp.resolve("data.csv"));
+        assertThat(unknown1)
+                .as("unknown extensions must reuse the cached default splitter")
+                .isSameAs(unknown2);
+
+        // Code splitter is NOT the cached default (different instance, different class config).
+        assertThat(indexer.splitterFor(tmp.resolve("Foo.py")))
+                .as("code splitter must be a distinct instance from the default")
+                .isNotSameAs(unknown1);
+    }
+
+    @Test
     void indexingUsesBatchedEmbedAllNotOneCallPerSegment(@TempDir Path tmp) throws IOException {
         Path file = tmp.resolve("Big.java");
         // Build content large enough that the recursive splitter produces several chunks.

--- a/src/test/java/com/devoxx/genie/service/rag/manifest/IndexManifestTest.java
+++ b/src/test/java/com/devoxx/genie/service/rag/manifest/IndexManifestTest.java
@@ -1,0 +1,106 @@
+package com.devoxx.genie.service.rag.manifest;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.FileTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class IndexManifestTest {
+
+    @Test
+    void mtimeBumpWithoutContentChangeDoesNotInvalidate(@TempDir Path tmp) throws IOException {
+        Path file = tmp.resolve("Unchanged.java");
+        Files.writeString(file, "class C { void m() {} }\n");
+
+        IndexManifest manifest = new InMemoryIndexManifest();
+        manifest.markIndexed(file, 3);
+        assertThat(manifest.isCurrent(file)).isTrue();
+
+        // Bump mtime forward — simulates a `touch`, a git checkout, or an IDE save with
+        // no actual edit. Pre-manifest code re-indexed every time. Content hash says no.
+        Files.setLastModifiedTime(file, FileTime.fromMillis(System.currentTimeMillis() + 10_000));
+
+        assertThat(manifest.isCurrent(file))
+                .as("identical bytes + advanced mtime must NOT trigger a re-index")
+                .isTrue();
+    }
+
+    @Test
+    void contentEditInvalidatesEvenWhenMtimeStaysTheSame(@TempDir Path tmp) throws IOException {
+        Path file = tmp.resolve("Edited.java");
+        Files.writeString(file, "class C { void m() {} }\n");
+        FileTime mtime = Files.getLastModifiedTime(file);
+
+        IndexManifest manifest = new InMemoryIndexManifest();
+        manifest.markIndexed(file, 3);
+
+        Files.writeString(file, "class C { void m() { System.out.println(\"changed\"); } }\n");
+        // Force mtime back to the original; the manifest must still detect the change.
+        Files.setLastModifiedTime(file, mtime);
+
+        assertThat(manifest.isCurrent(file))
+                .as("content differs even though mtime is unchanged; content-hash check must catch it")
+                .isFalse();
+    }
+
+    @Test
+    void schemaVersionChangeInvalidatesAllEntries(@TempDir Path tmp) throws IOException {
+        Path file = tmp.resolve("Old.java");
+        Files.writeString(file, "class C {}\n");
+
+        // Simulate a manifest with an entry written under a previous schema version.
+        InMemoryIndexManifest manifest = new InMemoryIndexManifest();
+        manifest.entries.put(file.toAbsolutePath().toString(),
+                new IndexManifestEntry(InMemoryIndexManifest.sha1OrNull(file),
+                        Files.getLastModifiedTime(file).toMillis(),
+                        System.currentTimeMillis(),
+                        1,
+                        "pre-v2-mystery-schema"));
+
+        assertThat(manifest.isCurrent(file))
+                .as("entries written under a different embedding schema version must NOT be treated as current")
+                .isFalse();
+    }
+
+    @Test
+    void jsonFileManifestRoundTripsThroughDisk(@TempDir Path tmp) throws IOException {
+        Path storage = tmp.resolve("manifest.json");
+        Path file = tmp.resolve("Roundtrip.java");
+        Files.writeString(file, "class R {}\n");
+
+        JsonFileIndexManifest writer = new JsonFileIndexManifest(storage);
+        writer.markIndexed(file, 7);
+        writer.flush();
+
+        assertThat(Files.exists(storage)).as("flush must create the manifest file").isTrue();
+        assertThat(Files.size(storage)).isGreaterThan(0);
+
+        // Reload in a fresh instance — proves the on-disk format works.
+        JsonFileIndexManifest reader = new JsonFileIndexManifest(storage);
+        assertThat(reader.isCurrent(file))
+                .as("reloaded manifest must recognise the indexed file")
+                .isTrue();
+    }
+
+    @Test
+    void flushIsAtomicAndIdempotent(@TempDir Path tmp) throws IOException {
+        Path storage = tmp.resolve("manifest.json");
+        Path file = tmp.resolve("F.java");
+        Files.writeString(file, "class F {}\n");
+
+        JsonFileIndexManifest manifest = new JsonFileIndexManifest(storage);
+        manifest.markIndexed(file, 1);
+        manifest.flush();
+        long firstSize = Files.size(storage);
+
+        // No mutations between flushes — second flush should be a no-op (no tmp file left behind).
+        manifest.flush();
+        assertThat(Files.size(storage)).isEqualTo(firstSize);
+        assertThat(Files.exists(storage.resolveSibling("manifest.json.tmp"))).isFalse();
+    }
+}

--- a/src/test/java/com/devoxx/genie/service/rag/validator/ChromeDBValidatorTest.java
+++ b/src/test/java/com/devoxx/genie/service/rag/validator/ChromeDBValidatorTest.java
@@ -1,5 +1,6 @@
 package com.devoxx.genie.service.rag.validator;
 
+import com.devoxx.genie.service.chromadb.ChromaDockerService;
 import com.devoxx.genie.ui.settings.DevoxxGenieStateService;
 import com.devoxx.genie.util.DockerUtil;
 import com.github.dockerjava.api.DockerClient;
@@ -158,7 +159,7 @@ class ChromeDBValidatorTest {
         boolean result = validator.isValid();
 
         assertThat(result).isTrue();
-        assertThat(validator.getMessage()).isEqualTo("ChromaDB v0.6.2 is running");
+        assertThat(validator.getMessage()).isEqualTo("ChromaDB v" + ChromaDockerService.CHROMA_VERSION + " is running");
     }
 
     @Test

--- a/src/test/java/com/devoxx/genie/service/rag/watcher/RAGFileWatcherTest.java
+++ b/src/test/java/com/devoxx/genie/service/rag/watcher/RAGFileWatcherTest.java
@@ -1,0 +1,167 @@
+package com.devoxx.genie.service.rag.watcher;
+
+import com.devoxx.genie.service.rag.ProjectIndexerService;
+import com.devoxx.genie.service.rag.manifest.IndexManifest;
+import com.devoxx.genie.service.rag.manifest.IndexManifestService;
+import com.devoxx.genie.ui.settings.DevoxxGenieStateService;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.openapi.vfs.newvfs.events.VFileContentChangeEvent;
+import com.intellij.openapi.vfs.newvfs.events.VFileDeleteEvent;
+import com.intellij.openapi.vfs.newvfs.events.VFileEvent;
+import com.intellij.util.messages.MessageBus;
+import com.intellij.util.messages.MessageBusConnection;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+import java.nio.file.Path;
+import java.util.Collection;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class RAGFileWatcherTest {
+
+    private MockedStatic<DevoxxGenieStateService> stateServiceStatic;
+    private MockedStatic<IndexManifestService> manifestServiceStatic;
+
+    private Project project;
+    private IndexManifest manifest;
+    private ProjectIndexerService indexer;
+
+    @BeforeEach
+    void setUp() {
+        stateServiceStatic = Mockito.mockStatic(DevoxxGenieStateService.class);
+        manifestServiceStatic = Mockito.mockStatic(IndexManifestService.class);
+
+        DevoxxGenieStateService state = mock(DevoxxGenieStateService.class);
+        stateServiceStatic.when(DevoxxGenieStateService::getInstance).thenReturn(state);
+        when(state.getRagEnabled()).thenReturn(true);
+
+        project = mock(Project.class);
+        when(project.getBasePath()).thenReturn("/abs/project");
+        MessageBus bus = mock(MessageBus.class);
+        when(project.getMessageBus()).thenReturn(bus);
+        MessageBusConnection connection = mock(MessageBusConnection.class);
+        when(bus.connect(any(com.intellij.openapi.Disposable.class))).thenReturn(connection);
+
+        manifest = mock(IndexManifest.class);
+        IndexManifestService manifestService = mock(IndexManifestService.class);
+        manifestServiceStatic.when(IndexManifestService::getInstance).thenReturn(manifestService);
+        when(manifestService.forProject(project)).thenReturn(manifest);
+
+        indexer = mock(ProjectIndexerService.class);
+    }
+
+    @AfterEach
+    void tearDown() {
+        stateServiceStatic.close();
+        manifestServiceStatic.close();
+    }
+
+    @Test
+    void untrackedFilesDoNotTriggerReindex() throws Exception {
+        RAGFileWatcher watcher = new RAGFileWatcher(project, indexer);
+        Path tracked = Path.of("/abs/project/Tracked.java");
+        Path untracked = Path.of("/abs/project/Untracked.java");
+        when(manifest.isTracked(tracked)).thenReturn(true);
+        when(manifest.isTracked(untracked)).thenReturn(false);
+
+        watcher.handleEvents(List.of(
+                changeEvent(untracked),
+                changeEvent(tracked)
+        ));
+
+        // Debounce window — wait just past it.
+        Thread.sleep(RAGFileWatcher.DEBOUNCE_MILLIS + 500);
+
+        ArgumentCaptor<Collection<Path>> captor = collectionCaptor();
+        verify(indexer).reindexFiles(eq(project), captor.capture());
+        assertThat(captor.getValue())
+                .as("only tracked files survive the watcher's filter")
+                .containsExactly(tracked);
+        watcher.dispose();
+    }
+
+    @Test
+    void deletesArePassedToRemoveFilesNotReindex() throws Exception {
+        RAGFileWatcher watcher = new RAGFileWatcher(project, indexer);
+        Path tracked = Path.of("/abs/project/Removed.java");
+        when(manifest.isTracked(tracked)).thenReturn(true);
+
+        watcher.handleEvents(List.of(deleteEvent(tracked)));
+        Thread.sleep(RAGFileWatcher.DEBOUNCE_MILLIS + 500);
+
+        verify(indexer).removeFiles(eq(project), any());
+        verify(indexer, never()).reindexFiles(any(), any());
+        watcher.dispose();
+    }
+
+    @Test
+    void rapidEditsAreDebouncedIntoASingleReindexCall() throws Exception {
+        RAGFileWatcher watcher = new RAGFileWatcher(project, indexer);
+        Path file = Path.of("/abs/project/Hot.java");
+        when(manifest.isTracked(file)).thenReturn(true);
+
+        // Three saves in rapid succession — the user typing Ctrl+S, Ctrl+S, Ctrl+S.
+        for (int i = 0; i < 3; i++) {
+            watcher.handleEvents(List.of(changeEvent(file)));
+            Thread.sleep(100);
+        }
+
+        // Now hold quiet for one full debounce window.
+        Thread.sleep(RAGFileWatcher.DEBOUNCE_MILLIS + 500);
+
+        // The whole burst should produce exactly one reindex call.
+        verify(indexer, Mockito.times(1)).reindexFiles(eq(project), any());
+        watcher.dispose();
+    }
+
+    @Test
+    void deleteSupersedesPendingChangeForTheSamePath() throws Exception {
+        RAGFileWatcher watcher = new RAGFileWatcher(project, indexer);
+        Path file = Path.of("/abs/project/Gone.java");
+        when(manifest.isTracked(file)).thenReturn(true);
+
+        // Edit then delete: only the delete should reach the indexer.
+        watcher.handleEvents(List.of(changeEvent(file)));
+        Thread.sleep(50);
+        watcher.handleEvents(List.of(deleteEvent(file)));
+        Thread.sleep(RAGFileWatcher.DEBOUNCE_MILLIS + 500);
+
+        verify(indexer).removeFiles(eq(project), any());
+        verify(indexer, never()).reindexFiles(any(), any());
+        watcher.dispose();
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    private static ArgumentCaptor<Collection<Path>> collectionCaptor() {
+        return ArgumentCaptor.forClass((Class) Collection.class);
+    }
+
+    private static VFileEvent changeEvent(Path file) {
+        VFileContentChangeEvent e = mock(VFileContentChangeEvent.class);
+        VirtualFile vf = mock(VirtualFile.class);
+        when(vf.getPath()).thenReturn(file.toString());
+        when(e.getFile()).thenReturn(vf);
+        return e;
+    }
+
+    private static VFileEvent deleteEvent(Path file) {
+        VFileDeleteEvent e = mock(VFileDeleteEvent.class);
+        VirtualFile vf = mock(VirtualFile.class);
+        when(vf.getPath()).thenReturn(file.toString());
+        when(e.getFile()).thenReturn(vf);
+        return e;
+    }
+}


### PR DESCRIPTION
## Summary
- Adds three Phase 4 RAG follow-up backlog tasks:
  - **task-217**: show loading indicator before query-expansion variant LLM calls start
  - **task-218**: fix misleading "one extra LLM call" help text for query expansion
  - **task-219**: make RAG mutually exclusive with MCP and Agent mode in settings UI

## Test plan
- [ ] Verify task files render correctly in Backlog.md tooling
- [ ] Confirm task IDs do not collide with existing tasks

🤖 Generated with [Claude Code](https://claude.com/claude-code)