### PR TITLE
feat: add support for IntelliJ 2026.2 EAP

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -39,7 +39,8 @@ val pluginVerifierCommunityIdeVersions = listOf(
     "2025.2.6.1"  // 252 line
 )
 val pluginVerifierUnifiedIdeVersions = listOf(
-    "2025.3.3"    // 253 line
+    "2025.3.3",          // 253 line
+    "2026.2-EAP-SNAPSHOT" // 262 line
 )
 
 fun Project.stripBinaryIncompatibleRuntimeJars(sandboxPluginPath: String) {
@@ -376,7 +377,7 @@ intellijPlatform {
     pluginConfiguration {
         ideaVersion {
             sinceBuild = "251"
-            untilBuild = "261.*"
+            untilBuild = "262.*"
         }
     }
 
@@ -426,6 +427,7 @@ tasks {
     //        ./gradlew runIde -PideVersion=2025.1.1
     //        ./gradlew runIde -PideVersion=2025.2.2
     //        ./gradlew runIde -PideVersion=2025.3.3
+    //        ./gradlew runIde -PideVersion=2026.2-EAP-SNAPSHOT
 
     withType<Jar> {
         duplicatesStrategy = DuplicatesStrategy.EXCLUDE

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -11,7 +11,7 @@
     <!-- A displayed Vendor name or Organization ID displayed on the Plugins Page. -->
     <vendor email="info@devoxx.com" url="https://devoxx.com">Devoxx</vendor>
 
-    <idea-version since-build="243" until-build="261.*"/>
+    <idea-version since-build="243" until-build="262.*"/>
 
     <!-- Description of the plugin displayed on the Plugin Page and IDE Plugin Manager.
          Simple HTML elements (text formatting, paragraphs, and lists) can be added inside of <![CDATA[ ]]> tag.


### PR DESCRIPTION
Extends the plugin's supported IntelliJ build range to include 2026.2 EAP (build branch `262`).

**Changes**
- `build.gradle.kts`: bump `untilBuild` from `261.*` to `262.*`
- `build.gradle.kts`: add `2026.2-EAP-SNAPSHOT` to `pluginVerifierUnifiedIdeVersions` (262 line)
- `build.gradle.kts`: add `runIde -PideVersion=2026.2-EAP-SNAPSHOT` usage comment
- `plugin.xml`: bump `until-build` from `261.*` to `262.*`

`sinceBuild` / `since-build` and the IC verifier list are unchanged.

**Testing**
`./gradlew test` — pre-existing environmental failures only (missing `libfreetype.so.6` in the test sandbox affecting IntelliJ UI test framework); no failures related to these metadata changes.