### PR TITLE
Fix/issue 1065 intelij 2026 debugging fails

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
     kotlin("jvm") version "2.3.21"
     kotlin("plugin.lombok") version "2.3.21"
     kotlin("plugin.compose") version "2.3.21"
-    id("org.jetbrains.intellij.platform") version "2.13.1"
+    id("org.jetbrains.intellij.platform") version "2.15.0"
     jacoco
 }
 
@@ -35,12 +35,7 @@ val binaryIncompatibleRuntimeJarPatterns = listOf(
     "kotlinx-coroutines-core-jvm-*.jar"
 )
 val packagedPluginDirName = "DevoxxGenie"
-val pluginVerifierCommunityIdeVersions = listOf(
-    "2025.1.7",   // 251 line
-    "2025.2.6.1"  // 252 line
-)
 val pluginVerifierUnifiedIdeVersions = listOf(
-    "2025.3.3",          // 253 line
     "2026.1",             // 261 line
     "2026.2-EAP-SNAPSHOT" // 262 line
 )
@@ -378,8 +373,8 @@ dependencies {
 intellijPlatform {
     pluginConfiguration {
         ideaVersion {
-            sinceBuild = "251"
-            untilBuild = "262.*"
+            sinceBuild = "261"
+            untilBuild = "261.*"
         }
     }
 
@@ -395,9 +390,6 @@ intellijPlatform {
 
     pluginVerification {
         ides {
-            pluginVerifierCommunityIdeVersions.forEach { ideVersion ->
-                create("IC", ideVersion) {}
-            }
             pluginVerifierUnifiedIdeVersions.forEach { ideVersion ->
                 create("IU", ideVersion) {}
             }
@@ -425,11 +417,7 @@ afterEvaluate {
 
 tasks {
     // Run plugin on different IntelliJ versions for testing
-    // Usage: ./gradlew runIde -PideVersion=2024.3.5
-    //        ./gradlew runIde -PideVersion=2025.1.1
-    //        ./gradlew runIde -PideVersion=2025.2.2
-    //        ./gradlew runIde -PideVersion=2025.3.3
-    //        ./gradlew runIde -PideVersion=2026.1
+    // Usage: ./gradlew runIde -PideVersion=2026.1
     //        ./gradlew runIde -PideVersion=2026.2-EAP-SNAPSHOT
 
     withType<Jar> {
@@ -484,9 +472,8 @@ tasks {
     }
 }
 
-java {
-    sourceCompatibility = JavaVersion.VERSION_17
-    targetCompatibility = JavaVersion.VERSION_17
+kotlin {
+    jvmToolchain(25)
 }
 
 kotlinLombok {
@@ -495,6 +482,6 @@ kotlinLombok {
 
 tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
     compilerOptions {
-        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17)
+        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_25)
     }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -24,7 +24,7 @@ repositories {
 }
 
 jacoco {
-    toolVersion = "0.8.12"
+    toolVersion = "0.8.14"
 }
 
 val binaryIncompatibleRuntimeJarPatterns = listOf(

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,9 +4,9 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
     java
-    kotlin("jvm") version "2.1.10"
-    kotlin("plugin.lombok") version "2.1.10"
-    kotlin("plugin.compose") version "2.1.10"
+    kotlin("jvm") version "2.3.21"
+    kotlin("plugin.lombok") version "2.3.21"
+    kotlin("plugin.compose") version "2.3.21"
     id("org.jetbrains.intellij.platform") version "2.13.1"
     jacoco
 }
@@ -18,6 +18,7 @@ repositories {
     mavenCentral()
     intellijPlatform {
         defaultRepositories()
+        jetbrainsRuntime()
     }
     google()
 }
@@ -40,6 +41,7 @@ val pluginVerifierCommunityIdeVersions = listOf(
 )
 val pluginVerifierUnifiedIdeVersions = listOf(
     "2025.3.3",          // 253 line
+    "2026.1",             // 261 line
     "2026.2-EAP-SNAPSHOT" // 262 line
 )
 
@@ -222,8 +224,8 @@ tasks.named("processResources") {
 
 dependencies {
     intellijPlatform {
-        // Allow overriding IDE version via property: ./gradlew runIde -PideVersion=2025.1.7
-        create("IC", providers.gradleProperty("ideVersion").orElse("2025.1.7")) {}
+        // Allow overriding IDE version via property: ./gradlew runIde -PideVersion=2026.1.1
+        intellijIdea(providers.gradleProperty("ideVersion").orElse("2026.1"))
         bundledPlugin("com.intellij.java")
         bundledPlugin("org.intellij.plugins.markdown")  // Required by markdown renderer
         composeUI()
@@ -427,6 +429,7 @@ tasks {
     //        ./gradlew runIde -PideVersion=2025.1.1
     //        ./gradlew runIde -PideVersion=2025.2.2
     //        ./gradlew runIde -PideVersion=2025.3.3
+    //        ./gradlew runIde -PideVersion=2026.1
     //        ./gradlew runIde -PideVersion=2026.2-EAP-SNAPSHOT
 
     withType<Jar> {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -39,7 +39,8 @@ val pluginVerifierCommunityIdeVersions = listOf(
     "2025.2.6.1"  // 252 line
 )
 val pluginVerifierUnifiedIdeVersions = listOf(
-    "2025.3.3"    // 253 line
+    "2025.3.3",          // 253 line
+    "2026.2-EAP-SNAPSHOT" // 262 line
 )
 
 fun Project.stripBinaryIncompatibleRuntimeJars(sandboxPluginPath: String) {
@@ -376,7 +377,7 @@ intellijPlatform {
     pluginConfiguration {
         ideaVersion {
             sinceBuild = "251"
-            untilBuild = "261.*"
+            untilBuild = "262.*"
         }
     }
 
@@ -426,6 +427,7 @@ tasks {
     //        ./gradlew runIde -PideVersion=2025.1.1
     //        ./gradlew runIde -PideVersion=2025.2.2
     //        ./gradlew runIde -PideVersion=2025.3.3
+    //        ./gradlew runIde -PideVersion=2026.2-EAP-SNAPSHOT
 
     withType<Jar> {
         duplicatesStrategy = DuplicatesStrategy.EXCLUDE

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -11,7 +11,7 @@
     <!-- A displayed Vendor name or Organization ID displayed on the Plugins Page. -->
     <vendor email="info@devoxx.com" url="https://devoxx.com">Devoxx</vendor>
 
-    <idea-version since-build="243" until-build="262.*"/>
+    <idea-version since-build="262" until-build="262.*"/>
 
     <!-- Description of the plugin displayed on the Plugin Page and IDE Plugin Manager.
          Simple HTML elements (text formatting, paragraphs, and lists) can be added inside of <![CDATA[ ]]> tag.

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -11,7 +11,7 @@
     <!-- A displayed Vendor name or Organization ID displayed on the Plugins Page. -->
     <vendor email="info@devoxx.com" url="https://devoxx.com">Devoxx</vendor>
 
-    <idea-version since-build="243" until-build="261.*"/>
+    <idea-version since-build="243" until-build="262.*"/>
 
     <!-- Description of the plugin displayed on the Plugin Page and IDE Plugin Manager.
          Simple HTML elements (text formatting, paragraphs, and lists) can be added inside of <![CDATA[ ]]> tag.


### PR DESCRIPTION
# Pull Request

## 📚 Documentation

Before submitting, please review our [Contributing Guide](https://genie.devoxx.com/docs/contributing).

## Description

This PR updates the IntelliJ Platform dependency configuration to support modern versions (2026.1+) and upgrades the Kotlin compiler to 2.3.21 to resolve metadata compatibility issues. Due to these changes, support for legacy IntelliJ versions (e.g., 2025.3.3) has been deprecated as they are incompatible with the new platform dependency structure and Kotlin metadata requirements.

**Note on Compatibility:**
The current configuration is intended primarily to facilitate development and debugging within **IntelliJ IDEA 2026.1**. Please be aware that this setup will cause startup failures in older versions (e.g., **2025.3.3**). I recommend maintaining this configuration for forward-looking development until support for older IntelliJ versions is officially deprecated and removed from the project.

## Type of Change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test addition/improvement

## Related Issue

<!-- Link to the issue this PR addresses -->
Fixes #1065 
Closes #1065
Relates #1064

## Changes Made

- Replaced deprecated `ideaIC` artifact with `intellijIdea()` helper in `build.gradle.kts`.
- Added `jetbrainsRuntime()` to `intellijPlatform` repository configuration.
- Upgraded Kotlin compiler, `plugin.lombok`, and `plugin.compose` to **2.3.21**.
- Added `2026.1` to `pluginVerifierUnifiedIdeVersions`.
- Deprecated support for IntelliJ Platform versions older than 2026.1.
- Updated JVM runtime to version 25, as it's the expected runtime: https://github.com/JetBrains/JetBrainsRuntime#releases-based-on-jdk-25

## Testing

**How has this been tested?**

- [ ] Unit tests
- [ ] Integration tests
- [X] Manual testing in IntelliJ IDEA
- [ ] Tested with local LLM (Ollama/LMStudio/GPT4All)
- [X] Tested with cloud LLM (Gemini)
- [ ] Tested with MCP servers
- [ ] Tested with RAG enabled

**Test Configuration:**
- IntelliJ IDEA version: 2026.1; 2025.3.3
- JDK version: temurin-25.0.3
- OS: Ubuntu 24.04.4 LTS

## Documentation

- [ ] I have updated the documentation at [genie.devoxx.com](https://genie.devoxx.com) if needed
- [ ] I have updated CLAUDE.md if architecture/patterns changed
- [ ] I have added/updated code comments for complex logic
- [ ] I have updated the README.md if needed

## Checklist

- [X] My code follows the existing code style
- [X] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published


## Breaking Changes
Drops support for versions <2026

## Additional notes

#### STEP 1: Addressing the Kotlin Metadata Error
After updating the dependency, the build encountered `Incompatible classes` errors (e.g., `binary version of its metadata is 2.3.0, expected version is 2.1.0`).

This occurs because the IntelliJ Platform 2026.1 is compiled with **Kotlin 2.1.x** (or newer), while the current project is configured to use an older Kotlin compiler version. To resolve this, we must ensure the project's Kotlin compiler version is compatible with the metadata generated by the target IDE version.

**Changes included:**
- Replaced `create("IC", ...)` with `intellijIdea(...)` in the `dependencies` block.
- Added `jetbrainsRuntime()` to the `intellijPlatform` repository configuration to ensure the correct runtime is resolved.
- Added `2026.1` to the `pluginVerifierUnifiedIdeVersions` list to support testing against the new target.

#### STEP 2: Updating dependencies

Upgraded the Kotlin compiler to **2.3.21** to resolve metadata compatibility issues.

**Changes included:**
- Upgraded `kotlin("jvm")`, `kotlin("plugin.lombok")`, and `kotlin("plugin.compose")` to **2.3.21**.

**Result:**
- DevoxxGenie plugin starts on IntelliJ IDEA **2026.1** however if now fails to start on version **2025.3.3**, with error:
```
Should be called at least in the state COMPONENTS_LOADED, the current state is: CONFIGURATION_STORE_INITIALIZED
Current violators count: 1



java.lang.Throwable
	at com.intellij.diagnostic.LoadingState.logStateError(LoadingState.java:56)
	at com.intellij.diagnostic.LoadingState.checkOccurred(LoadingState.java:52)
	at com.intellij.openapi.util.registry.Registry$Companion.getInstance(Registry.kt:182)
	at com.intellij.openapi.util.registry.Registry$Companion.is(Registry.kt:89)
	at com.intellij.openapi.progress.impl.PlatformTaskSupportKt.isRhizomeProgressEnabled(PlatformTaskSupport.kt:62)
	at com.intellij.openapi.progress.impl.PlatformTaskSupport$withBackgroundProgressInternal$2.invokeSuspend(PlatformTaskSupport.kt:104)
	at com.intellij.openapi.progress.impl.PlatformTaskSupport$withBackgroundProgressInternal$2.invoke(PlatformTaskSupport.kt)
	at com.intellij.openapi.progress.impl.PlatformTaskSupport$withBackgroundProgressInternal$2.invoke(PlatformTaskSupport.kt)
	at kotlinx.coroutines.intrinsics.UndispatchedKt.startUndispatchedOrReturn(Undispatched.kt:44)
	at kotlinx.coroutines.CoroutineScopeKt.coroutineScope(CoroutineScope.kt:285)
	at com.intellij.openapi.progress.impl.PlatformTaskSupport.withBackgroundProgressInternal(PlatformTaskSupport.kt:103)
	at com.intellij.platform.ide.progress.TasksKt.withBackgroundProgress(tasks.kt:83)
	at com.intellij.platform.ide.progress.TasksKt.withBackgroundProgress(tasks.kt:42)
	at com.intellij.openapi.vfs.newvfs.RefreshQueueImpl.collectEventsSuspending(RefreshQueueImpl.kt:151)
	at com.intellij.openapi.vfs.newvfs.RefreshQueueImpl.access$collectEventsSuspending(RefreshQueueImpl.kt:42)
	at com.intellij.openapi.vfs.newvfs.RefreshQueueImpl$queueAsyncSessionWithCoroutines$3.invokeSuspend(RefreshQueueImpl.kt:170)
	at com.intellij.openapi.vfs.newvfs.RefreshQueueImpl$queueAsyncSessionWithCoroutines$3.invoke(RefreshQueueImpl.kt)
	at com.intellij.openapi.vfs.newvfs.RefreshQueueImpl$queueAsyncSessionWithCoroutines$3.invoke(RefreshQueueImpl.kt)
	at com.intellij.openapi.vfs.newvfs.RefreshQueueImpl$launchWithPermit$1$1$1.invokeSuspend(RefreshQueueImpl.kt:91)
	at com.intellij.openapi.vfs.newvfs.RefreshQueueImpl$launchWithPermit$1$1$1.invoke(RefreshQueueImpl.kt)
	at com.intellij.openapi.vfs.newvfs.RefreshQueueImpl$launchWithPermit$1$1$1.invoke(RefreshQueueImpl.kt)
	at kotlinx.coroutines.intrinsics.UndispatchedKt.startUndispatchedOrReturn(Undispatched.kt:44)
	at kotlinx.coroutines.CoroutineScopeKt.coroutineScope(CoroutineScope.kt:285)
	at com.intellij.openapi.vfs.newvfs.RefreshQueueImpl$launchWithPermit$1.invokeSuspend(RefreshQueueImpl.kt:90)
	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith$$$capture(ContinuationImpl.kt:34)
	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt)
	at --- Async.Stack.Trace --- (captured by IntelliJ IDEA debugger)
	at kotlinx.coroutines.debug.internal.DebugProbesImpl$CoroutineOwner.<init>(DebugProbesImpl.kt:531)
	at kotlinx.coroutines.debug.internal.DebugProbesImpl.createOwner(DebugProbesImpl.kt:510)
	at kotlinx.coroutines.debug.internal.DebugProbesImpl.probeCoroutineCreated$kotlinx_coroutines_core(DebugProbesImpl.kt:497)
	at kotlin.coroutines.jvm.internal.DebugProbesKt.probeCoroutineCreated(DebugProbes.kt:7)
	at kotlin.coroutines.intrinsics.IntrinsicsKt__IntrinsicsJvmKt.createCoroutineUnintercepted(IntrinsicsJvm.kt:161)
	at kotlinx.coroutines.intrinsics.CancellableKt.startCoroutineCancellable(Cancellable.kt:26)
	at kotlinx.coroutines.CoroutineStart.invoke(CoroutineStart.kt:358)
	at kotlinx.coroutines.AbstractCoroutine.start(AbstractCoroutine.kt:134)
	at kotlinx.coroutines.BuildersKt__Builders_commonKt.launch(Builders.common.kt:52)
	at kotlinx.coroutines.BuildersKt.launch(Unknown Source)
	at kotlinx.coroutines.BuildersKt__Builders_commonKt.launch$default(Builders.common.kt:43)
	at kotlinx.coroutines.BuildersKt.launch$default(Unknown Source)
	at com.intellij.openapi.vfs.newvfs.RefreshQueueImpl.launchWithPermit(RefreshQueueImpl.kt:88)
	at com.intellij.openapi.vfs.newvfs.RefreshQueueImpl.queueAsyncSessionWithCoroutines(RefreshQueueImpl.kt:168)
	at com.intellij.openapi.vfs.newvfs.RefreshQueueImpl.execute$intellij_platform_ide_impl(RefreshQueueImpl.kt:65)
	at com.intellij.openapi.vfs.newvfs.RefreshSessionImpl.launch(RefreshSessionImpl.kt:112)
	at com.intellij.openapi.vfs.newvfs.RefreshQueue.refresh(RefreshQueue.kt:28)
	at com.intellij.openapi.vfs.newvfs.RefreshQueue.refresh(RefreshQueue.kt:18)
	at com.intellij.ide.plugins.DynamicPluginVfsListenerInitializer.execute(DynamicPluginVfsListener.kt:54)
	at com.intellij.ide.plugins.DynamicPluginVfsListenerInitializer$execute$1.invokeSuspend(DynamicPluginVfsListener.kt)
	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith$$$capture(ContinuationImpl.kt:34)
	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt)
	at --- Async.Stack.Trace --- (captured by IntelliJ IDEA debugger)
	at kotlinx.coroutines.debug.internal.DebugProbesImpl$CoroutineOwner.<init>(DebugProbesImpl.kt:531)
	at kotlinx.coroutines.debug.internal.DebugProbesImpl.createOwner(DebugProbesImpl.kt:510)
	at kotlinx.coroutines.debug.internal.DebugProbesImpl.probeCoroutineCreated$kotlinx_coroutines_core(DebugProbesImpl.kt:497)
	at kotlin.coroutines.jvm.internal.DebugProbesKt.probeCoroutineCreated(DebugProbes.kt:7)
	at kotlin.coroutines.intrinsics.IntrinsicsKt__IntrinsicsJvmKt.createCoroutineUnintercepted(IntrinsicsJvm.kt:161)
	at kotlinx.coroutines.intrinsics.CancellableKt.startCoroutineCancellable(Cancellable.kt:26)
	at kotlinx.coroutines.CoroutineStart.invoke(CoroutineStart.kt:358)
	at kotlinx.coroutines.AbstractCoroutine.start(AbstractCoroutine.kt:134)
	at kotlinx.coroutines.BuildersKt__Builders_commonKt.launch(Builders.common.kt:52)
	at kotlinx.coroutines.BuildersKt.launch(Unknown Source)
	at kotlinx.coroutines.BuildersKt__Builders_commonKt.launch$default(Builders.common.kt:43)
	at kotlinx.coroutines.BuildersKt.launch$default(Unknown Source)
	at com.intellij.platform.ide.bootstrap.ApplicationLoader.executeAsyncAppInitListeners(ApplicationLoader.kt:282)
	at com.intellij.platform.ide.bootstrap.ApplicationLoader.access$executeAsyncAppInitListeners(ApplicationLoader.kt:1)
	at com.intellij.platform.ide.bootstrap.ApplicationLoader$loadApp$2$4$3.invokeSuspend(ApplicationLoader.kt:219)
	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith$$$capture(ContinuationImpl.kt:34)
	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt)
	at --- Async.Stack.Trace --- (captured by IntelliJ IDEA debugger)
	at kotlinx.coroutines.debug.internal.DebugProbesImpl$CoroutineOwner.<init>(DebugProbesImpl.kt:531)
	at kotlinx.coroutines.debug.internal.DebugProbesImpl.createOwner(DebugProbesImpl.kt:510)
	at kotlinx.coroutines.debug.internal.DebugProbesImpl.probeCoroutineCreated$kotlinx_coroutines_core(DebugProbesImpl.kt:497)
	at kotlin.coroutines.jvm.internal.DebugProbesKt.probeCoroutineCreated(DebugProbes.kt:7)
	at kotlin.coroutines.intrinsics.IntrinsicsKt__IntrinsicsJvmKt.createCoroutineUnintercepted(IntrinsicsJvm.kt:161)
	at kotlinx.coroutines.intrinsics.CancellableKt.startCoroutineCancellable(Cancellable.kt:26)
	at kotlinx.coroutines.CoroutineStart.invoke(CoroutineStart.kt:358)
	at kotlinx.coroutines.AbstractCoroutine.start(AbstractCoroutine.kt:134)
	at kotlinx.coroutines.BuildersKt__Builders_commonKt.launch(Builders.common.kt:52)
	at kotlinx.coroutines.BuildersKt.launch(Unknown Source)
	at kotlinx.coroutines.BuildersKt__Builders_commonKt.launch$default(Builders.common.kt:43)
	at kotlinx.coroutines.BuildersKt.launch$default(Unknown Source)
	at com.intellij.platform.ide.bootstrap.ApplicationLoader$loadApp$2$4.invokeSuspend(ApplicationLoader.kt:218)
	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith$$$capture(ContinuationImpl.kt:34)
	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt)
	at --- Async.Stack.Trace --- (captured by IntelliJ IDEA debugger)
	at kotlinx.coroutines.debug.internal.DebugProbesImpl$CoroutineOwner.<init>(DebugProbesImpl.kt:531)
	at kotlinx.coroutines.debug.internal.DebugProbesImpl.createOwner(DebugProbesImpl.kt:510)
	at kotlinx.coroutines.debug.internal.DebugProbesImpl.probeCoroutineCreated$kotlinx_coroutines_core(DebugProbesImpl.kt:497)
	at kotlin.coroutines.jvm.internal.DebugProbesKt.probeCoroutineCreated(DebugProbes.kt:7)
	at kotlin.coroutines.intrinsics.IntrinsicsKt__IntrinsicsJvmKt.createCoroutineUnintercepted(IntrinsicsJvm.kt:161)
	at kotlinx.coroutines.intrinsics.CancellableKt.startCoroutineCancellable(Cancellable.kt:26)
	at kotlinx.coroutines.CoroutineStart.invoke(CoroutineStart.kt:358)
	at kotlinx.coroutines.AbstractCoroutine.start(AbstractCoroutine.kt:134)
	at kotlinx.coroutines.BuildersKt__Builders_commonKt.launch(Builders.common.kt:52)
	at kotlinx.coroutines.BuildersKt.launch(Unknown Source)
	at kotlinx.coroutines.BuildersKt__Builders_commonKt.launch$default(Builders.common.kt:43)
	at kotlinx.coroutines.BuildersKt.launch$default(Unknown Source)
	at com.intellij.platform.ide.bootstrap.ApplicationLoader$loadApp$2.invokeSuspend(ApplicationLoader.kt:205)
	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith$$$capture(ContinuationImpl.kt:34)
	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt)
	at --- Async.Stack.Trace --- (captured by IntelliJ IDEA debugger)
	at kotlinx.coroutines.debug.internal.DebugProbesImpl$CoroutineOwner.<init>(DebugProbesImpl.kt:531)
	at kotlinx.coroutines.debug.internal.DebugProbesImpl.createOwner(DebugProbesImpl.kt:510)
	at kotlinx.coroutines.debug.internal.DebugProbesImpl.probeCoroutineCreated$kotlinx_coroutines_core(DebugProbesImpl.kt:497)
	at kotlin.coroutines.jvm.internal.DebugProbesKt.probeCoroutineCreated(DebugProbes.kt:7)
	at kotlin.coroutines.intrinsics.IntrinsicsKt__IntrinsicsJvmKt.createCoroutineUnintercepted(IntrinsicsJvm.kt:161)
	at kotlinx.coroutines.intrinsics.CancellableKt.startCoroutineCancellable(Cancellable.kt:26)
	at kotlinx.coroutines.CoroutineStart.invoke(CoroutineStart.kt:358)
	at kotlinx.coroutines.AbstractCoroutine.start(AbstractCoroutine.kt:134)
	at kotlinx.coroutines.BuildersKt__Builders_commonKt.async(Builders.common.kt:87)
	at kotlinx.coroutines.BuildersKt.async(Unknown Source)
	at kotlinx.coroutines.BuildersKt__Builders_commonKt.async$default(Builders.common.kt:78)
	at kotlinx.coroutines.BuildersKt.async$default(Unknown Source)
	at com.intellij.platform.ide.bootstrap.StartupUtil.startApplication(startup.kt:281)
	at com.intellij.idea.Main$startApp$2.invokeSuspend(Main.kt:164)
	at com.intellij.idea.Main$startApp$2.invoke(Main.kt)
	at com.intellij.idea.Main$startApp$2.invoke(Main.kt)
	at kotlinx.coroutines.intrinsics.UndispatchedKt.startUndispatchedOrReturn(Undispatched.kt:44)
	at kotlinx.coroutines.BuildersKt__Builders_commonKt.withContext(Builders.common.kt:166)
	at kotlinx.coroutines.BuildersKt.withContext(Unknown Source)
	at com.intellij.platform.diagnostic.telemetry.impl.TracerKt.span(tracer.kt:56)
	at com.intellij.platform.diagnostic.telemetry.impl.TracerKt.span$default(tracer.kt:49)
	at com.intellij.idea.Main.startApp(Main.kt:87)
	at com.intellij.idea.Main.access$startApp(Main.kt:1)
	at com.intellij.idea.Main$mainImpl$1$1.invokeSuspend(Main.kt:74)
	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith$$$capture(ContinuationImpl.kt:34)
	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt)
	at --- Async.Stack.Trace --- (captured by IntelliJ IDEA debugger)
	at kotlinx.coroutines.debug.internal.DebugProbesImpl$CoroutineOwner.<init>(DebugProbesImpl.kt:531)
	at kotlinx.coroutines.debug.internal.DebugProbesImpl.createOwner(DebugProbesImpl.kt:510)
	at kotlinx.coroutines.debug.internal.DebugProbesImpl.probeCoroutineCreated$kotlinx_coroutines_core(DebugProbesImpl.kt:497)
	at kotlin.coroutines.jvm.internal.DebugProbesKt.probeCoroutineCreated(DebugProbes.kt:7)
	at kotlin.coroutines.intrinsics.IntrinsicsKt__IntrinsicsJvmKt.createCoroutineUnintercepted(IntrinsicsJvm.kt:161)
	at kotlinx.coroutines.intrinsics.CancellableKt.startCoroutineCancellable(Cancellable.kt:26)
	at kotlinx.coroutines.CoroutineStart.invoke(CoroutineStart.kt:358)
	at kotlinx.coroutines.AbstractCoroutine.start(AbstractCoroutine.kt:134)
	at kotlinx.coroutines.BuildersKt__BuildersKt.runBlocking$BuildersKt__BuildersKt(Builders.kt:84)
	at kotlinx.coroutines.BuildersKt__BuildersKt.runBlocking(Builders.kt:53)
	at kotlinx.coroutines.BuildersKt.runBlocking(Unknown Source)
	at kotlinx.coroutines.BuildersKt__BuildersKt.runBlocking$default(Builders.kt:48)
	at kotlinx.coroutines.BuildersKt.runBlocking$default(Unknown Source)
	at com.intellij.idea.Main.mainImpl(Main.kt:66)
	at com.intellij.idea.Main.main(Main.kt:47)
```
Error received:

<img width="480" height="270" alt="Screenshot from 2026-05-28 18-07-03" src="https://github.com/user-attachments/assets/04202689-5473-4595-b651-8c2ce5603a77" />


**Final result:**
After unsuccessful attempts to debug the issue, I proceeded to upgrade all dependencies. 
This change is split into two commits: the first enables the necessary debugging environment, and the second removes support for legacy IntelliJ versions.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the project's license.
