### PR TITLE
fix: resolve JetBrains verifier issues for v1.7.0

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -36,8 +36,9 @@ val binaryIncompatibleRuntimeJarPatterns = listOf(
 )
 val packagedPluginDirName = "DevoxxGenie"
 val pluginVerifierUnifiedIdeVersions = listOf(
-    "2026.1",             // 261 line
-    "2026.2-EAP-SNAPSHOT" // 262 line
+    "2025.1",             // 251 line — minimum supported (sinceBuild)
+    "2026.1"              // 261 line
+    // "2026.2-EAP-SNAPSHOT" // 262 line — not yet available
 )
 
 fun Project.stripBinaryIncompatibleRuntimeJars(sandboxPluginPath: String) {

--- a/src/main/java/com/devoxx/genie/service/analytics/AnalyticsService.java
+++ b/src/main/java/com/devoxx/genie/service/analytics/AnalyticsService.java
@@ -1,11 +1,10 @@
 package com.devoxx.genie.service.analytics;
 
+import com.devoxx.genie.service.PropertiesService;
 import com.devoxx.genie.ui.settings.DevoxxGenieStateService;
-import com.intellij.ide.plugins.PluginManagerCore;
 import com.intellij.openapi.application.ApplicationInfo;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.components.Service;
-import com.intellij.openapi.extensions.PluginId;
 import lombok.extern.slf4j.Slf4j;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -44,8 +43,6 @@ public final class AnalyticsService {
     public static final String EVENT_FEATURE_ENABLED = "feature_enabled";
     public static final String EVENT_FEATURE_USED = "feature_used";
     public static final String EVENT_FEATURE_COUNTS = "feature_counts";
-
-    private static final String PLUGIN_ID = "com.devoxx.genie";
 
     private final String sessionId;
     private HttpClient httpClient;
@@ -238,9 +235,9 @@ public final class AnalyticsService {
     @NotNull
     private static String pluginVersion() {
         try {
-            var descriptor = PluginManagerCore.getPlugin(PluginId.getId(PLUGIN_ID));
-            if (descriptor != null && descriptor.getVersion() != null) {
-                return descriptor.getVersion();
+            String version = PropertiesService.getInstance().getVersion();
+            if (version != null && !version.isBlank()) {
+                return version;
             }
         } catch (Exception ignored) {
             // fall through

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -708,7 +708,7 @@
     <depends optional="true" config-file="php-features.xml">com.jetbrains.php</depends>
     <depends optional="true" config-file="python-features.xml">com.intellij.modules.python</depends>
     <depends optional="true" config-file="clion-features.xml">com.intellij.modules.clion</depends>
-    <depends optional="true" config-file="rust-features.xml">org.rust.lang</depends>
+    <depends optional="true" config-file="rust-features.xml">com.jetbrains.rust</depends>
     <depends optional="true" config-file="webstorm-features.xml">JavaScript</depends>
     <depends optional="true" config-file="kotlin-features.xml">org.jetbrains.kotlin</depends>
     <depends optional="true" config-file="goland-features.xml">org.jetbrains.plugins.go</depends>

--- a/src/main/resources/META-INF/rust-features.xml
+++ b/src/main/resources/META-INF/rust-features.xml
@@ -1,6 +1,6 @@
 <idea-plugin>
     <!-- Specific features for Rust projects in RustRover or other Rust-capable IDEs -->
-    <depends>org.rust.lang</depends>
+    <depends>com.jetbrains.rust</depends>
     
     <extensions defaultExtensionNs="com.intellij">
         <projectScannerExtension implementation="com.devoxx.genie.service.analyzer.languages.rust.RustProjectScannerExtension"/>

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,1 @@
-version=1.6.0
+version=1.7.0


### PR DESCRIPTION
## Summary
- **Internal API**: Replace `PluginManagerCore.getPlugin(PluginId)` in `AnalyticsService` with `PropertiesService.getInstance().getVersion()` — a public API already used consistently elsewhere in the plugin
- **Deprecated plugin ID**: Update optional Rust dependency from `org.rust.lang` (deprecated intellij-rust) to `com.jetbrains.rust` (current official JetBrains Rust plugin)
- **Verifier config**: Add `2025.1` (sinceBuild minimum) to the Gradle verifier IDE list; comment out `2026.2-EAP-SNAPSHOT` which doesn't exist yet in JetBrains' servers

## Test plan
- [x] `./gradlew compileJava` — clean build
- [x] `./gradlew test` — all tests pass (including `PluginDistributionPackagingTest`)
- [x] `./gradlew verifyPlugin` against IU-251 (2025.1) — **Compatible**
- [x] `./gradlew verifyPlugin` against IU-261 (2026.1) — **Compatible**
- [x] No `internal-api-usages.txt` generated in either verifier report

🤖 Generated with [Claude Code](https://claude.com/claude-code)