### PR TITLE
chore: add Claude Opus 4.8 to models.json

### DIFF
--- a/docusaurus/static/api/models.json
+++ b/docusaurus/static/api/models.json
@@ -17,6 +17,15 @@
   "providers": {
     "Anthropic": [
       {
+        "modelName": "claude-opus-4-8",
+        "displayName": "Claude 4.8 Opus",
+        "inputCost": 5,
+        "outputCost": 25,
+        "inputMaxTokens": 1000000,
+        "outputMaxTokens": 128000,
+        "apiKeyUsed": true
+      },
+      {
         "modelName": "claude-opus-4-7",
         "displayName": "Claude 4.7 Opus",
         "inputCost": 5,
@@ -562,6 +571,13 @@
       }
     ],
     "Bedrock": [
+      {
+        "modelName": "anthropic.claude-opus-4-8",
+        "displayName": "Claude Opus 4.8",
+        "inputCost": 5,
+        "outputCost": 25,
+        "inputMaxTokens": 1000000
+      },
       {
         "modelName": "anthropic.claude-opus-4-7",
         "displayName": "Claude Opus 4.7",


### PR DESCRIPTION
## Summary
Adds Claude Opus 4.8 to the model registry served at `docusaurus/static/api/models.json`.

- **Anthropic API**: `claude-opus-4-8` — "Claude 4.8 Opus"
- **Bedrock**: `anthropic.claude-opus-4-8` — "Claude Opus 4.8"

Both entries: $5 / input MTok, $25 / output MTok, 1M input tokens, 128k max output (API entry).

## Verification
Values confirmed against official docs:
- [Anthropic Models overview](https://platform.claude.com/docs/en/about-claude/models/overview) — flagship Opus, $5/$25, 1M context, 128k output, Jan 2026 cutoff
- [AWS Bedrock model card](https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-anthropic-claude-opus-4-8.html) — Bedrock ID `anthropic.claude-opus-4-8` (no `-v1` suffix, matching Opus 4.7), available since May 28, 2026

🤖 Generated with [Claude Code](https://claude.com/claude-code)