### PR TITLE
Add backlog tasks 224-226 for Hermes-inspired agentic features

### DIFF
--- a/backlog/tasks/task-224 - Self-improving-Skill-Writer-capture-and-refine-agent-skills-from-successful-runs.md
+++ b/backlog/tasks/task-224 - Self-improving-Skill-Writer-capture-and-refine-agent-skills-from-successful-runs.md
@@ -1,0 +1,112 @@
+---
+id: TASK-224
+title: Self-improving Skill Writer — capture and refine agent skills from successful runs
+status: To Do
+assignee: []
+created_date: '2026-06-05 10:17'
+updated_date: '2026-06-05 10:17'
+labels:
+  - agent-mode
+  - skills
+  - feature
+  - hermes
+dependencies: []
+references:
+  - src/main/java/com/devoxx/genie/service/skill/SkillRegistry.java
+  - src/main/java/com/devoxx/genie/service/agent/AgentToolProviderFactory.java
+  - src/main/java/com/devoxx/genie/service/agent/tool/BuiltInToolProvider.java
+  - src/main/java/com/devoxx/genie/service/agent/AgentLoopTracker.java
+  - src/main/java/com/devoxx/genie/service/agent/AgentApprovalProvider.java
+  - src/main/java/com/devoxx/genie/service/prompt/strategy/StreamingPromptStrategy.java
+  - src/main/java/com/devoxx/genie/service/ChatService.java
+  - src/main/java/com/devoxx/genie/ui/settings/DevoxxGenieStateService.java
+  - src/main/java/com/devoxx/genie/ui/settings/agent/AgentSettingsComponent.java
+  - 'https://github.com/NousResearch/hermes-agent'
+  - 'https://agentskills.io/'
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+## Overview
+
+This task introduces a **Skill Writer**: a "learning loop" that lets the agent capture a successful multi-step run as a reusable **skill document**, and later refine that skill when it is used again. This is the single defining capability of Nous Research's Hermes Agent ("the only agent with a built-in learning loop — it creates skills from experience, improves them during use"), and it is the main agentic gap in DevoxxGenie today.
+
+### Current state (from codebase exploration)
+
+DevoxxGenie already **reads** skills but cannot **write** them:
+
+- `SkillRegistry` loads **static** skill markdown files (LangChain4J experimental `@Skill` + `FileSystemSkillLoader`) from a priority-ordered set of directories: `~/.agents/skills/`, `~/.claude/skills/`, `~/.devoxxgenie/skills/`, and project-local `.agents/.claude/.devoxxgenie/skills/`. It exposes `activate_skill` (and optional `read_skill_resource`) to the agent.
+- `AgentToolProviderFactory` wires `SkillRegistry.buildSkills().toolProvider()` into the agent tool chain.
+- There is **no mechanism** that captures a successful trajectory and persists it as a new skill, and no mechanism to refine an existing skill after use.
+
+This task adds the write/refine half of the loop, reusing the existing on-disk skill convention so captured skills are immediately discoverable by `SkillRegistry` on the next agent run.
+
+### Design principles
+
+- **User-curated, not silent.** Hermes nudges itself to persist knowledge; for an IDE we keep the human in the loop. Capture should be **proposed** (a confirmation dialog showing the draft skill), consistent with DevoxxGenie's existing approval-centric agent UX (`AgentApprovalProvider`). This avoids polluting the skill library with low-quality entries.
+- **Reuse the existing storage convention.** Write captured skills as markdown to the **project-local** `<project>/.devoxxgenie/skills/<skill-name>/SKILL.md` (highest-precedence project location that `SkillRegistry` already scans), so no new loader or registry is needed. A global-vs-project destination choice can be offered in the dialog.
+- **Progressive disclosure.** Follow the agentskills.io shape that `SkillRegistry` already consumes (name + description front-matter + body), so captured skills are compatible with the same `activate_skill` path and stay token-cheap until activated.
+- **Off the EDT.** Skill drafting calls the selected LLM provider; it must run off the Event Dispatch Thread (see CLAUDE.md EDT constraints), like other prompt execution.
+
+## Implementation Plan
+
+### 1. `capture_skill` agent tool (new)
+
+- New `CaptureSkillToolExecutor` under `service/agent/tool/`, registered in `BuiltInToolProvider` behind a `skillCaptureEnabled` flag (default false).
+- Tool signature: `capture_skill(name, description, steps)` — the agent supplies a short name, a one-line description, and the ordered procedure (the distilled "how I solved it"). The executor renders these into the agentskills.io `SKILL.md` format and writes the file.
+- Because it writes to disk, it must pass through `AgentApprovalProvider` as a **write** tool (NOT added to `READ_ONLY_TOOLS`), surfacing the draft skill in the approval dialog for the user to accept/edit/reject.
+- After a successful write, trigger an async `SkillRegistry` reload so the new skill is available without an IDE restart (the registry already supports async reload).
+
+### 2. End-of-run capture heuristic (the "nudge")
+
+- After an agent run completes in `StreamingPromptStrategy` (and the non-streaming path), evaluate a lightweight heuristic: the run **succeeded** (no error / user did not cancel) AND it used a non-trivial number of tool calls (read `AgentLoopTracker` for the executed-call count; threshold configurable, e.g. >= 4).
+- When the heuristic fires, post a non-blocking suggestion (balloon/notification, mirroring `EventAutomationService`'s confirmation balloon) offering "Save this as a reusable skill?". Accepting asks the model to draft the skill (off the EDT) and opens the same approval/edit dialog as the `capture_skill` tool.
+- The heuristic must be cheap and must NOT block the response; it only proposes.
+
+### 3. Skill refinement (`refine_skill`)
+
+- When an existing skill is activated during a run (observable via the `activate_skill` path), and that run subsequently succeeds or fails, allow the agent to propose an edit to the activated skill via a `refine_skill(name, updated_steps, reason)` tool.
+- Refinement is also a **write** operation → approval dialog + on-disk update. Keep a simple version trail (e.g. append-only `CHANGELOG` section in `SKILL.md`, or a `.bak` of the prior version) so refinements are reversible. No external versioning system.
+
+### 4. Settings & gating
+
+- Add `skillCaptureEnabled: Boolean` (default false) to `DevoxxGenieStateService`.
+- Add a "Skill Capture" section to `AgentSettingsComponent`: enable checkbox, capture-threshold (min tool calls) field, and a destination default (project vs `~/.devoxxgenie/skills`). Help text explaining the learning loop.
+
+### 5. Tests
+
+- Unit test `CaptureSkillToolExecutor`: renders valid agentskills.io `SKILL.md`, writes to the correct project-local directory, sanitizes the skill name into a safe folder name, and returns an error string (not an exception) on IO failure.
+- Test the end-of-run heuristic in isolation (given a mock `AgentLoopTracker` call count + success flag, it proposes vs stays silent at the threshold boundary).
+- Test that a captured skill is subsequently discoverable by `SkillRegistry` (round-trip), and that refinement updates the file and preserves a recoverable prior version.
+- Verify graceful degradation when the feature flag is off (no tool registered, no end-of-run prompt).
+
+## Out of scope (capture as follow-ups)
+
+- Fully autonomous (no-confirmation) capture and periodic self-reinforcement nudges à la Hermes — keep human-in-the-loop for v1.
+- Agent-authored *executable* tools (Hermes' Python `skill_manage`). DevoxxGenie skills are knowledge documents, not new code-level tools; generating runnable tools is a separate, larger effort.
+- Sharing/syncing skills to a remote registry (agentskills.io publishing).
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 A `capture_skill(name, description, steps)` built-in agent tool exists, gated behind a `skillCaptureEnabled` setting (default false), and writes an agentskills.io-compatible `SKILL.md` into a skills directory already scanned by `SkillRegistry`
+- [ ] #2 `capture_skill` is treated as a write tool: it routes through `AgentApprovalProvider` and presents the drafted skill to the user for accept/edit/reject before anything is written to disk
+- [ ] #3 After a captured skill is written, `SkillRegistry` reloads so the skill is usable via `activate_skill` without an IDE restart
+- [ ] #4 When an agent run completes successfully and used at least the configured number of tool calls (read from `AgentLoopTracker`), the user is offered a non-blocking suggestion to save the run as a skill; the suggestion never blocks or delays the response
+- [ ] #5 Skill drafting (LLM summarisation of the trajectory) runs off the EDT using the currently selected LLM provider
+- [ ] #6 A `refine_skill(name, updated_steps, reason)` tool lets the agent propose an edit to a previously activated skill; refinement is approval-gated and preserves a recoverable previous version of the skill
+- [ ] #7 An Agent Mode "Skill Capture" settings section exposes the enable toggle, the capture threshold, and the default destination (project vs user home), persisted via `DevoxxGenieStateService`
+- [ ] #8 Skill name input is sanitised into a safe directory name and IO failures are returned as error strings (not thrown) so the agent loop recovers gracefully
+- [ ] #9 Unit tests cover skill rendering/writing, the end-of-run threshold boundary, the SkillRegistry round-trip (capture → discover → activate), and refinement version preservation
+- [ ] #10 With the feature flag off, no capture tool is registered and no end-of-run prompt appears; plugin builds (`./gradlew buildPlugin`) and all tests pass (`./gradlew test`)
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Originated from research comparing DevoxxGenie's agent mode to Nous Research's Hermes Agent (https://github.com/NousResearch/hermes-agent), whose signature feature is a closed learning loop: it writes a reusable skill document after solving a hard problem and self-improves skills during use. DevoxxGenie already has the *read* side (`SkillRegistry` + `activate_skill`, agentskills.io-shaped files in `~/.agents`, `~/.claude`, `~/.devoxxgenie` and project-local equivalents) but no *write/refine* side. This task adds capture + refine while keeping a human-in-the-loop confirmation step (consistent with the existing `AgentApprovalProvider` UX) instead of Hermes' fully autonomous persistence.
+
+Key reuse points: `SkillRegistry` (loader + async reload), `AgentToolProviderFactory` (tool-chain assembly), `BuiltInToolProvider` (flag-gated tool registration pattern — see the `web_search`/`semantic_search` blocks), `AgentLoopTracker` (executed tool-call count for the heuristic), `AgentApprovalProvider` (write-tool approval), `EventAutomationService` (confirmation-balloon pattern for the non-blocking suggestion). Per CLAUDE.md: create a feature branch before code changes, keep summary/drafting off the EDT, and write behavioural tests first where practical.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-225 - Agent-task-planner-with-explicit-decomposition-and-writable-sub-agent-delegation.md
+++ b/backlog/tasks/task-225 - Agent-task-planner-with-explicit-decomposition-and-writable-sub-agent-delegation.md
@@ -1,0 +1,105 @@
+---
+id: TASK-225
+title: Agent task planner with explicit decomposition and writable sub-agent delegation
+status: To Do
+assignee: []
+created_date: '2026-06-05 10:17'
+updated_date: '2026-06-05 10:17'
+labels:
+  - agent-mode
+  - planner
+  - sub-agents
+  - feature
+  - hermes
+dependencies: []
+references:
+  - src/main/java/com/devoxx/genie/service/agent/tool/ParallelExploreToolExecutor.java
+  - src/main/java/com/devoxx/genie/service/agent/SubAgentRunner.java
+  - src/main/java/com/devoxx/genie/service/agent/AgentLoopTracker.java
+  - src/main/java/com/devoxx/genie/service/agent/AgentToolProviderFactory.java
+  - src/main/java/com/devoxx/genie/service/agent/tool/BuiltInToolProvider.java
+  - src/main/java/com/devoxx/genie/service/agent/AgentApprovalProvider.java
+  - src/main/java/com/devoxx/genie/ui/settings/DevoxxGenieStateService.java
+  - src/main/java/com/devoxx/genie/ui/settings/agent/AgentSettingsComponent.java
+  - 'https://github.com/NousResearch/hermes-agent'
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+## Overview
+
+Add an explicit **Planner** and a **writable `delegate_task`** capability to Agent Mode. In Hermes Agent the Planner "breaks tasks into sub-tasks and spawns sub-agents", and `delegate_task` "spawns child agent instances with isolated context, restricted toolsets, and their own terminal sessions". DevoxxGenie has the *spawning* half but neither an explicit plan nor writable delegation.
+
+### Current state (from codebase exploration)
+
+- `ParallelExploreToolExecutor` + `SubAgentRunner` already spawn 2–5 sub-agents with isolated `MessageWindowChatMemory`, their own (configurable) model, an `AgentLoopTracker` with a lower call limit, per-thread timeout, and cancellation propagation registered on the parent tracker.
+- **Limitation 1 — read-only only.** Sub-agents get a `ReadOnlyToolProvider` (only `read_file` / `list_files` / `search_files`). They can explore but cannot *do* a sub-task (no write/edit/run). This makes `parallel_explore` a research fan-out, not true delegation.
+- **Limitation 2 — no explicit plan.** Task decomposition is implicit in the LLM's prompting. There is no user-visible plan, no checklist, no per-sub-task status. The "Planner" box in the Hermes diagram has no DevoxxGenie equivalent.
+
+This task fills both gaps while reusing the existing sub-agent machinery.
+
+### Design principles
+
+- **Reuse, don't rebuild.** Build on `SubAgentRunner` and the `AgentLoopTracker` cancellation tree. `delegate_task` is `parallel_explore`'s sibling with a broader (still scoped + approval-gated) toolset.
+- **Plan is transparent.** The plan must be visible to the user (rendered as a checklist in the output panel) so autonomous multi-step work stays inspectable — this is also a safety property.
+- **Writable delegation stays safe.** A delegated sub-agent that can write/run must still honour `AgentApprovalProvider` (write approvals bubble to the user) and a bounded tool-call budget. Default the delegated toolset to read-only-plus-scoped-write, opt-in, and never broader than the parent's allowed set.
+
+## Implementation Plan
+
+### 1. `plan_task` tool / planning pre-pass
+
+- Add a `plan_task(goal)` built-in tool (registered in `BuiltInToolProvider`, gated by a `taskPlannerEnabled` flag) that asks the model to emit an ordered list of sub-tasks as structured output (id, title, optional dependency ids, suggested toolset scope).
+- Persist the plan for the current run (in-memory, keyed like the agent loop) and render it as a **checklist** in `PromptOutputPanel`, updating each item's status (pending / in-progress / done / failed) as the run proceeds. Reuse existing output-panel rendering rather than introducing a new UI surface.
+- `plan_task` is read-only (planning produces no side effects) → add to `AgentApprovalProvider.READ_ONLY_TOOLS`.
+
+### 2. `delegate_task` tool (writable sibling of parallel_explore)
+
+- New `DelegateTaskToolExecutor` under `service/agent/tool/`, modelled on `ParallelExploreToolExecutor` but for a single (or small set of) delegated sub-task(s) that may modify the workspace.
+- Each delegated sub-agent uses a `SubAgentRunner` configured with a **scoped, opt-in writable** tool provider (e.g. read tools + `edit_file`/`write_file`/`run_command` only when the parent enabled delegation-writes), a dedicated `AgentLoopTracker` (lower budget), its own memory, and timeout — all already supported.
+- Cancellation: register each delegated runner as a `Cancellable` child of the parent tracker (same pattern `ParallelExploreToolExecutor` already uses) so user cancellation stops the whole tree.
+- Approval: delegated write/run calls route through the parent's `AgentApprovalProvider`, so the user still sees and approves writes initiated by sub-agents. The delegated toolset must never exceed the parent's permitted set.
+- Result: collect each sub-task's outcome and merge into a markdown summary returned to the parent agent (mirroring `parallel_explore`'s result merge), and update the plan checklist statuses.
+
+### 3. Settings & gating
+
+- Add to `DevoxxGenieStateService`: `taskPlannerEnabled` (default false), `delegateTaskEnabled` (default false), `delegateAllowWrites` (default false), and a delegated sub-agent tool-call budget (reuse existing sub-agent parallelism/limit fields where possible).
+- Add a "Planner & Delegation" section to `AgentSettingsComponent` with these toggles and clear help text warning that delegated writes are still approval-gated.
+
+### 4. Tests
+
+- Unit test `plan_task` output parsing (well-formed plan → checklist model; malformed → graceful error string).
+- Test `DelegateTaskToolExecutor` toolset scoping: with `delegateAllowWrites=false` the delegated provider exposes read-only tools only; with it true, the scoped write tools appear but never exceed the parent's set.
+- Test cancellation propagation: cancelling the parent `AgentLoopTracker` stops delegated runners (assert the `Cancellable` registration + flag broadcast).
+- Test that delegated write calls are still gated by `AgentApprovalProvider`.
+- Verify graceful degradation when both flags are off (neither tool registered).
+
+## Out of scope (capture as follow-ups)
+
+- Hermes' separate terminal/session per sub-agent across remote backends (Docker/SSH/Modal/Daytona) — DevoxxGenie sub-agents run in-process against the local workspace.
+- Automatic re-planning / plan repair on sub-task failure (v1: surface failure in the checklist and let the parent agent decide).
+- Persisting plans across IDE restarts.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 A `plan_task(goal)` built-in tool (gated by `taskPlannerEnabled`, default false) produces an ordered, structured list of sub-tasks with ids and optional dependencies
+- [ ] #2 The generated plan is rendered as a status-tracking checklist in the output panel and each item's status updates (pending/in-progress/done/failed) as the run proceeds
+- [ ] #3 `plan_task` is registered as read-only in `AgentApprovalProvider.READ_ONLY_TOOLS`
+- [ ] #4 A `delegate_task` built-in tool (gated by `delegateTaskEnabled`, default false) spawns a sub-agent via the existing `SubAgentRunner` to execute a delegated sub-task
+- [ ] #5 Delegated sub-agents default to a read-only scoped toolset; write/run tools are exposed only when `delegateAllowWrites` is enabled, and the delegated toolset never exceeds the parent agent's permitted set
+- [ ] #6 Write/run calls made by a delegated sub-agent still route through the parent `AgentApprovalProvider` and require user approval
+- [ ] #7 Each delegated sub-agent runs with its own `AgentLoopTracker` budget and timeout, and is registered as a Cancellable child so cancelling the parent stops the whole sub-agent tree
+- [ ] #8 An Agent Mode "Planner & Delegation" settings section exposes the planner/delegation/allow-writes toggles and budget, persisted via `DevoxxGenieStateService`
+- [ ] #9 Unit tests cover plan parsing, delegated-toolset scoping (writes off vs on), approval gating of delegated writes, and cancellation propagation
+- [ ] #10 With both flags off, neither tool is registered; plugin builds (`./gradlew buildPlugin`) and all tests pass (`./gradlew test`)
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Originated from research comparing DevoxxGenie's agent mode to Nous Research's Hermes Agent (https://github.com/NousResearch/hermes-agent). Hermes' "Planner" breaks tasks into sub-tasks and spawns sub-agents, and its `delegate_task` spawns child agents with isolated context and restricted toolsets. DevoxxGenie already has the spawning primitive (`ParallelExploreToolExecutor` + `SubAgentRunner`, with isolated memory, per-sub-agent `AgentLoopTracker`, timeout, and cancellation propagation) but (a) sub-agents are read-only via `ReadOnlyToolProvider`, and (b) there is no explicit, user-visible plan. This task adds an explicit `plan_task` (rendered as a checklist) and a writable, approval-gated `delegate_task` that reuses the same machinery.
+
+Reuse points: `SubAgentRunner` (sub-agent execution context, configurable model/memory/limit/timeout), `ParallelExploreToolExecutor` (thread-pool fan-out + result merge + Cancellable registration pattern), `AgentLoopTracker` (budget + cancellation tree), `AgentApprovalProvider` (write approvals — keep delegated writes gated), `BuiltInToolProvider` (flag-gated registration). Per CLAUDE.md: feature branch before code changes; UI/checklist updates on the EDT, long-running sub-agent work off it; behavioural tests first where practical. Keep scope tight — no remote backends, no automatic re-planning in v1.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-226 - Scheduled-cron-agent-automations-for-unattended-recurring-tasks.md
+++ b/backlog/tasks/task-226 - Scheduled-cron-agent-automations-for-unattended-recurring-tasks.md
@@ -1,0 +1,99 @@
+---
+id: TASK-226
+title: Scheduled / cron agent automations for unattended recurring tasks
+status: To Do
+assignee: []
+created_date: '2026-06-05 10:17'
+updated_date: '2026-06-05 10:17'
+labels:
+  - agent-mode
+  - automation
+  - scheduling
+  - feature
+  - hermes
+dependencies: []
+references:
+  - src/main/java/com/devoxx/genie/service/automation/EventAutomationService.java
+  - src/main/java/com/devoxx/genie/service/agent/AgentToolProviderFactory.java
+  - src/main/java/com/devoxx/genie/service/ChatService.java
+  - src/main/java/com/devoxx/genie/ui/settings/DevoxxGenieStateService.java
+  - src/main/java/com/devoxx/genie/ui/settings/agent/AgentSettingsComponent.java
+  - 'https://github.com/NousResearch/hermes-agent'
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+## Overview
+
+Add **time-based (scheduled / cron) automations** so DevoxxGenie can run agent prompts unattended on a recurring schedule. Hermes Agent provides "scheduled tasks using natural language or cron expressions ... with result delivery ... and pause/resume/edit". DevoxxGenie currently only triggers automations on IDE events, not on a clock.
+
+### Current state (from codebase exploration)
+
+- `EventAutomationService` maps IDE events (file save, VCS commit, etc.) to prompt templates with variable interpolation, and can auto-submit a prompt or show a confirmation balloon.
+- There is **no time-based trigger** — nothing runs "every morning", "hourly", or on a cron expression. The infrastructure for *defining* an automation (prompt template + variable interpolation + submit/confirm flow) already exists; only the **scheduler** is missing.
+
+This task adds a scheduling layer on top of the existing automation infrastructure rather than building a parallel system.
+
+### Design principles
+
+- **Reuse `EventAutomationService`'s execution path.** A scheduled automation is the same "template → interpolate → submit/confirm" flow, triggered by a timer instead of an IDE event. Refactor the trigger/registration so both event-based and time-based automations share the submit path.
+- **IDE-appropriate scheduling.** Use IntelliJ's `AppExecutorUtil.getAppScheduledExecutorService()` (or `Alarm`) for scheduling — NOT raw threads. Schedules only fire while the IDE is open (document this clearly; we are not a daemon like Hermes).
+- **Off the EDT, with safe submission.** Timer callbacks run off the EDT; prompt submission must hop onto the correct thread via `ApplicationManager.getApplication().invokeLater()` as the existing automation flow does.
+- **Visible and controllable.** Scheduled automations must be listable with pause / resume / edit / delete and last-run / next-run status, so unattended runs are never opaque.
+
+## Implementation Plan
+
+### 1. Schedule model & persistence
+
+- Define a `ScheduledAutomation` model: id, name, schedule expression (cron and/or a small natural-language vocabulary like "every day at 09:00", "hourly"), the prompt template, enabled flag, and last/next-run timestamps.
+- Persist the list via `DevoxxGenieStateService` (consistent with how other settings persist). Per-project or application-level — match how `EventAutomationService` automations are currently scoped.
+
+### 2. Scheduler service
+
+- New `ScheduledAutomationService` that, on project open, registers each enabled automation with `AppExecutorUtil.getAppScheduledExecutorService()` (compute next-fire from the cron/NL expression). On fire, it interpolates the template and routes into the **shared** automation submit path extracted from `EventAutomationService`.
+- Parse cron via a small dependency-free parser or a vetted cron library already on the classpath; support a minimal natural-language subset mapped onto cron. Validate expressions at save time with a clear error.
+- Update last-run/next-run on each fire; reschedule the next occurrence. Cleanly dispose all schedules on project close (no leaked timers).
+
+### 3. Optional: agent-callable scheduling tool
+
+- Optionally expose a `schedule_task(name, schedule, prompt)` built-in tool (gated by a flag) so the agent itself can create a scheduled automation — matching Hermes' model where the agent schedules its own follow-ups. Creating a schedule is a side-effecting action → approval-gated via `AgentApprovalProvider`. This can be a follow-up if it widens scope too far.
+
+### 4. Settings / management UI
+
+- Add a "Scheduled Automations" management UI (in `AgentSettingsComponent` or a dedicated panel): list automations with next-run/last-run, and add / edit / pause / resume / delete actions. Editing reuses the prompt-template editor pattern from the event-automation UI.
+
+### 5. Tests
+
+- Unit test schedule-expression parsing and next-fire computation (cron + the NL subset; invalid expressions return a clear validation error).
+- Test that firing routes through the shared automation submit path with correct variable interpolation (submission mocked).
+- Test pause/resume/edit/delete update both persistence and the live scheduler registration.
+- Test that disposing the service cancels all scheduled futures (no leaked timers).
+
+## Out of scope (capture as follow-ups)
+
+- Running schedules while the IDE is closed (true daemon behaviour) — out of scope for an IDE plugin; document the "only while IDE is open" limitation.
+- Delivering results to external platforms (Telegram/Slack/email) as Hermes does — DevoxxGenie surfaces results in the tool window; external delivery is a separate integration.
+- Distributed/remote execution backends.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 A `ScheduledAutomation` model (id, name, schedule expression, prompt template, enabled, last/next run) is defined and persisted via `DevoxxGenieStateService`
+- [ ] #2 Cron expressions and a minimal natural-language subset (e.g. "every day at 09:00", "hourly") are supported and validated at save time with a clear error on invalid input
+- [ ] #3 A `ScheduledAutomationService` schedules enabled automations using IntelliJ's application scheduled executor (not raw threads) and computes/refreshes the next-fire time after each run
+- [ ] #4 On fire, the automation interpolates its template and submits via a submit path shared with `EventAutomationService` (event-based and time-based automations reuse the same execution flow)
+- [ ] #5 Timer callbacks run off the EDT and submission hops to the correct thread via `invokeLater`, consistent with the existing automation flow
+- [ ] #6 A management UI lists scheduled automations with next-run/last-run and supports add / edit / pause / resume / delete
+- [ ] #7 Disposing the service (project close) cancels all scheduled futures with no leaked timers
+- [ ] #8 The "only runs while the IDE is open" limitation is clearly documented in the UI/help text
+- [ ] #9 Unit tests cover expression parsing & next-fire computation, validation of invalid expressions, the shared submit path with interpolation (submission mocked), pause/resume/edit/delete, and disposal cancelling all futures
+- [ ] #10 Plugin builds (`./gradlew buildPlugin`) and all tests pass (`./gradlew test`)
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Originated from research comparing DevoxxGenie's agent mode to Nous Research's Hermes Agent (https://github.com/NousResearch/hermes-agent), which offers scheduled tasks via natural-language or cron expressions with pause/resume/edit. DevoxxGenie's `EventAutomationService` already provides the "template → interpolate → submit/confirm" flow for IDE-event triggers; this task adds the missing time-based scheduler on top of that same flow rather than a parallel system. Key constraint vs Hermes: an IDE plugin is not a daemon, so schedules only fire while the IDE is open — document this rather than trying to emulate always-on behaviour. Use `AppExecutorUtil.getAppScheduledExecutorService()` / `Alarm`, keep timer work off the EDT, and dispose all futures on project close. Per CLAUDE.md: feature branch before code changes; behavioural tests first where practical.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-227 - Remote-chat-control-via-messaging-channels-Telegram-long-polling-MVP-with-adapter-abstraction.md
+++ b/backlog/tasks/task-227 - Remote-chat-control-via-messaging-channels-Telegram-long-polling-MVP-with-adapter-abstraction.md
@@ -1,0 +1,130 @@
+---
+id: TASK-227
+title: Remote chat control via messaging channels — Telegram long-polling MVP with adapter abstraction
+status: To Do
+assignee: []
+created_date: '2026-06-05 10:29'
+updated_date: '2026-06-05 10:29'
+labels:
+  - agent-mode
+  - messaging
+  - channels
+  - feature
+  - hermes
+  - security
+dependencies: []
+references:
+  - src/main/java/com/devoxx/genie/service/ExternalPromptService.java
+  - src/main/java/com/devoxx/genie/ui/topic/AppTopics.java
+  - src/main/java/com/devoxx/genie/ui/listener/ConversationEventListener.java
+  - src/main/java/com/devoxx/genie/service/prompt/response/streaming/StreamingResponseHandler.java
+  - src/main/java/com/devoxx/genie/ui/window/ConversationTabRegistry.java
+  - src/main/java/com/devoxx/genie/service/automation/EventAutomationService.java
+  - src/main/java/com/devoxx/genie/service/agent/AgentApprovalProvider.java
+  - src/main/java/com/devoxx/genie/ui/settings/DevoxxGenieStateService.java
+  - 'https://github.com/NousResearch/hermes-agent'
+  - 'https://hermes-agent.nousresearch.com/docs/user-guide/messaging/'
+  - 'https://core.telegram.org/bots/api#getupdates'
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+## Overview
+
+Let a user **drive the DevoxxGenie chat from another device** (e.g. their phone) over a messaging channel. You send a message from Telegram, it runs as a prompt in the IDE's AI chat, and the response is delivered back to your phone. This mirrors the **Messaging Gateway** box of Nous Research's Hermes Agent ("chat with Hermes from Telegram, Discord, Slack, …"), scoped realistically to an IntelliJ plugin.
+
+This task delivers the **MVP**: a single **Telegram** adapter using **long-polling**, behind a `ChannelAdapter` abstraction so additional platforms can be added later (see follow-up task-228), with the **security model built in from day one** (this is non-negotiable — see below).
+
+### Why this is feasible (from codebase exploration)
+
+DevoxxGenie already exposes clean in/out seams (an external plugin, SonarLint, already injects prompts via reflection):
+
+- **Inbound (drive the chat):** `ExternalPromptService.setPromptText(String)` injects a prompt into the active tab and routes it to execution; alternatively publish `AppTopics.PROMPT_SUBMISSION_TOPIC` → `onPromptSubmitted(project, prompt, tabId)` on the IntelliJ MessageBus.
+- **Outbound (capture the reply):** subscribe to `AppTopics.CONVERSATION_TOPIC` → `onNewConversation(ChatMessageContext)`; the final reply is `ChatMessageContext.getAiMessage().text()`. Streaming tokens are available via `StreamingResponseHandler` if live updates are wanted.
+- **Routing:** `ConversationTabRegistry` + the optional `tabId` parameter already support targeting a specific conversation tab; chat memory is keyed by `projectHash-tabId`.
+
+The bridge is essentially: *inbound message → `invokeLater` → publish to `PROMPT_SUBMISSION_TOPIC` → await `CONVERSATION_TOPIC` → send the text back out.*
+
+### The central architectural constraint
+
+DevoxxGenie is a **plugin, not a daemon**: it only runs while the IDE is open, on a dev machine that is behind NAT/firewall with no public IP. This dictates the connection style — the plugin must make **outbound** connections only:
+
+- **Telegram Bot API long-polling (`getUpdates`)** needs only a bot token, makes outbound calls only, and works behind any firewall → **chosen for the MVP**.
+- Webhook-based channels (e.g. WhatsApp Cloud API, Slack Events API) require a public endpoint and are explicitly **out of scope** here.
+
+Headline use case this enables: *kick off a long agent task at your desk, walk away, and receive the result + send follow-ups from your phone.*
+
+## Security model (REQUIRED in this task — not a follow-up)
+
+A messaging bridge turns a chat app into **remote control of an agent that can run shell commands and edit files** on the developer's machine (agent mode has `run_command` / `write_file` / `edit_file`). The following are mandatory and must ship with the MVP:
+
+1. **Deny-by-default allowlist** of Telegram user IDs (mirrors Hermes' default: deny anyone not allowlisted). Empty allowlist ⇒ the bot replies to no one. Messages from non-allowlisted IDs are ignored/refused and logged.
+2. **Bot token stored in IntelliJ `PasswordSafe`** (CredentialAttributes), NOT in the plaintext `DevoxxGenieSettingsPlugin.xml` state. (Codebase currently serializes secrets as plaintext XML — acceptable for a local API key, NOT for a remote-access credential.)
+3. **Remote capability gating.** Remotely-submitted prompts default to a restricted mode (no agent writes / no shell). An explicit, separate opt-in is required to allow remote-triggered writes; when enabled, remote-triggered write/run tools must still pass through `AgentApprovalProvider` so the developer approves at the IDE. The default must be safe.
+4. **Off by default**, clearly labelled, with a visible "remote control active" indicator in the IDE.
+5. **Project disambiguation.** When multiple IDE windows/projects are open, the adapter must target a single explicitly-bound project (a `/project` selector command + a stored binding); never broadcast a remote prompt to all projects.
+
+## Implementation Plan
+
+### 1. ChannelAdapter abstraction
+
+- `ChannelAdapter` interface: lifecycle (`start`/`stop`/`pause`/`resume`), inbound callback (delivers `(senderId, text)`), and `sendReply(chatId, text)`. Keep it platform-agnostic so task-228 can add Slack/Discord without touching the core.
+- `ChannelGatewayService` (application- or project-level service) that owns the active adapters, the allowlist, the project binding, and the inbound→submit / response→outbound wiring. Reuse the EDT-marshalling + submit path already used by `ExternalPromptService` / `EventAutomationService`.
+
+### 2. Telegram adapter (long-polling)
+
+- `TelegramChannelAdapter` runs a background long-poll loop calling Telegram `getUpdates` (outbound HTTPS; reuse the project's existing HTTP client stack). No inbound server, no public endpoint.
+- On an allowlisted message: marshal to EDT via `ApplicationManager.getApplication().invokeLater(...)`, publish to `PROMPT_SUBMISSION_TOPIC` for the bound project/tab.
+- Subscribe to `CONVERSATION_TOPIC`; on completion, format `getAiMessage().text()` (handle Telegram's 4096-char limit by chunking; render code blocks reasonably) and `sendMessage` back to the originating chat.
+- A circuit breaker (à la Hermes) auto-pauses the adapter after repeated upstream failures and surfaces an IDE notification; resumable from settings or a command.
+
+### 3. Slash-style control commands (in-channel)
+
+- Minimal admin commands over the channel: `/project list|use <name>` (bind target project), `/status`, `/pause`, `/resume`, `/stop`. Only allowlisted admins may use them.
+
+### 4. Settings UI
+
+- New "Messaging Channels" settings section: enable toggle (default off), Telegram bot token field (persisted via PasswordSafe), allowlist editor (user IDs), the "allow remote writes/shell" opt-in (default off, with a clear warning), and the bound-project selector. Live status (running/paused/circuit-broken) + last-error display.
+
+### 5. Tests
+
+- Unit test the inbound path: an allowlisted message results in a `PROMPT_SUBMISSION_TOPIC` publish on the EDT for the bound project; a non-allowlisted message does NOT (and is logged/refused).
+- Test the outbound path: a `CONVERSATION_TOPIC` completion produces a correctly chunked reply sent via a mocked Telegram client.
+- Test capability gating: with remote-writes off, remote prompts cannot trigger write/shell tools; with it on, such tools still route through `AgentApprovalProvider`.
+- Test PasswordSafe round-trip for the token (token never written to the XML state).
+- Test the long-poll loop offset handling and circuit-breaker pause/resume (Telegram client mocked); graceful disposal cancels the loop with no leaked threads.
+- Verify feature-off default: no network activity, no adapter started.
+
+## Out of scope (covered elsewhere / future)
+
+- Additional channel adapters (Slack Socket Mode, Discord gateway) → **task-228** (depends on this task's `ChannelAdapter` abstraction).
+- Webhook-based channels (WhatsApp Cloud API, Slack Events API) and any companion relay server for always-on / public-endpoint delivery → future task; explicitly not in the MVP.
+- True always-on operation while the IDE is closed (daemon behaviour) — document the "only runs while the IDE is open" limitation, same constraint as task-226.
+- Voice transcription / media attachments / cron delivery (Hermes extras).
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 A `ChannelAdapter` abstraction and a `ChannelGatewayService` exist; the gateway wires inbound messages to `PROMPT_SUBMISSION_TOPIC` and outbound replies from `CONVERSATION_TOPIC`, reusing the existing EDT-marshalling submit path
+- [ ] #2 A `TelegramChannelAdapter` connects via Bot API long-polling (`getUpdates`, outbound only — no inbound server / public endpoint) and works behind a NAT/firewall
+- [ ] #3 An allowlisted Telegram message runs as a prompt in the bound project's chat and the response is delivered back to the originating Telegram chat (chunked to respect the 4096-char limit)
+- [ ] #4 Authorization is deny-by-default: messages from user IDs not in the configured allowlist are refused and logged; an empty allowlist replies to no one
+- [ ] #5 The Telegram bot token is stored via IntelliJ `PasswordSafe` and never written to `DevoxxGenieSettingsPlugin.xml`
+- [ ] #6 Remote-submitted prompts default to a restricted mode (no agent writes/shell); enabling remote writes is a separate explicit opt-in, and remote-triggered write/run tools still pass through `AgentApprovalProvider`
+- [ ] #7 When multiple projects are open, a remote message targets a single explicitly-bound project (via a `/project` selector + stored binding), never all projects
+- [ ] #8 In-channel admin commands (`/project`, `/status`, `/pause`, `/resume`, `/stop`) work and are restricted to allowlisted admins; a circuit breaker auto-pauses the adapter on repeated upstream failures with an IDE notification
+- [ ] #9 A "Messaging Channels" settings section provides enable toggle (default off), token (PasswordSafe), allowlist editor, the remote-writes opt-in with a warning, the bound-project selector, and live status
+- [ ] #10 Unit tests cover allowlist enforcement, inbound→submit and response→outbound paths, capability gating, PasswordSafe token round-trip, and circuit-breaker/disposal (no leaked threads); with the feature off there is no network activity. Plugin builds (`./gradlew buildPlugin`) and all tests pass (`./gradlew test`)
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Originated from research comparing DevoxxGenie's agent mode to Nous Research's Hermes Agent (https://github.com/NousResearch/hermes-agent), whose Messaging Gateway is a single background process hosting many platform adapters with deny-by-default allowlist auth, per-chat sessions, a `/platform` control command, and per-platform circuit breakers (https://hermes-agent.nousresearch.com/docs/user-guide/messaging/).
+
+Key architectural finding: DevoxxGenie is a plugin, not a daemon, behind NAT — so adapters must be outbound-only. Telegram long-polling (`getUpdates`) is the only widely-used channel that is both firewall-friendly and trivial to set up, hence the MVP. The in/out seams already exist and are already used by a third party (SonarLint injects prompts via `ExternalPromptService`): inbound `ExternalPromptService.setPromptText` / `AppTopics.PROMPT_SUBMISSION_TOPIC`, outbound `AppTopics.CONVERSATION_TOPIC` (`ChatMessageContext.getAiMessage().text()`), tab routing via `ConversationTabRegistry` + `tabId`. Reuse the `EventAutomationService` submit/EDT pattern.
+
+Security is the hard part, not the bridge: remote control of an agent with `run_command`/`write_file` is a real RCE surface, so allowlist + PasswordSafe token + remote-capability gating + safe defaults are mandatory in the MVP (not deferred). Per CLAUDE.md: feature branch before code changes; keep the poll loop off the EDT and submission marshalled onto it; behavioural tests first where practical. Document the "only runs while the IDE is open" limitation (shared with task-226).
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-228 - Additional-messaging-channel-adapters-Slack-Socket-Mode-and-Discord-gateway.md
+++ b/backlog/tasks/task-228 - Additional-messaging-channel-adapters-Slack-Socket-Mode-and-Discord-gateway.md
@@ -1,0 +1,97 @@
+---
+id: TASK-228
+title: Additional messaging channel adapters — Slack (Socket Mode) and Discord (gateway)
+status: To Do
+assignee: []
+created_date: '2026-06-05 10:29'
+updated_date: '2026-06-05 10:29'
+labels:
+  - agent-mode
+  - messaging
+  - channels
+  - feature
+  - hermes
+dependencies:
+  - task-227
+references:
+  - src/main/java/com/devoxx/genie/service/automation/EventAutomationService.java
+  - src/main/java/com/devoxx/genie/ui/topic/AppTopics.java
+  - src/main/java/com/devoxx/genie/ui/settings/DevoxxGenieStateService.java
+  - 'https://github.com/NousResearch/hermes-agent'
+  - 'https://hermes-agent.nousresearch.com/docs/user-guide/messaging/'
+  - 'https://api.slack.com/apis/socket-mode'
+  - 'https://discord.com/developers/docs/topics/gateway'
+priority: low
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+## Overview
+
+Add **Slack** and **Discord** channel adapters on top of the `ChannelAdapter` abstraction delivered in **task-227** (Telegram MVP). This extends remote chat control to two more popular team platforms while reusing all of the MVP's core wiring (inbound → `PROMPT_SUBMISSION_TOPIC`, outbound ← `CONVERSATION_TOPIC`, allowlist, PasswordSafe credentials, remote-capability gating, project binding, circuit breaker).
+
+**This task depends on task-227** and must not start until the `ChannelAdapter` abstraction and `ChannelGatewayService` exist. If implementing this reveals leaks in that abstraction, fix the abstraction in task-227's code rather than special-casing here.
+
+### Why Slack Socket Mode and Discord gateway (and not webhooks)
+
+Same constraint as the MVP: DevoxxGenie is a plugin behind NAT with no public IP, so adapters must connect **outbound only**.
+
+- **Slack — Socket Mode**: an outbound WebSocket from the app to Slack; no public webhook endpoint required. Firewall-friendly. (Slack's Events API webhook variant requires a public URL and is therefore out of scope.)
+- **Discord — Gateway**: bots maintain an outbound persistent WebSocket to Discord's gateway. Firewall-friendly by design.
+
+Both fit the outbound-only model cleanly, so they are the right second and third channels. WhatsApp (webhook + Meta business verification + ToS issues on unofficial libraries) remains explicitly out of scope.
+
+## Implementation Plan
+
+### 1. SlackChannelAdapter (Socket Mode)
+
+- Implement `ChannelAdapter` using Slack Socket Mode: obtain a WebSocket URL via `apps.connections.open` (app-level token), maintain the outbound socket, ack events, and handle reconnects.
+- Map Slack identities (user IDs) onto the shared allowlist model; threads/channels map onto the gateway's per-conversation routing and the bound project.
+- Send replies via `chat.postMessage`; respect Slack formatting (mrkdwn, code blocks) and message-size limits.
+- Credentials (bot token + app-level token) stored via PasswordSafe, consistent with task-227.
+
+### 2. DiscordChannelAdapter (gateway)
+
+- Implement `ChannelAdapter` against the Discord gateway WebSocket (identify, heartbeat, resume, message-create events). Either a minimal client or a vetted JVM Discord library — evaluate dependency weight before adding one; prefer reusing the existing HTTP/WebSocket stack if practical.
+- Map Discord user IDs onto the allowlist; channels/DMs onto conversation routing and the bound project.
+- Send replies via the channel message endpoint; handle the 2000-char limit by chunking; render code blocks.
+- Token via PasswordSafe.
+
+### 3. Shared concerns (reuse, do not re-implement)
+
+- Allowlist, deny-by-default auth, remote-capability gating (restricted-by-default; remote writes opt-in and still `AgentApprovalProvider`-gated), project binding, circuit breaker, and the inbound/outbound MessageBus wiring all come from task-227's `ChannelGatewayService`. These adapters only translate platform-specific transport/identity/formatting.
+- Extend the "Messaging Channels" settings section with per-platform enable toggles, credential fields (PasswordSafe), and per-platform allowlists. Each platform shows independent live status (running/paused/circuit-broken).
+- Optionally add per-platform tool scoping (Hermes assigns different toolsets per platform) — keep simple: each platform inherits the same remote-capability gating unless explicitly overridden.
+
+### 4. Tests
+
+- For each adapter: allowlist enforcement (allowlisted → submit; others refused/logged), outbound reply formatting + chunking against the platform limit (transport mocked), reconnect/resume handling, and circuit-breaker pause/resume.
+- Confirm both adapters run concurrently with the Telegram adapter through a single `ChannelGatewayService` without cross-talk (a message on one platform replies only on that platform/conversation).
+- Disposal cancels all sockets/loops with no leaked threads.
+
+## Out of scope
+
+- Webhook-only channels (WhatsApp Cloud API, Slack Events API), any companion relay server, and always-on/daemon operation — future tasks.
+- Voice/media/transcription and cron delivery.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 A `SlackChannelAdapter` implements the task-227 `ChannelAdapter` using Slack Socket Mode (outbound WebSocket, no public endpoint) and works behind a NAT/firewall
+- [ ] #2 A `DiscordChannelAdapter` implements `ChannelAdapter` using the Discord gateway WebSocket (outbound, no public endpoint) and works behind a NAT/firewall
+- [ ] #3 Both adapters reuse the shared allowlist (deny-by-default), remote-capability gating, project binding, and circuit-breaker from `ChannelGatewayService` — these are not re-implemented per adapter
+- [ ] #4 Inbound messages route to `PROMPT_SUBMISSION_TOPIC` for the bound project and responses from `CONVERSATION_TOPIC` are sent back to the originating Slack/Discord conversation, chunked to each platform's message-size limit with reasonable code-block rendering
+- [ ] #5 All platform credentials (Slack bot + app-level tokens, Discord bot token) are stored via IntelliJ `PasswordSafe`, never in the XML state
+- [ ] #6 The "Messaging Channels" settings section gains per-platform enable toggles, credential fields, per-platform allowlists, and independent live status; all default off
+- [ ] #7 Telegram, Slack, and Discord adapters can run concurrently through one `ChannelGatewayService` with no cross-talk (a message replies only on its own platform/conversation)
+- [ ] #8 Reconnect/resume is handled for both WebSocket adapters, and disposal cancels all sockets/loops with no leaked threads
+- [ ] #9 Any new third-party dependency (e.g. a Discord JVM library) is justified vs reusing the existing HTTP/WebSocket stack and documented
+- [ ] #10 Unit tests cover allowlist enforcement, outbound formatting/chunking, reconnect handling, and concurrent multi-platform operation; plugin builds (`./gradlew buildPlugin`) and all tests pass (`./gradlew test`)
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Follow-up to task-227 (Telegram long-polling MVP + `ChannelAdapter` abstraction), itself from research comparing DevoxxGenie to Nous Research's Hermes Agent messaging gateway (https://hermes-agent.nousresearch.com/docs/user-guide/messaging/), which hosts many platform adapters in one process. Same outbound-only constraint (plugin behind NAT) drives the choice of Slack Socket Mode and the Discord gateway — both are outbound WebSockets needing no public endpoint, unlike webhook variants. All security/routing/gating logic is inherited from task-227's `ChannelGatewayService`; these adapters only handle platform-specific transport, identity mapping, and message formatting/chunking (Slack mrkdwn; Discord 2000-char limit). Evaluate dependency weight before pulling in a Discord library. Per CLAUDE.md: feature branch before code changes; sockets off the EDT, submission marshalled onto it; behavioural tests first where practical.
+<!-- SECTION:NOTES:END -->


### PR DESCRIPTION
Adds three backlog tasks capturing the top missing Hermes-style agent
capabilities identified during research vs NousResearch/hermes-agent:

- task-224: Self-improving Skill Writer (capture + refine skills from
  successful agent runs) — the defining Hermes learning loop; builds on
  the existing read-only SkillRegistry/activate_skill plumbing.
- task-225: Explicit task planner + writable, approval-gated sub-agent
  delegation — extends ParallelExploreToolExecutor/SubAgentRunner beyond
  read-only fan-out and adds a visible plan checklist.
- task-226: Scheduled/cron agent automations — adds a time-based trigger
  layer on top of the existing EventAutomationService submit path.

Note: persistent semantic conversation memory (the 4th Hermes pillar) is
already tracked by task-211, so it was intentionally not duplicated.