### PR TITLE
fix: stop bundling platform coroutines jar; restore plugin build (#1054)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -115,8 +115,16 @@ tasks.register("updateProperties") {
     }
 }
 
-tasks.named("buildPlugin") {
+tasks.named<Zip>("buildPlugin") {
     dependsOn("updateProperties")
+
+    // Defense-in-depth for issue #1054: never ship runtime jars the IntelliJ Platform already
+    // provides. stripBinaryIncompatibleRuntimeJars only cleans the runIde/test sandboxes; the
+    // published distribution is produced by this Zip task, so filter the same jars out here
+    // regardless of which transitive dependency reintroduces them.
+    binaryIncompatibleRuntimeJarPatterns.forEach { pattern ->
+        exclude("**/lib/$pattern")
+    }
 }
 
 // Diagnostic CLI for the RAG store. Talks to the same ChromaDB + Ollama the plugin uses.
@@ -219,8 +227,11 @@ tasks.named("processResources") {
 
 dependencies {
     intellijPlatform {
+        // Starting with 2025.3 (build 253) IntelliJ IDEA is a single unified product: the
+        // separate Community (IC) Maven artifact is no longer published, so create("IC", ...)
+        // can no longer resolve. Use the unified intellijIdea(...) accessor instead.
         // Allow overriding IDE version via property: ./gradlew runIde -PideVersion=2026.1
-        create("IC", providers.gradleProperty("ideVersion").orElse("2025.3.3")) {}
+        intellijIdea(providers.gradleProperty("ideVersion").orElse("2025.3.3"))
         bundledPlugin("com.intellij.java")
         bundledPlugin("org.intellij.plugins.markdown")  // Required by markdown renderer
         composeUI()
@@ -287,6 +298,11 @@ dependencies {
     implementation("io.netty:netty-all:$nettyVersion")
     // Compose Markdown Renderer aligned with the 251 Compose/Kotlin toolchain
     implementation("com.mikepenz:multiplatform-markdown-renderer-jvm:$markdownRendererVersion") {
+        // The IntelliJ Platform provides coroutines at runtime. Bundling our own copy makes the
+        // plugin classloader load kotlinx.coroutines.flow.FlowCollector while the platform loads
+        // SafeCollector, causing a cross-classloader ClassCastException (issue #1054).
+        exclude(group = "org.jetbrains.kotlinx", module = "kotlinx-coroutines-core")
+        exclude(group = "org.jetbrains.kotlinx", module = "kotlinx-coroutines-core-jvm")
         exclude(group = "org.jetbrains", module = "markdown")
     }
     implementation("com.mikepenz:multiplatform-markdown-renderer-code-jvm:$markdownRendererVersion") {

--- a/src/test/java/com/devoxx/genie/packaging/PluginDistributionPackagingTest.java
+++ b/src/test/java/com/devoxx/genie/packaging/PluginDistributionPackagingTest.java
@@ -1,0 +1,123 @@
+package com.devoxx.genie.packaging;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Optional;
+import java.util.regex.Pattern;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipFile;
+
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+/**
+ * Regression test for issue #1054.
+ *
+ * <p>The IntelliJ Platform ships its own Kotlin coroutines runtime. When the plugin
+ * distribution bundles its <em>own</em> copy of {@code kotlinx-coroutines-core(-jvm)} the
+ * plugin's {@code PluginClassLoader} loads classes such as
+ * {@code kotlinx.coroutines.flow.FlowCollector} while the platform's {@code PathClassLoader}
+ * loads {@code kotlinx.coroutines.flow.internal.SafeCollector}. When the platform inline
+ * completion API hands a {@code SafeCollector} to the plugin's compiled Kotlin
+ * ({@code DevoxxGenieInlineCompletionProvider.getSuggestionDebounced}) the cross-classloader
+ * cast fails with:
+ *
+ * <pre>
+ * java.lang.ClassCastException: class kotlinx.coroutines.flow.internal.SafeCollector
+ *   cannot be cast to class kotlinx.coroutines.flow.FlowCollector
+ *   (SafeCollector is in unnamed module of loader PathClassLoader;
+ *    FlowCollector is in unnamed module of loader PluginClassLoader)
+ * </pre>
+ *
+ * <p>{@code stripBinaryIncompatibleRuntimeJars} already removes these jars from the
+ * {@code prepareSandbox}/{@code prepareTestSandbox} outputs (so {@code runIde} and the
+ * test sandbox are clean and the bug is invisible during development), but it was NOT applied
+ * to the {@code buildPlugin} distribution that is actually published. This test inspects the
+ * built distribution ZIP and fails if any forbidden coroutines jar is present in the plugin
+ * {@code lib/} directory.
+ */
+class PluginDistributionPackagingTest {
+
+    /**
+     * Jars that must never be bundled in the plugin distribution because the IntelliJ Platform
+     * provides them at runtime. Mirrors {@code binaryIncompatibleRuntimeJarPatterns} in
+     * {@code build.gradle.kts} (the coroutines entries).
+     */
+    private static final List<Pattern> FORBIDDEN_LIB_JARS = Arrays.asList(
+            Pattern.compile("kotlinx-coroutines-core-.*\\.jar"),
+            Pattern.compile("kotlinx-coroutines-core-jvm-.*\\.jar")
+    );
+
+    @Test
+    void distributionMustNotBundlePlatformCoroutinesJars() throws Exception {
+        Optional<File> distribution = findLatestDistributionZip();
+
+        // The distribution is only produced by `./gradlew buildPlugin`. When it is absent
+        // (e.g. a plain `./gradlew test` on a clean checkout) there is nothing to verify, so
+        // skip rather than fail spuriously. Run `./gradlew buildPlugin` to exercise this test.
+        assumeTrue(distribution.isPresent(),
+                "No plugin distribution ZIP found under build/distributions/ - run ./gradlew buildPlugin first");
+
+        File zip = distribution.get();
+        List<String> offending = new ArrayList<>();
+
+        try (ZipFile zipFile = new ZipFile(zip)) {
+            var entries = zipFile.entries();
+            while (entries.hasMoreElements()) {
+                ZipEntry entry = entries.nextElement();
+                String name = entry.getName();
+                if (entry.isDirectory()) {
+                    continue;
+                }
+                // Only inspect jars that live in the packaged plugin's lib/ directory,
+                // e.g. "DevoxxGenie/lib/kotlinx-coroutines-core-jvm-1.8.0.jar".
+                int libIdx = name.indexOf("/lib/");
+                if (libIdx < 0) {
+                    continue;
+                }
+                String fileName = name.substring(name.lastIndexOf('/') + 1);
+                for (Pattern forbidden : FORBIDDEN_LIB_JARS) {
+                    if (forbidden.matcher(fileName).matches()) {
+                        offending.add(name);
+                        break;
+                    }
+                }
+            }
+        }
+
+        if (!offending.isEmpty()) {
+            fail("Plugin distribution '" + zip.getName() + "' bundles coroutines jars that conflict "
+                    + "with the IntelliJ Platform classloader (issue #1054). "
+                    + "These must be excluded from the published plugin:\n  "
+                    + String.join("\n  ", offending));
+        }
+    }
+
+    /**
+     * Locates the most recently modified plugin distribution ZIP produced by buildPlugin.
+     * Walks up from the working directory so the test works regardless of the module the
+     * test runner is launched from.
+     */
+    private static Optional<File> findLatestDistributionZip() {
+        Path dir = Paths.get("").toAbsolutePath();
+        for (int depth = 0; depth < 4 && dir != null; depth++) {
+            File distributions = dir.resolve("build").resolve("distributions").toFile();
+            if (distributions.isDirectory()) {
+                File[] zips = distributions.listFiles(
+                        (d, fileName) -> fileName.endsWith(".zip") && fileName.startsWith("DevoxxGenie"));
+                if (zips != null && zips.length > 0) {
+                    return Arrays.stream(zips).max(Comparator.comparingLong(File::lastModified));
+                }
+            }
+            dir = dir.getParent();
+        }
+        return Optional.empty();
+    }
+}


### PR DESCRIPTION
Fixes #1054

## Problem
Inline completion crashed on the **first** request with:

```
java.lang.ClassCastException: class kotlinx.coroutines.flow.internal.SafeCollector
  cannot be cast to class kotlinx.coroutines.flow.FlowCollector
  (SafeCollector is in unnamed module of loader PathClassLoader;
   FlowCollector is in unnamed module of loader PluginClassLoader)
```

Chat mode worked fine — only inline completion (which goes through the platform's coroutine `Flow` API) was affected.

## Root cause
The published distribution bundled its own copy of coroutines:

```
DevoxxGenie/lib/kotlinx-coroutines-core-jvm-1.8.0.jar   ← contains both FlowCollector and SafeCollector
```

The IntelliJ Platform already provides coroutines at runtime. With a duplicate on the plugin classpath, the plugin's `PluginClassLoader` loads `FlowCollector` while the platform's `PathClassLoader` loads `SafeCollector`. When the platform inline-completion API hands a `Flow` to the plugin's compiled `DevoxxGenieInlineCompletionProvider.getSuggestionDebounced`, the cross-classloader cast fails.

`stripBinaryIncompatibleRuntimeJars` already removed these jars from the `prepareSandbox`/`prepareTestSandbox` outputs — so `runIde` and tests were clean and the bug was **invisible during development** — but it was never applied to the `buildPlugin` distribution that ships to the Marketplace.

The jar leaked in via the base `multiplatform-markdown-renderer-jvm` dependency, which excluded only `org.jetbrains:markdown` (the `-code-jvm` variant already excluded coroutines).

## Changes
- **Stop the leak at the source** — add `kotlinx-coroutines-core`/`-core-jvm` excludes to the base `multiplatform-markdown-renderer-jvm` dependency.
- **Defense-in-depth** — filter the platform-provided runtime jars directly out of the `buildPlugin` Zip, so any future transitive reintroduction can't reach the published artifact.
- **Regression test** — `PluginDistributionPackagingTest` inspects the built distribution ZIP and fails if any coroutines jar lives under the plugin `lib/`. It `assumeTrue`-skips when no distribution exists, so a plain `./gradlew test` on a clean checkout isn't affected.

### Also: restore the build
The build was failing for everyone with `Could not find idea:ideaIC:2025.3.3`. Since **2025.3 (build 253) IntelliJ IDEA is a single unified product** and the separate Community (`idea:ideaIC`) Maven artifact is no longer published, `create("IC", ...)` can no longer resolve. Switched to the unified `intellijIdea(...)` accessor (the `-PideVersion` override still works).

## Verification (default build, no `-PideVersion` override)
- `./gradlew clean buildPlugin` → **BUILD SUCCESSFUL** (previously failed on `buildSearchableOptions`).
- Fresh distribution `lib/` → **zero** coroutines jars.
- `PluginDistributionPackagingTest` → fails before the fix, **passes** after.
- Full `./gradlew test` → **BUILD SUCCESSFUL**, no failures.

## Note (not changed)
`pluginVerification.ides` (build.gradle.kts) still uses `create("IU", ...)` for 2026.x. It only affects `verifyPlugin`, not this breakage — left as-is to keep the change focused. Happy to follow up if `verifyPlugin` later fails to resolve those IDEs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)