### PR TITLE
fix: restore IntelliJ 2025.x compatibility

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,10 +4,10 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
     java
-    kotlin("jvm") version "2.3.21"
-    kotlin("plugin.lombok") version "2.3.21"
-    kotlin("plugin.compose") version "2.3.21"
-    id("org.jetbrains.intellij.platform") version "2.15.0"
+    kotlin("jvm") version "2.1.10"
+    kotlin("plugin.lombok") version "2.1.10"
+    kotlin("plugin.compose") version "2.1.10"
+    id("org.jetbrains.intellij.platform") version "2.13.1"
     jacoco
 }
 
@@ -219,8 +219,8 @@ tasks.named("processResources") {
 
 dependencies {
     intellijPlatform {
-        // Allow overriding IDE version via property: ./gradlew runIde -PideVersion=2026.1.1
-        intellijIdea(providers.gradleProperty("ideVersion").orElse("2026.1"))
+        // Allow overriding IDE version via property: ./gradlew runIde -PideVersion=2026.1
+        create("IC", providers.gradleProperty("ideVersion").orElse("2025.3.3")) {}
         bundledPlugin("com.intellij.java")
         bundledPlugin("org.intellij.plugins.markdown")  // Required by markdown renderer
         composeUI()
@@ -373,8 +373,8 @@ dependencies {
 intellijPlatform {
     pluginConfiguration {
         ideaVersion {
-            sinceBuild = "261"
-            untilBuild = "261.*"
+            sinceBuild = "251"
+            untilBuild = "262.*"
         }
     }
 
@@ -472,8 +472,9 @@ tasks {
     }
 }
 
-kotlin {
-    jvmToolchain(25)
+java {
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
 }
 
 kotlinLombok {
@@ -482,6 +483,6 @@ kotlinLombok {
 
 tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
     compilerOptions {
-        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_25)
+        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17)
     }
 }

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -11,7 +11,7 @@
     <!-- A displayed Vendor name or Organization ID displayed on the Plugins Page. -->
     <vendor email="info@devoxx.com" url="https://devoxx.com">Devoxx</vendor>
 
-    <idea-version since-build="262" until-build="262.*"/>
+    <idea-version since-build="243" until-build="262.*"/>
 
     <!-- Description of the plugin displayed on the Plugin Page and IDE Plugin Manager.
          Simple HTML elements (text formatting, paragraphs, and lists) can be added inside of <![CDATA[ ]]> tag.


### PR DESCRIPTION
## Summary
- Reverts the build portion of PR #1065 (2026-only migration) that broke loading and Compose rendering on IntelliJ 2025.x, while keeping a wide support range (251–262.*) so it still runs on the 2026 EAP.
- Fixes three layered failures: `requires build 261` (sinceBuild 261→251), `UnsupportedClassVersionError class file v69` (Java/Kotlin target 25→17), and `NoSuchMethodError Duration.Companion.fromRawValue` in Compose a11y (Kotlin toolchain 2.3.21→2.1.10, platform plugin 2.15.0→2.13.1, build target 2026.1→IC 2025.3.3).
- Compose (1.7.3) and Skiko (0.8.18) artifact versions are unchanged — the root cause was the Kotlin toolchain + platform build target feeding `composeUI()`, not the Compose/Skiko versions.

## Test plan
- [x] Loads on IntelliJ IDEA 2025.3 (build 253)
- [x] Loads on IntelliJ IDEA 2026 EAP
- [x] `./gradlew clean buildPlugin` succeeds (JDK 21)
- [x] `./gradlew test` / `verifyPlugin` green
- [x] Tool window + Compose UI render without `NoSuchMethodError`

🤖 Generated with [Claude Code](https://claude.com/claude-code)