### PR TITLE
fix(websearch): fix Web switch visibility and streaming mode crash

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -140,6 +140,19 @@ tasks.register<JavaExec>("ragQuery") {
     standardInput = System.`in`
 }
 
+// Diagnostic CLI for the web search integration. Exercises Tavily/Google + LLM pipeline
+// without the IntelliJ service layer.
+// Examples:
+//   TAVILY_API_KEY=xxx OPENAI_API_KEY=yyy ./gradlew webSearch --args="tavily 'latest news on Iran'"
+//   GOOGLE_API_KEY=xxx GOOGLE_CSI_KEY=yyy OPENAI_API_KEY=zzz ./gradlew webSearch --args="google 'IntelliJ 2025'"
+tasks.register<JavaExec>("webSearch") {
+    group = "verification"
+    description = "Test the web search pipeline from the command line (see WebSearchCli for usage)."
+    mainClass.set("com.devoxx.genie.service.prompt.websearch.cli.WebSearchCli")
+    classpath = sourceSets["main"].runtimeClasspath
+    standardInput = System.`in`
+}
+
 val generatedBlogResourcesDir = layout.buildDirectory.dir("generated-resources/blog")
 
 sourceSets.named("main") {

--- a/src/main/java/com/devoxx/genie/service/prompt/websearch/WebSearchPromptExecutionService.java
+++ b/src/main/java/com/devoxx/genie/service/prompt/websearch/WebSearchPromptExecutionService.java
@@ -1,5 +1,6 @@
 package com.devoxx.genie.service.prompt.websearch;
 
+import com.devoxx.genie.chatmodel.ChatModelProvider;
 import com.devoxx.genie.model.request.ChatMessageContext;
 import com.devoxx.genie.ui.settings.DevoxxGenieStateService;
 import com.intellij.openapi.application.ApplicationManager;
@@ -19,6 +20,9 @@ import java.util.Optional;
 
 @Slf4j
 public class WebSearchPromptExecutionService {
+
+    // Package-private to allow injection in tests
+    ChatModelProvider chatModelProvider = new ChatModelProvider();
 
     public static WebSearchPromptExecutionService getInstance() {
         return ApplicationManager.getApplication().getService(WebSearchPromptExecutionService.class);
@@ -63,8 +67,16 @@ public class WebSearchPromptExecutionService {
             .maxResults(DevoxxGenieStateService.getInstance().getMaxSearchResults())
             .build();
 
+        // AiServices with a synchronous String-returning method requires chatModel, not streamingChatModel.
+        // In streaming mode only streamingChatModel is set on the context, so we create a non-streaming
+        // model from the same provider/settings on demand.
+        dev.langchain4j.model.chat.ChatModel chatModel = chatMessageContext.getChatModel();
+        if (chatModel == null) {
+            chatModel = chatModelProvider.getChatLanguageModel(chatMessageContext);
+        }
+
         SearchWebsite website = AiServices.builder(SearchWebsite.class)
-            .chatModel(chatMessageContext.getChatModel())
+            .chatModel(chatModel)
             .contentRetriever(contentRetriever)
             .build();
 

--- a/src/main/java/com/devoxx/genie/service/prompt/websearch/cli/WebSearchCli.java
+++ b/src/main/java/com/devoxx/genie/service/prompt/websearch/cli/WebSearchCli.java
@@ -1,0 +1,200 @@
+package com.devoxx.genie.service.prompt.websearch.cli;
+
+import dev.langchain4j.model.chat.ChatModel;
+import dev.langchain4j.model.ollama.OllamaChatModel;
+import dev.langchain4j.model.openai.OpenAiChatModel;
+import dev.langchain4j.rag.content.retriever.ContentRetriever;
+import dev.langchain4j.rag.content.retriever.WebSearchContentRetriever;
+import dev.langchain4j.service.AiServices;
+import dev.langchain4j.service.SystemMessage;
+import dev.langchain4j.web.search.WebSearchEngine;
+import dev.langchain4j.web.search.google.customsearch.GoogleCustomWebSearchEngine;
+import dev.langchain4j.web.search.tavily.TavilyWebSearchEngine;
+
+import java.time.Duration;
+import java.util.Locale;
+
+/**
+ * Standalone diagnostic CLI for the web search integration. Exercises the same Tavily/Google +
+ * LLM pipeline that the plugin uses, but bypasses the IntelliJ service layer so it can run from
+ * {@code ./gradlew webSearch}.
+ *
+ * <p>Usage:
+ * <pre>
+ *   ./gradlew webSearch --args="tavily 'latest news on Iran'"
+ *   ./gradlew webSearch --args="google 'IntelliJ IDEA 2025 release'"
+ * </pre>
+ *
+ * <p>LLM selection via {@code LLM_PROVIDER} env var (default: {@code ollama}):
+ * <ul>
+ *   <li>{@code ollama}  — local Ollama instance (no API key needed)</li>
+ *   <li>{@code openai}  — OpenAI cloud API</li>
+ * </ul>
+ *
+ * <p>Ollama env vars (when LLM_PROVIDER=ollama or unset):
+ * <ul>
+ *   <li>{@code OLLAMA_BASE_URL} — base URL (default {@code http://localhost:11434})</li>
+ *   <li>{@code OLLAMA_MODEL}    — model name (default {@code qwen3.6:35b-mlx})</li>
+ * </ul>
+ *
+ * <p>OpenAI env vars (when LLM_PROVIDER=openai):
+ * <ul>
+ *   <li>{@code OPENAI_API_KEY} — required</li>
+ *   <li>{@code OPENAI_MODEL}   — model name (default {@code gpt-4o-mini})</li>
+ * </ul>
+ *
+ * <p>Web-search env vars:
+ * <ul>
+ *   <li>{@code TAVILY_API_KEY}              — required for Tavily</li>
+ *   <li>{@code GOOGLE_API_KEY + GOOGLE_CSI_KEY} — required for Google</li>
+ * </ul>
+ */
+public final class WebSearchCli {
+
+    private static final int DEFAULT_MAX_RESULTS = 5;
+    private static final String DEFAULT_OLLAMA_URL   = "http://localhost:11434";
+    private static final String DEFAULT_OLLAMA_MODEL = "qwen3.6:35b-mlx";
+    private static final String DEFAULT_OPENAI_MODEL = "gpt-4o-mini";
+
+    private WebSearchCli() {}
+
+    interface SearchWebsite {
+        @SystemMessage("""
+                Provide a paragraph-long answer, not a long step by step explanation.
+                Reply with "I don't know the answer" if the provided information isn't relevant.
+            """)
+        String search(String query);
+    }
+
+    public static void main(String[] args) throws Exception {
+        if (args.length < 2) {
+            printUsage();
+            System.exit(2);
+        }
+
+        String searchProvider = args[0].toLowerCase(Locale.ROOT);
+        String query          = args[1];
+        int maxResults        = args.length >= 3 ? Integer.parseInt(args[2]) : DEFAULT_MAX_RESULTS;
+
+        System.out.printf("Query      : %s%n", query);
+        System.out.printf("MaxResults : %d%n", maxResults);
+
+        WebSearchEngine engine = buildSearchEngine(searchProvider);
+
+        ContentRetriever contentRetriever = WebSearchContentRetriever.builder()
+                .webSearchEngine(engine)
+                .maxResults(maxResults)
+                .build();
+
+        ChatModel chatModel = buildChatModel();
+
+        SearchWebsite service = AiServices.builder(SearchWebsite.class)
+                .chatModel(chatModel)
+                .contentRetriever(contentRetriever)
+                .build();
+
+        System.out.println("\nSearching...");
+        long start = System.currentTimeMillis();
+        String answer = service.search(query);
+        long elapsed = System.currentTimeMillis() - start;
+
+        System.out.printf("%nAnswer (%dms):%n%s%n", elapsed, answer);
+    }
+
+    private static WebSearchEngine buildSearchEngine(String provider) {
+        return switch (provider) {
+            case "tavily" -> {
+                String key = requireEnv("TAVILY_API_KEY");
+                System.out.println("Search     : Tavily");
+                yield TavilyWebSearchEngine.builder()
+                        .apiKey(key)
+                        .build();
+            }
+            case "google" -> {
+                String apiKey = requireEnv("GOOGLE_API_KEY");
+                String csiKey = requireEnv("GOOGLE_CSI_KEY");
+                System.out.println("Search     : Google Custom Search");
+                yield GoogleCustomWebSearchEngine.builder()
+                        .apiKey(apiKey)
+                        .csi(csiKey)
+                        .build();
+            }
+            default -> {
+                System.err.println("Unknown search provider: " + provider + " (use 'tavily' or 'google')");
+                printUsage();
+                System.exit(2);
+                yield null;
+            }
+        };
+    }
+
+    private static ChatModel buildChatModel() {
+        String llmProvider = env("LLM_PROVIDER", "ollama").toLowerCase(Locale.ROOT);
+        return switch (llmProvider) {
+            case "ollama" -> buildOllamaModel();
+            case "openai" -> buildOpenAiModel();
+            default -> {
+                System.err.println("Unknown LLM_PROVIDER: " + llmProvider + " (use 'ollama' or 'openai')");
+                System.exit(1);
+                yield null;
+            }
+        };
+    }
+
+    private static ChatModel buildOllamaModel() {
+        String baseUrl = env("OLLAMA_BASE_URL", DEFAULT_OLLAMA_URL);
+        String model   = env("OLLAMA_MODEL",    DEFAULT_OLLAMA_MODEL);
+        System.out.printf("LLM        : Ollama %s @ %s%n", model, baseUrl);
+        return OllamaChatModel.builder()
+                .baseUrl(baseUrl)
+                .modelName(model)
+                .timeout(Duration.ofMinutes(5))
+                .build();
+    }
+
+    private static ChatModel buildOpenAiModel() {
+        String key   = requireEnv("OPENAI_API_KEY");
+        String model = env("OPENAI_MODEL", DEFAULT_OPENAI_MODEL);
+        System.out.printf("LLM        : OpenAI %s%n", model);
+        return OpenAiChatModel.builder()
+                .apiKey(key)
+                .modelName(model)
+                .build();
+    }
+
+    private static String requireEnv(String key) {
+        String value = System.getenv(key);
+        if (value == null || value.isBlank()) {
+            System.err.println("Missing required env var: " + key);
+            System.exit(1);
+        }
+        return value;
+    }
+
+    private static String env(String key, String fallback) {
+        String v = System.getenv(key);
+        return v == null || v.isBlank() ? fallback : v;
+    }
+
+    private static void printUsage() {
+        System.err.println("""
+                Usage:
+                  ./gradlew webSearch --args="<search-provider> '<query>' [maxResults=5]"
+
+                  search-provider: tavily | google
+
+                Examples:
+                  ./gradlew webSearch --args="tavily 'latest news on Iran'"
+                  OLLAMA_MODEL=qwen3.6:35b-mlx ./gradlew webSearch --args="tavily 'latest news on Iran'"
+                  LLM_PROVIDER=openai OPENAI_API_KEY=xxx ./gradlew webSearch --args="google 'IntelliJ 2025' 10"
+
+                LLM selection (LLM_PROVIDER env var, default: ollama):
+                  ollama  — OLLAMA_BASE_URL (default http://localhost:11434), OLLAMA_MODEL (default qwen3.6:35b-mlx)
+                  openai  — OPENAI_API_KEY (required), OPENAI_MODEL (default gpt-4o-mini)
+
+                Search provider env vars:
+                  TAVILY_API_KEY                    (for tavily)
+                  GOOGLE_API_KEY + GOOGLE_CSI_KEY   (for google)
+                """);
+    }
+}

--- a/src/main/java/com/devoxx/genie/ui/settings/websearch/WebSearchProvidersConfigurable.java
+++ b/src/main/java/com/devoxx/genie/ui/settings/websearch/WebSearchProvidersConfigurable.java
@@ -16,9 +16,17 @@ public class WebSearchProvidersConfigurable implements Configurable {
     private final Project project;
     private final WebSearchProvidersComponent webSearchProvidersComponent;
 
+    // Snapshot of isWebSearchEnabled taken when the settings dialog opens (reset()).
+    // The ItemListener in WebSearchProvidersComponent mutates stateService immediately on every
+    // checkbox change, so stateService can no longer be used as the "before" value in isModified().
+    // Comparing against this snapshot ensures isModified() returns true when the user actually
+    // toggled the checkbox, so IntelliJ calls apply() and the WEB_SEARCH_STATE_TOPIC is published.
+    private boolean initialIsWebSearchEnabled;
+
     public WebSearchProvidersConfigurable(Project project) {
         this.project = project;
         webSearchProvidersComponent = new WebSearchProvidersComponent();
+        initialIsWebSearchEnabled = DevoxxGenieStateService.getInstance().getIsWebSearchEnabled();
     }
 
     /**
@@ -49,16 +57,11 @@ public class WebSearchProvidersConfigurable implements Configurable {
     public boolean isModified() {
         DevoxxGenieStateService stateService = DevoxxGenieStateService.getInstance();
 
-        boolean isModified = false;
+        // Use initialIsWebSearchEnabled (not stateService) for the enable checkbox: the ItemListener
+        // in WebSearchProvidersComponent mutates stateService live, so stateService always equals
+        // the checkbox and would make this check always return false.
+        boolean isModified = webSearchProvidersComponent.getEnableWebSearchCheckbox().isSelected() != initialIsWebSearchEnabled;
 
-        isModified |= !stateService.getIsWebSearchEnabled().equals(webSearchProvidersComponent.getEnableWebSearchCheckbox().isSelected());
-
-        webSearchProvidersComponent.getEnableWebSearchCheckbox().addItemListener(event -> {
-            String text = webSearchProvidersComponent.getEnableWebSearchCheckbox().getText();
-            stateService.setIsWebSearchEnabled(text.equalsIgnoreCase("true"));
-        });
-
-        isModified |= webSearchProvidersComponent.getEnableWebSearchCheckbox().isSelected() != stateService.getIsWebSearchEnabled();
         isModified |= stateService.isTavilySearchEnabled() != webSearchProvidersComponent.getTavilySearchEnabledCheckBox().isSelected();
         isModified |= isFieldModified(webSearchProvidersComponent.getTavilySearchApiKeyField(), stateService.getTavilySearchKey());
 
@@ -105,6 +108,10 @@ public class WebSearchProvidersConfigurable implements Configurable {
     @Override
     public void reset() {
         DevoxxGenieStateService settings = DevoxxGenieStateService.getInstance();
+
+        // Refresh snapshot before resetting the checkbox (the checkbox's ItemListener will fire
+        // and update stateService, but the snapshot stays anchored to the persisted value).
+        initialIsWebSearchEnabled = settings.getIsWebSearchEnabled();
 
         webSearchProvidersComponent.getEnableWebSearchCheckbox().setSelected(settings.getIsWebSearchEnabled());
 

--- a/src/main/java/com/devoxx/genie/ui/settings/websearch/WebSearchProvidersConfigurable.java
+++ b/src/main/java/com/devoxx/genie/ui/settings/websearch/WebSearchProvidersConfigurable.java
@@ -78,7 +78,9 @@ public class WebSearchProvidersConfigurable implements Configurable {
     public void apply() {
         DevoxxGenieStateService settings = DevoxxGenieStateService.getInstance();
 
-        settings.setIsWebSearchEnabled(webSearchProvidersComponent.getEnableWebSearchCheckbox().isSelected());
+        boolean isWebSearchEnabled = webSearchProvidersComponent.getEnableWebSearchCheckbox().isSelected();
+
+        settings.setIsWebSearchEnabled(isWebSearchEnabled);
         settings.setTavilySearchEnabled(webSearchProvidersComponent.getTavilySearchEnabledCheckBox().isSelected());
         settings.setTavilySearchKey(new String(webSearchProvidersComponent.getTavilySearchApiKeyField().getPassword()));
         settings.setGoogleSearchEnabled(webSearchProvidersComponent.getGoogleSearchEnabledCheckBox().isSelected());
@@ -88,6 +90,13 @@ public class WebSearchProvidersConfigurable implements Configurable {
 
         // Re-arm the feature-enablement analytics snapshot (task-209).
         com.devoxx.genie.service.analytics.DevoxxGenieSettingsChangedTopic.notifySettingsChanged();
+
+        // Always publish so the Web switch in SearchOptionsPanel reflects the current state.
+        // The ItemListener in WebSearchProvidersComponent already mutates stateService directly,
+        // so comparing oldValue/newValue here would always see them as equal.
+        project.getMessageBus()
+                .syncPublisher(AppTopics.WEB_SEARCH_STATE_TOPIC)
+                .onWebSearchStateChange(isWebSearchEnabled);
     }
 
     /**

--- a/src/main/java/com/devoxx/genie/ui/window/DevoxxGenieToolWindowContent.java
+++ b/src/main/java/com/devoxx/genie/ui/window/DevoxxGenieToolWindowContent.java
@@ -227,17 +227,14 @@ public class DevoxxGenieToolWindowContent implements SettingsChangeListener, Glo
             // Subscribe to file references events and forward them to the conversation panel
             MessageBusUtil.subscribe(connection, AppTopics.FILE_REFERENCES_TOPIC, promptOutputPanel.getConversationPanel());
 
-            // Search options panel : Set up message bus listeners for visibility changes
-            MessageBusUtil.subscribe(connection, AppTopics.RAG_STATE_TOPIC, enabled -> {
-                InputSwitch ragSwitch = submitPanel.getPromptInputArea().getSearchOptionsPanel().getSwitches().get(0);
-                ragSwitch.setVisible(enabled);
-                ragSwitch.setSelected(enabled);
-                submitPanel.getPromptInputArea().getSearchOptionsPanel().updatePanelVisibility();
-            });
+            // Search options panel: RAG no longer has a per-session toggle (removed in task-222),
+            // so only the web search switch remains at index 0.
             MessageBusUtil.subscribe(connection, AppTopics.WEB_SEARCH_STATE_TOPIC, enabled -> {
-                InputSwitch webSearchSwitch = submitPanel.getPromptInputArea().getSearchOptionsPanel().getSwitches().get(1);
+                InputSwitch webSearchSwitch = submitPanel.getPromptInputArea().getSearchOptionsPanel().getSwitches().get(0);
                 webSearchSwitch.setVisible(enabled);
-                webSearchSwitch.setSelected(enabled);
+                if (!enabled) {
+                    webSearchSwitch.setSelected(false);
+                }
                 submitPanel.getPromptInputArea().getSearchOptionsPanel().updatePanelVisibility();
             });
 

--- a/src/test/java/com/devoxx/genie/service/prompt/websearch/WebSearchPromptExecutionServiceTest.java
+++ b/src/test/java/com/devoxx/genie/service/prompt/websearch/WebSearchPromptExecutionServiceTest.java
@@ -1,11 +1,14 @@
 package com.devoxx.genie.service.prompt.websearch;
 
+import com.devoxx.genie.chatmodel.ChatModelProvider;
 import com.devoxx.genie.model.request.ChatMessageContext;
 import com.devoxx.genie.ui.settings.DevoxxGenieStateService;
 import com.intellij.openapi.application.Application;
 import com.intellij.openapi.application.ApplicationManager;
 import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.service.IllegalConfigurationException;
 import dev.langchain4j.model.chat.ChatModel;
+import dev.langchain4j.model.chat.StreamingChatModel;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -20,6 +23,7 @@ import org.mockito.quality.Strictness;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
@@ -29,6 +33,8 @@ class WebSearchPromptExecutionServiceTest {
     @Mock private DevoxxGenieStateService mockStateService;
     @Mock private ChatMessageContext mockContext;
     @Mock private ChatModel mockChatModel;
+    @Mock private StreamingChatModel mockStreamingChatModel;
+    @Mock private ChatModelProvider mockChatModelProvider;
 
     private MockedStatic<ApplicationManager> applicationManagerMock;
     private MockedStatic<DevoxxGenieStateService> stateServiceMock;
@@ -50,6 +56,7 @@ class WebSearchPromptExecutionServiceTest {
         when(mockContext.getChatModel()).thenReturn(mockChatModel);
 
         service = new WebSearchPromptExecutionService();
+        service.chatModelProvider = mockChatModelProvider;
     }
 
     @AfterEach
@@ -100,5 +107,42 @@ class WebSearchPromptExecutionServiceTest {
         Optional<AiMessage> result = service.searchWeb(mockContext);
 
         assertThat(result).isEmpty();
+    }
+
+    // Regression test: when streaming mode is active, getChatModel() returns null. The service
+    // must obtain a non-streaming chatModel from ChatModelProvider (AiServices requires chatModel
+    // for synchronous String-returning methods — streamingChatModel alone is not sufficient).
+    @Test
+    void searchWeb_withTavilyEnabled_andNullChatModel_usesChatModelProvider() {
+        when(mockStateService.isTavilySearchEnabled()).thenReturn(true);
+        when(mockStateService.getTavilySearchKey()).thenReturn("test-tavily-key");
+        when(mockStateService.getMaxSearchResults()).thenReturn(3);
+        when(mockContext.getChatModel()).thenReturn(null);                    // streaming mode: no chatModel
+        when(mockChatModelProvider.getChatLanguageModel(mockContext)).thenReturn(mockChatModel);
+        when(mockContext.getUserPrompt()).thenReturn("latest news on Iran");
+
+        // The service obtains a chatModel via the provider and calls AiServices.
+        // The call to Tavily itself will fail (no real API backend) but must NOT throw
+        // IllegalConfigurationException about a missing chatModel.
+        assertThatThrownBy(() -> service.searchWeb(mockContext))
+                .isNotInstanceOf(IllegalConfigurationException.class);
+
+        // Verify the provider was consulted to obtain the non-streaming model.
+        verify(mockChatModelProvider).getChatLanguageModel(mockContext);
+    }
+
+    @Test
+    void searchWeb_withTavilyEnabled_andExistingChatModel_doesNotConsultProvider() {
+        when(mockStateService.isTavilySearchEnabled()).thenReturn(true);
+        when(mockStateService.getTavilySearchKey()).thenReturn("test-tavily-key");
+        when(mockStateService.getMaxSearchResults()).thenReturn(3);
+        when(mockContext.getChatModel()).thenReturn(mockChatModel);           // non-streaming mode: chatModel present
+        when(mockContext.getUserPrompt()).thenReturn("latest news on Iran");
+
+        // chatModel is already set — provider must NOT be invoked.
+        assertThatThrownBy(() -> service.searchWeb(mockContext))
+                .isNotInstanceOf(IllegalConfigurationException.class);
+
+        verify(mockChatModelProvider, never()).getChatLanguageModel(any());
     }
 }


### PR DESCRIPTION
## Summary
- **Web switch always visible bug**: stale `RAG_STATE_TOPIC` subscriber (left over after task-222 removed the RAG session toggle) was incorrectly making the Web switch visible; wrong index `get(1)` caused `IndexOutOfBoundsException`; settings `apply()` never published `WEB_SEARCH_STATE_TOPIC` so live toggle had no effect
- **Streaming mode crash**: `AiServices` with a synchronous `String`-returning interface requires `chatModel` — passing `null` (as happens when only `streamingChatModel` is set) threw `IllegalConfigurationException` / `IllegalArgumentException`; fixed by obtaining a non-streaming model on-demand via `ChatModelProvider` when `chatModel` is absent
- **WebSearchCli**: new standalone diagnostic tool (`./gradlew webSearch`) that exercises the full Tavily/Google + LLM pipeline without IntelliJ, defaulting to local Ollama (`qwen3.6:35b-mlx`)

## Test plan
- [x] Enable Web Search (Tavily) in Settings → Web Search; confirm the "Web" switch appears in the input area
- [x] Disable Web Search in Settings; confirm the "Web" switch disappears
- [x] With streaming mode ON and Tavily configured, submit a web search query — should return results instead of `IllegalConfigurationException`
- [ ] `TAVILY_API_KEY=xxx ./gradlew webSearch --args="tavily 'latest news on Iran'"` returns an answer via Ollama
- [ ] All `WebSearchPromptExecutionServiceTest` tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)