### PR TITLE
fix: migrate API keys from plaintext XML to IntelliJ PasswordSafe (review fixes)

### DIFF
--- a/src/main/java/com/devoxx/genie/service/DevoxxGenieSettingsService.java
+++ b/src/main/java/com/devoxx/genie/service/DevoxxGenieSettingsService.java
@@ -57,6 +57,14 @@ public interface DevoxxGenieSettingsService {
 
     String getOpenRouterKey();
 
+    String getGrokKey();
+
+    String getKimiKey();
+
+    String getGlmKey();
+
+    String getCustomOpenAIApiKey();
+
     Boolean getIsWebSearchEnabled();
 
     String getGoogleSearchKey();
@@ -152,6 +160,14 @@ public interface DevoxxGenieSettingsService {
     void setDeepSeekKey(String key);
 
     void setOpenRouterKey(String key);
+
+    void setGrokKey(String key);
+
+    void setKimiKey(String key);
+
+    void setGlmKey(String key);
+
+    void setCustomOpenAIApiKey(String key);
 
     void setIsWebSearchEnabled(Boolean flag);
 

--- a/src/main/java/com/devoxx/genie/service/credentials/CredentialKey.java
+++ b/src/main/java/com/devoxx/genie/service/credentials/CredentialKey.java
@@ -7,7 +7,7 @@ import org.jetbrains.annotations.NotNull;
 /**
  * Enumeration of every secret credential stored by DevoxxGenie.
  * <p>
- * The {@link #subKey()} value is, by design, equal to the exact Java field name
+ * The {@link #getSubKey()} value is, by design, equal to the exact Java field name
  * on {@link com.devoxx.genie.ui.settings.DevoxxGenieStateService} that used to
  * hold the plaintext value. This 1:1 mapping is used by the credential
  * migration routine to locate the legacy field via reflection.
@@ -57,9 +57,6 @@ public enum CredentialKey {
      */
     public @NotNull CredentialAttributes attributes() {
         return new CredentialAttributes(
-                CredentialAttributesKt.generateServiceName(SERVICE_NAME, subKey),
-                null,
-                null,
-                false);
+                CredentialAttributesKt.generateServiceName(SERVICE_NAME, subKey));
     }
 }

--- a/src/main/java/com/devoxx/genie/service/credentials/CredentialKey.java
+++ b/src/main/java/com/devoxx/genie/service/credentials/CredentialKey.java
@@ -1,0 +1,65 @@
+package com.devoxx.genie.service.credentials;
+
+import com.intellij.credentialStore.CredentialAttributes;
+import com.intellij.credentialStore.CredentialAttributesKt;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Enumeration of every secret credential stored by DevoxxGenie.
+ * <p>
+ * The {@link #subKey()} value is, by design, equal to the exact Java field name
+ * on {@link com.devoxx.genie.ui.settings.DevoxxGenieStateService} that used to
+ * hold the plaintext value. This 1:1 mapping is used by the credential
+ * migration routine to locate the legacy field via reflection.
+ */
+public enum CredentialKey {
+    OPEN_AI_KEY          ("openAIKey"),
+    MISTRAL_KEY          ("mistralKey"),
+    ANTHROPIC_KEY        ("anthropicKey"),
+    GROQ_KEY             ("groqKey"),
+    DEEP_INFRA_KEY       ("deepInfraKey"),
+    GEMINI_KEY           ("geminiKey"),
+    DEEP_SEEK_KEY        ("deepSeekKey"),
+    OPEN_ROUTER_KEY      ("openRouterKey"),
+    GROK_KEY             ("grokKey"),
+    KIMI_KEY             ("kimiKey"),
+    GLM_KEY              ("glmKey"),
+    AZURE_OPEN_AI_KEY    ("azureOpenAIKey"),
+    AWS_ACCESS_KEY_ID    ("awsAccessKeyId"),
+    AWS_SECRET_KEY       ("awsSecretKey"),
+    AWS_BEARER_TOKEN     ("awsBearerToken"),
+    CUSTOM_OPEN_AI_KEY   ("customOpenAIApiKey"),
+    GOOGLE_SEARCH_KEY    ("googleSearchKey"),
+    GOOGLE_CSI_KEY       ("googleCSIKey"),
+    TAVILY_SEARCH_KEY    ("tavilySearchKey");
+
+    /** PasswordSafe service-name prefix. Entries appear as "DevoxxGenie — &lt;subKey&gt;". */
+    public static final String SERVICE_NAME = "DevoxxGenie";
+
+    private final String subKey;
+
+    CredentialKey(@NotNull String subKey) {
+        this.subKey = subKey;
+    }
+
+    /**
+     * The PasswordSafe entry sub-key. Equal to the legacy Java field name
+     * on {@code DevoxxGenieStateService} so that reflection-based migration
+     * can locate the source value.
+     */
+    public @NotNull String getSubKey() {
+        return subKey;
+    }
+
+    /**
+     * Build the {@link CredentialAttributes} used by IntelliJ's
+     * {@code PasswordSafe} for this key.
+     */
+    public @NotNull CredentialAttributes attributes() {
+        return new CredentialAttributes(
+                CredentialAttributesKt.generateServiceName(SERVICE_NAME, subKey),
+                null,
+                null,
+                false);
+    }
+}

--- a/src/main/java/com/devoxx/genie/service/credentials/CredentialService.java
+++ b/src/main/java/com/devoxx/genie/service/credentials/CredentialService.java
@@ -1,0 +1,43 @@
+package com.devoxx.genie.service.credentials;
+
+import com.intellij.openapi.application.ApplicationManager;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Application-scoped service that stores DevoxxGenie API keys and tokens in
+ * IntelliJ's {@code PasswordSafe} (OS keychain / KeePass / KWallet, depending
+ * on the platform).
+ * <p>
+ * Implementations must degrade gracefully — see {@link #isAvailable()} —
+ * because PasswordSafe can be missing or broken in headless test runs and
+ * some container/cloud IDE environments.
+ */
+public interface CredentialService {
+
+    static @NotNull CredentialService getInstance() {
+        return ApplicationManager.getApplication().getService(CredentialService.class);
+    }
+
+    /**
+     * Returns the credential value for {@code key}, or {@code ""} if absent
+     * or if PasswordSafe is unavailable. Never returns {@code null}.
+     */
+    @NotNull String getCredential(@NotNull CredentialKey key);
+
+    /**
+     * Stores {@code value} under {@code key}. A {@code null} or empty value
+     * removes the entry, equivalent to {@link #removeCredential(CredentialKey)}.
+     */
+    void setCredential(@NotNull CredentialKey key, @Nullable String value);
+
+    /** Removes the credential entry for {@code key}. */
+    void removeCredential(@NotNull CredentialKey key);
+
+    /**
+     * {@code true} if IntelliJ's {@code PasswordSafe} is reachable for this
+     * process. When {@code false}, get/set operate on an in-memory fallback
+     * map and values are lost on JVM restart.
+     */
+    boolean isAvailable();
+}

--- a/src/main/java/com/devoxx/genie/service/credentials/PasswordSafeCredentialService.java
+++ b/src/main/java/com/devoxx/genie/service/credentials/PasswordSafeCredentialService.java
@@ -1,0 +1,92 @@
+package com.devoxx.genie.service.credentials;
+
+import com.intellij.credentialStore.Credentials;
+import com.intellij.ide.passwordSafe.PasswordSafe;
+import com.intellij.openapi.diagnostic.Logger;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.EnumMap;
+import java.util.Map;
+
+/**
+ * Default {@link CredentialService} implementation, backed by IntelliJ's
+ * {@code PasswordSafe} with an in-memory fallback for environments where
+ * the OS keychain is unavailable (headless tests, broken backends).
+ */
+public final class PasswordSafeCredentialService implements CredentialService {
+
+    private static final Logger LOG = Logger.getInstance(PasswordSafeCredentialService.class);
+
+    /** Used only when PasswordSafe is unavailable; otherwise serves as a write-through cache. */
+    private final Map<CredentialKey, String> memoryFallback = new EnumMap<>(CredentialKey.class);
+
+    private final boolean passwordSafeAvailable;
+
+    public PasswordSafeCredentialService() {
+        boolean available;
+        try {
+            available = PasswordSafe.getInstance() != null;
+        } catch (Throwable t) {
+            LOG.warn("PasswordSafe is not available; falling back to in-memory credential storage", t);
+            available = false;
+        }
+        this.passwordSafeAvailable = available;
+    }
+
+    @Override
+    public @NotNull String getCredential(@NotNull CredentialKey key) {
+        if (!passwordSafeAvailable) {
+            return memoryFallback.getOrDefault(key, "");
+        }
+        try {
+            Credentials creds = PasswordSafe.getInstance().get(key.attributes());
+            String password = (creds == null) ? null : creds.getPasswordAsString();
+            if (password != null) {
+                return password;
+            }
+        } catch (Throwable t) {
+            LOG.warn("PasswordSafe.get(" + key + ") failed; using in-memory fallback", t);
+        }
+        return memoryFallback.getOrDefault(key, "");
+    }
+
+    @Override
+    public synchronized void setCredential(@NotNull CredentialKey key, @Nullable String value) {
+        if (value == null || value.isEmpty()) {
+            removeCredential(key);
+            return;
+        }
+        if (!passwordSafeAvailable) {
+            memoryFallback.put(key, value);
+            return;
+        }
+        try {
+            PasswordSafe.getInstance().set(key.attributes(), new Credentials(CredentialKey.SERVICE_NAME, value));
+            // Write-through cache so reads after a failed PasswordSafe.get can still return the value
+            // within the same JVM lifetime.
+            memoryFallback.put(key, value);
+        } catch (Throwable t) {
+            LOG.warn("PasswordSafe.set(" + key + ") failed; using in-memory fallback", t);
+            memoryFallback.put(key, value);
+        }
+    }
+
+    @Override
+    public synchronized void removeCredential(@NotNull CredentialKey key) {
+        memoryFallback.remove(key);
+        if (!passwordSafeAvailable) {
+            return;
+        }
+        try {
+            PasswordSafe.getInstance().set(key.attributes(), null);
+        } catch (Throwable t) {
+            LOG.warn("PasswordSafe.set(" + key + ", null) failed", t);
+        }
+    }
+
+    @Override
+    public boolean isAvailable() {
+        return passwordSafeAvailable;
+    }
+}

--- a/src/main/java/com/devoxx/genie/service/credentials/PasswordSafeCredentialService.java
+++ b/src/main/java/com/devoxx/genie/service/credentials/PasswordSafeCredentialService.java
@@ -18,7 +18,11 @@ public final class PasswordSafeCredentialService implements CredentialService {
 
     private static final Logger LOG = Logger.getInstance(PasswordSafeCredentialService.class);
 
-    /** Used only when PasswordSafe is unavailable; otherwise serves as a write-through cache. */
+    /**
+     * Fallback store used when PasswordSafe is unavailable. It also holds a write-side cache
+     * of credentials set during this JVM lifetime (populated by {@link #setCredential}, not by
+     * reads), so a value remains readable even if a later PasswordSafe {@code get()} fails.
+     */
     private final Map<CredentialKey, String> memoryFallback = new EnumMap<>(CredentialKey.class);
 
     private final boolean passwordSafeAvailable;

--- a/src/main/java/com/devoxx/genie/service/credentials/PasswordSafeCredentialService.java
+++ b/src/main/java/com/devoxx/genie/service/credentials/PasswordSafeCredentialService.java
@@ -35,7 +35,7 @@ public final class PasswordSafeCredentialService implements CredentialService {
     }
 
     @Override
-    public @NotNull String getCredential(@NotNull CredentialKey key) {
+    public synchronized @NotNull String getCredential(@NotNull CredentialKey key) {
         if (!passwordSafeAvailable) {
             return memoryFallback.getOrDefault(key, "");
         }
@@ -62,7 +62,10 @@ public final class PasswordSafeCredentialService implements CredentialService {
             return;
         }
         try {
-            PasswordSafe.getInstance().set(key.attributes(), new Credentials(CredentialKey.SERVICE_NAME, value));
+            // Use null userName so the lookup key matches CredentialKey.attributes() exactly
+            // (which builds CredentialAttributes with userName=null). Mixing a real user-name
+            // here and null on retrieval breaks the round-trip on some keychain backends.
+            PasswordSafe.getInstance().set(key.attributes(), new Credentials(null, value));
             // Write-through cache so reads after a failed PasswordSafe.get can still return the value
             // within the same JVM lifetime.
             memoryFallback.put(key, value);

--- a/src/main/java/com/devoxx/genie/startup/CredentialMigrationStartupActivity.java
+++ b/src/main/java/com/devoxx/genie/startup/CredentialMigrationStartupActivity.java
@@ -1,0 +1,39 @@
+package com.devoxx.genie.startup;
+
+import com.devoxx.genie.ui.settings.DevoxxGenieStateService;
+import com.intellij.openapi.diagnostic.Logger;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.startup.ProjectActivity;
+import kotlin.Unit;
+import kotlin.coroutines.Continuation;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Belt-and-braces fallback for the plaintext-credential migration. The primary
+ * migration runs synchronously inside {@link DevoxxGenieStateService#loadState}
+ * the first time settings are deserialised after the upgrade. This activity
+ * re-runs the migration on each project open in case the previous attempt was
+ * deferred (e.g. PasswordSafe was unavailable or threw at that moment). The
+ * migration is idempotent and a no-op once {@code credentialsMigratedV1} is
+ * set.
+ */
+public class CredentialMigrationStartupActivity implements ProjectActivity {
+
+    private static final Logger LOG = Logger.getInstance(CredentialMigrationStartupActivity.class);
+
+    @Nullable
+    @Override
+    public Object execute(@NotNull Project project, @NotNull Continuation<? super Unit> continuation) {
+        try {
+            DevoxxGenieStateService state = DevoxxGenieStateService.getInstance();
+            if (!state.isCredentialsMigratedV1()) {
+                state.migrateCredentialsToPasswordSafe();
+            }
+        } catch (Throwable t) {
+            // Migration must never break IDE startup.
+            LOG.warn("Credential migration retry failed during project startup", t);
+        }
+        return Unit.INSTANCE;
+    }
+}

--- a/src/main/java/com/devoxx/genie/ui/settings/DevoxxGenieStateService.java
+++ b/src/main/java/com/devoxx/genie/ui/settings/DevoxxGenieStateService.java
@@ -9,15 +9,22 @@ import com.devoxx.genie.model.automation.EventAutomationSettings;
 import com.devoxx.genie.model.mcp.MCPSettings;
 import com.devoxx.genie.model.spec.CliToolConfig;
 import com.devoxx.genie.service.DevoxxGenieSettingsService;
+import com.devoxx.genie.service.credentials.CredentialKey;
+import com.devoxx.genie.service.credentials.CredentialService;
 import com.devoxx.genie.util.DefaultLLMSettingsUtil;
+import com.intellij.openapi.application.Application;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.components.PersistentStateComponent;
 import com.intellij.openapi.components.State;
 import com.intellij.openapi.components.Storage;
+import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.util.xmlb.XmlSerializerUtil;
+import com.intellij.util.xmlb.annotations.Transient;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.Setter;
+
+import java.lang.reflect.Field;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -118,6 +125,7 @@ public final class DevoxxGenieStateService implements PersistentStateComponent<D
     // Local custom OpenAI-compliant LLM fields
     private String customOpenAIUrl = "";
     private String customOpenAIModelName = "";
+    @Getter(AccessLevel.NONE) @Setter(AccessLevel.NONE)
     private String customOpenAIApiKey = "";
 
     // Local LLM Providers
@@ -147,23 +155,46 @@ public final class DevoxxGenieStateService implements PersistentStateComponent<D
     private boolean isKimiEnabled = false;
     private boolean isGlmEnabled = false;
 
-    // LLM API Keys
+    // LLM API Keys — stored in IntelliJ PasswordSafe via {@link CredentialService}.
+    // The fields below remain only as one-shot landing pads for legacy plaintext XML so
+    // that the credential-migration routine in {@link #loadState} can read the value and
+    // move it to PasswordSafe. After migration each field is wiped and stays empty.
+    // Lombok's generated accessors are disabled; the hand-written ones below delegate to
+    // {@link CredentialService}. Field-level @Transient is intentionally NOT used so that
+    // XmlSerializer still populates the field on first deserialization of legacy XML;
+    // the @Transient annotations are placed on the accessor methods so that subsequent
+    // saves never re-emit the secret.
+    @Getter(AccessLevel.NONE) @Setter(AccessLevel.NONE)
     private String openAIKey = "";
+    @Getter(AccessLevel.NONE) @Setter(AccessLevel.NONE)
     private String mistralKey = "";
+    @Getter(AccessLevel.NONE) @Setter(AccessLevel.NONE)
     private String anthropicKey = "";
+    @Getter(AccessLevel.NONE) @Setter(AccessLevel.NONE)
     private String groqKey = "";
+    @Getter(AccessLevel.NONE) @Setter(AccessLevel.NONE)
     private String deepInfraKey = "";
+    @Getter(AccessLevel.NONE) @Setter(AccessLevel.NONE)
     private String geminiKey = "";
+    @Getter(AccessLevel.NONE) @Setter(AccessLevel.NONE)
     private String deepSeekKey = "";
+    @Getter(AccessLevel.NONE) @Setter(AccessLevel.NONE)
     private String openRouterKey = "";
+    @Getter(AccessLevel.NONE) @Setter(AccessLevel.NONE)
     private String grokKey = "";
+    @Getter(AccessLevel.NONE) @Setter(AccessLevel.NONE)
     private String kimiKey = "";
+    @Getter(AccessLevel.NONE) @Setter(AccessLevel.NONE)
     private String glmKey = "";
     private String azureOpenAIEndpoint = "";
     private String azureOpenAIDeployment = "";
+    @Getter(AccessLevel.NONE) @Setter(AccessLevel.NONE)
     private String azureOpenAIKey = "";
+    @Getter(AccessLevel.NONE) @Setter(AccessLevel.NONE)
     private String awsAccessKeyId = "";
+    @Getter(AccessLevel.NONE) @Setter(AccessLevel.NONE)
     private String awsSecretKey = "";
+    @Getter(AccessLevel.NONE) @Setter(AccessLevel.NONE)
     private String awsBearerToken = "";
     private String awsProfileName = "";
     private String awsRegion = "";
@@ -175,10 +206,21 @@ public final class DevoxxGenieStateService implements PersistentStateComponent<D
     private boolean tavilySearchEnabled = false;
     private boolean googleSearchEnabled = false;
 
+    @Getter(AccessLevel.NONE) @Setter(AccessLevel.NONE)
     private String googleSearchKey = "";
+    @Getter(AccessLevel.NONE) @Setter(AccessLevel.NONE)
     private String googleCSIKey = "";
+    @Getter(AccessLevel.NONE) @Setter(AccessLevel.NONE)
     private String tavilySearchKey = "";
     private Integer maxSearchResults = MAX_SEARCH_RESULTS;
+
+    /**
+     * Set to {@code true} after the one-shot credential migration has moved every plaintext
+     * key out of XML and into PasswordSafe. Persisted so the migration only ever runs once
+     * per install. Public read access is via {@link #isCredentialsMigratedV1()}; we keep
+     * Lombok's accessor for serialization purposes.
+     */
+    private boolean credentialsMigratedV1 = false;
 
     // Global fallback fields
     private static final String DEFAULT_PROVIDER = ModelProvider.Ollama.getName();
@@ -493,6 +535,13 @@ public final class DevoxxGenieStateService implements PersistentStateComponent<D
         migrateLegacyCustomPrompts(state);
         initializeUserPrompt();
 
+        // Migrate plaintext credentials from XML into PasswordSafe (idempotent).
+        // Runs synchronously so callers never observe a window where the State has
+        // plaintext but PasswordSafe does not yet.
+        if (!credentialsMigratedV1) {
+            migrateCredentialsToPasswordSafe();
+        }
+
         // Notify all listeners that the state has been loaded
         for (Runnable listener : loadListeners) {
             listener.run();
@@ -592,7 +641,7 @@ public final class DevoxxGenieStateService implements PersistentStateComponent<D
 
     public boolean isAzureOpenAIEnabled() {
         return showAzureOpenAIFields &&
-                !azureOpenAIKey.isEmpty() &&
+                !getAzureOpenAIKey().isEmpty() &&
                 !azureOpenAIEndpoint.isEmpty() &&
                 !azureOpenAIDeployment.isEmpty();
     }
@@ -603,9 +652,9 @@ public final class DevoxxGenieStateService implements PersistentStateComponent<D
         }
 
         return switch (getAwsBedrockAuthMode()) {
-            case ACCESS_KEY -> !awsAccessKeyId.isEmpty() && !awsSecretKey.isEmpty();
+            case ACCESS_KEY -> !getAwsAccessKeyId().isEmpty() && !getAwsSecretKey().isEmpty();
             case PROFILE -> !awsProfileName.isEmpty();
-            case BEARER_TOKEN -> !awsBearerToken.isEmpty();
+            case BEARER_TOKEN -> !getAwsBearerToken().isEmpty();
         };
     }
 
@@ -685,4 +734,183 @@ public final class DevoxxGenieStateService implements PersistentStateComponent<D
             default -> null;
         };
     }
+
+    // ------------------------------------------------------------------
+    // Credential accessors — delegate to PasswordSafe via CredentialService.
+    // All 19 accessors below replace the Lombok-generated ones that have been
+    // disabled on the corresponding fields. They are marked @Transient so that
+    // XmlSerializer skips them on save (so the secret never ends up in
+    // DevoxxGenieSettingsPlugin.xml again).
+    // ------------------------------------------------------------------
+
+    /**
+     * Lookup helper for the {@link CredentialService}. Returns a per-instance no-op
+     * fallback when either the IntelliJ {@code Application} container is not yet
+     * initialised or the {@code CredentialService} is not registered (unit tests that
+     * instantiate {@code DevoxxGenieStateService} directly or via the platform test
+     * framework without registering the service). The fallback is instance-scoped so
+     * that test cases do not bleed credential state into one another.
+     */
+    private @NotNull CredentialService creds() {
+        Application app = ApplicationManager.getApplication();
+        if (app != null) {
+            try {
+                CredentialService service = app.getService(CredentialService.class);
+                if (service != null) {
+                    return service;
+                }
+            } catch (Throwable ignored) {
+                // fall through to in-memory fallback
+            }
+        }
+        return testFallbackCredentialService;
+    }
+
+    /**
+     * In-memory {@link CredentialService} used only when the IntelliJ application
+     * container is unavailable (unit tests). Per-instance so that a fresh
+     * {@code new DevoxxGenieStateService()} in a test {@code @BeforeEach} starts
+     * with a clean credential slate.
+     */
+    @Transient
+    @Getter(AccessLevel.NONE) @Setter(AccessLevel.NONE)
+    private final CredentialService testFallbackCredentialService = new CredentialService() {
+        private final Map<CredentialKey, String> store = new java.util.concurrent.ConcurrentHashMap<>();
+
+        @Override public @NotNull String getCredential(@NotNull CredentialKey key) {
+            return store.getOrDefault(key, "");
+        }
+        @Override public void setCredential(@NotNull CredentialKey key, @Nullable String value) {
+            if (value == null || value.isEmpty()) store.remove(key);
+            else store.put(key, value);
+        }
+        @Override public void removeCredential(@NotNull CredentialKey key) {
+            store.remove(key);
+        }
+        @Override public boolean isAvailable() {
+            return false;
+        }
+    };
+
+    @Transient @Override public @NotNull String getOpenAIKey()        { return creds().getCredential(CredentialKey.OPEN_AI_KEY); }
+    @Transient @Override public void          setOpenAIKey(String v)  { creds().setCredential(CredentialKey.OPEN_AI_KEY, v); }
+
+    @Transient @Override public @NotNull String getMistralKey()       { return creds().getCredential(CredentialKey.MISTRAL_KEY); }
+    @Transient @Override public void          setMistralKey(String v) { creds().setCredential(CredentialKey.MISTRAL_KEY, v); }
+
+    @Transient @Override public @NotNull String getAnthropicKey()       { return creds().getCredential(CredentialKey.ANTHROPIC_KEY); }
+    @Transient @Override public void          setAnthropicKey(String v) { creds().setCredential(CredentialKey.ANTHROPIC_KEY, v); }
+
+    @Transient @Override public @NotNull String getGroqKey()       { return creds().getCredential(CredentialKey.GROQ_KEY); }
+    @Transient @Override public void          setGroqKey(String v) { creds().setCredential(CredentialKey.GROQ_KEY, v); }
+
+    @Transient @Override public @NotNull String getDeepInfraKey()       { return creds().getCredential(CredentialKey.DEEP_INFRA_KEY); }
+    @Transient @Override public void          setDeepInfraKey(String v) { creds().setCredential(CredentialKey.DEEP_INFRA_KEY, v); }
+
+    @Transient @Override public @NotNull String getGeminiKey()       { return creds().getCredential(CredentialKey.GEMINI_KEY); }
+    @Transient @Override public void          setGeminiKey(String v) { creds().setCredential(CredentialKey.GEMINI_KEY, v); }
+
+    @Transient @Override public @NotNull String getDeepSeekKey()       { return creds().getCredential(CredentialKey.DEEP_SEEK_KEY); }
+    @Transient @Override public void          setDeepSeekKey(String v) { creds().setCredential(CredentialKey.DEEP_SEEK_KEY, v); }
+
+    @Transient @Override public @NotNull String getOpenRouterKey()       { return creds().getCredential(CredentialKey.OPEN_ROUTER_KEY); }
+    @Transient @Override public void          setOpenRouterKey(String v) { creds().setCredential(CredentialKey.OPEN_ROUTER_KEY, v); }
+
+    @Transient @Override public @NotNull String getGrokKey()       { return creds().getCredential(CredentialKey.GROK_KEY); }
+    @Transient @Override public void          setGrokKey(String v) { creds().setCredential(CredentialKey.GROK_KEY, v); }
+
+    @Transient @Override public @NotNull String getKimiKey()       { return creds().getCredential(CredentialKey.KIMI_KEY); }
+    @Transient @Override public void          setKimiKey(String v) { creds().setCredential(CredentialKey.KIMI_KEY, v); }
+
+    @Transient @Override public @NotNull String getGlmKey()       { return creds().getCredential(CredentialKey.GLM_KEY); }
+    @Transient @Override public void          setGlmKey(String v) { creds().setCredential(CredentialKey.GLM_KEY, v); }
+
+    @Transient @Override public @NotNull String getAzureOpenAIKey()       { return creds().getCredential(CredentialKey.AZURE_OPEN_AI_KEY); }
+    @Transient @Override public void          setAzureOpenAIKey(String v) { creds().setCredential(CredentialKey.AZURE_OPEN_AI_KEY, v); }
+
+    @Transient @Override public @NotNull String getAwsAccessKeyId()       { return creds().getCredential(CredentialKey.AWS_ACCESS_KEY_ID); }
+    @Transient @Override public void          setAwsAccessKeyId(String v) { creds().setCredential(CredentialKey.AWS_ACCESS_KEY_ID, v); }
+
+    @Transient @Override public @NotNull String getAwsSecretKey()       { return creds().getCredential(CredentialKey.AWS_SECRET_KEY); }
+    @Transient @Override public void          setAwsSecretKey(String v) { creds().setCredential(CredentialKey.AWS_SECRET_KEY, v); }
+
+    @Transient @Override public @NotNull String getAwsBearerToken()       { return creds().getCredential(CredentialKey.AWS_BEARER_TOKEN); }
+    @Transient @Override public void          setAwsBearerToken(String v) { creds().setCredential(CredentialKey.AWS_BEARER_TOKEN, v); }
+
+    @Transient @Override public @NotNull String getCustomOpenAIApiKey()       { return creds().getCredential(CredentialKey.CUSTOM_OPEN_AI_KEY); }
+    @Transient @Override public void          setCustomOpenAIApiKey(String v) { creds().setCredential(CredentialKey.CUSTOM_OPEN_AI_KEY, v); }
+
+    @Transient @Override public @NotNull String getGoogleSearchKey()       { return creds().getCredential(CredentialKey.GOOGLE_SEARCH_KEY); }
+    @Transient @Override public void          setGoogleSearchKey(String v) { creds().setCredential(CredentialKey.GOOGLE_SEARCH_KEY, v); }
+
+    @Transient @Override public @NotNull String getGoogleCSIKey()       { return creds().getCredential(CredentialKey.GOOGLE_CSI_KEY); }
+    @Transient @Override public void          setGoogleCSIKey(String v) { creds().setCredential(CredentialKey.GOOGLE_CSI_KEY, v); }
+
+    @Transient @Override public @NotNull String getTavilySearchKey()       { return creds().getCredential(CredentialKey.TAVILY_SEARCH_KEY); }
+    @Transient @Override public void          setTavilySearchKey(String v) { creds().setCredential(CredentialKey.TAVILY_SEARCH_KEY, v); }
+
+    // ------------------------------------------------------------------
+    // One-shot migration from plaintext XML fields into PasswordSafe.
+    // ------------------------------------------------------------------
+
+    /**
+     * Walks every {@link CredentialKey}, reads the matching legacy field via reflection,
+     * and — if non-blank — hands it to {@link CredentialService} (which writes it to
+     * PasswordSafe) before wiping the legacy field. Sets {@link #credentialsMigratedV1}
+     * on success and asks IntelliJ to flush state so the now-blank XML hits disk
+     * immediately.
+     * <p>
+     * Non-fatal: any per-field failure is logged and skipped; the migration flag is only
+     * raised when the entire pass completes. Safe to call multiple times — calls are
+     * no-ops once the flag is set or when PasswordSafe is unavailable.
+     */
+    public void migrateCredentialsToPasswordSafe() {
+        if (credentialsMigratedV1) {
+            return;
+        }
+        CredentialService service;
+        try {
+            service = CredentialService.getInstance();
+        } catch (Throwable t) {
+            LOG.warn("CredentialService unavailable; deferring plaintext-credential migration", t);
+            return;
+        }
+        if (!service.isAvailable()) {
+            // PasswordSafe not reachable in this process — leave plaintext in place so the
+            // next normal IDE startup can complete the migration.
+            return;
+        }
+
+        int migrated = 0;
+        int failed = 0;
+        for (CredentialKey key : CredentialKey.values()) {
+            try {
+                Field field = DevoxxGenieStateService.class.getDeclaredField(key.getSubKey());
+                field.setAccessible(true);
+                Object raw = field.get(this);
+                String legacy = (raw == null) ? "" : raw.toString();
+                if (!legacy.isBlank()) {
+                    String existing = service.getCredential(key);
+                    if (existing == null || existing.isEmpty()) {
+                        service.setCredential(key, legacy);
+                        migrated++;
+                    }
+                    // Wipe plaintext copy whether or not we overwrote PasswordSafe.
+                    field.set(this, "");
+                }
+            } catch (Throwable t) {
+                failed++;
+                LOG.warn("Failed to migrate credential field '" + key.getSubKey() + "' to PasswordSafe", t);
+            }
+        }
+        credentialsMigratedV1 = true;
+        try {
+            ApplicationManager.getApplication().saveSettings();
+        } catch (Throwable t) {
+            LOG.warn("Failed to flush settings after credential migration", t);
+        }
+        LOG.info("Credential migration complete: migrated=" + migrated + " failed=" + failed);
+    }
+
+    private static final Logger LOG = Logger.getInstance(DevoxxGenieStateService.class);
 }

--- a/src/main/java/com/devoxx/genie/ui/settings/DevoxxGenieStateService.java
+++ b/src/main/java/com/devoxx/genie/ui/settings/DevoxxGenieStateService.java
@@ -19,6 +19,7 @@ import com.intellij.openapi.components.State;
 import com.intellij.openapi.components.Storage;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.util.xmlb.XmlSerializerUtil;
+import com.intellij.util.xmlb.annotations.OptionTag;
 import com.intellij.util.xmlb.annotations.Transient;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -125,7 +126,7 @@ public final class DevoxxGenieStateService implements PersistentStateComponent<D
     // Local custom OpenAI-compliant LLM fields
     private String customOpenAIUrl = "";
     private String customOpenAIModelName = "";
-    @Getter(AccessLevel.NONE) @Setter(AccessLevel.NONE)
+    @Getter(AccessLevel.NONE) @Setter(AccessLevel.NONE) @OptionTag("customOpenAIApiKey")
     private String customOpenAIApiKey = "";
 
     // Local LLM Providers
@@ -155,46 +156,76 @@ public final class DevoxxGenieStateService implements PersistentStateComponent<D
     private boolean isKimiEnabled = false;
     private boolean isGlmEnabled = false;
 
-    // LLM API Keys — stored in IntelliJ PasswordSafe via {@link CredentialService}.
-    // The fields below remain only as one-shot landing pads for legacy plaintext XML so
-    // that the credential-migration routine in {@link #loadState} can read the value and
-    // move it to PasswordSafe. After migration each field is wiped and stays empty.
-    // Lombok's generated accessors are disabled; the hand-written ones below delegate to
-    // {@link CredentialService}. Field-level @Transient is intentionally NOT used so that
-    // XmlSerializer still populates the field on first deserialization of legacy XML;
-    // the @Transient annotations are placed on the accessor methods so that subsequent
-    // saves never re-emit the secret.
-    @Getter(AccessLevel.NONE) @Setter(AccessLevel.NONE)
+    // ============================================================================
+    // LEGACY-XML CREDENTIAL LANDING PADS
+    // ----------------------------------------------------------------------------
+    // The 19 fields below remain ONLY to receive plaintext credentials from
+    // pre-PasswordSafe versions of DevoxxGenieSettingsPlugin.xml during the first
+    // {@link #loadState} call after an upgrade. The migration routine in
+    // {@link #migrateCredentialsToPasswordSafe} reads each field via reflection,
+    // hands the value to {@link CredentialService} (which writes it to IntelliJ's
+    // PasswordSafe), and then wipes the field. After migration the fields stay
+    // empty for the lifetime of the install.
+    //
+    // Why @OptionTag + @Transient (on the hand-written accessors) instead of the
+    // "obvious" approach of leaving fields plain or relying on Lombok-generated
+    // accessors:
+    //
+    // IntelliJ's BeanBinding / XmlSerializer always prefers an accessor pair over
+    // a same-named field when both exist (it deduplicates via accessor name). The
+    // hand-written getters/setters intentionally read from / write to
+    // PasswordSafe, so if BeanBinding picked up that pair as the property binding,
+    // {@code getState()} would call {@code getOpenAIKey()} on save, read the live
+    // secret from PasswordSafe, and serialise it right back into the XML — the
+    // very leak the migration is meant to close.
+    //
+    // The fix has two parts, applied to every credential field:
+    //   1. The hand-written accessors carry @com.intellij.util.xmlb.annotations.Transient
+    //      so BeanBinding rejects them in PropertyCollector#isAcceptableProperty
+    //      and removes them from the property map entirely.
+    //   2. The fields carry @OptionTag(...) (a "store annotation") which forces
+    //      PropertyCollector#doCollectOwnFields to register the *field* even though
+    //      it is private. With the accessor pair gone from the map, the field
+    //      escapes the dedup loop and becomes the sole binding for that property
+    //      name. XmlSerializer then reads & writes the field directly — never
+    //      touching PasswordSafe. Once the field has been wiped post-migration its
+    //      empty value matches the default-bean's empty value and the
+    //      SkipDefaultsSerializationFilter omits it from the XML.
+    //
+    // Lombok @Getter(NONE)/@Setter(NONE) keeps Lombok from auto-generating
+    // accessors that would shadow ours.
+    // ============================================================================
+    @Getter(AccessLevel.NONE) @Setter(AccessLevel.NONE) @OptionTag("openAIKey")
     private String openAIKey = "";
-    @Getter(AccessLevel.NONE) @Setter(AccessLevel.NONE)
+    @Getter(AccessLevel.NONE) @Setter(AccessLevel.NONE) @OptionTag("mistralKey")
     private String mistralKey = "";
-    @Getter(AccessLevel.NONE) @Setter(AccessLevel.NONE)
+    @Getter(AccessLevel.NONE) @Setter(AccessLevel.NONE) @OptionTag("anthropicKey")
     private String anthropicKey = "";
-    @Getter(AccessLevel.NONE) @Setter(AccessLevel.NONE)
+    @Getter(AccessLevel.NONE) @Setter(AccessLevel.NONE) @OptionTag("groqKey")
     private String groqKey = "";
-    @Getter(AccessLevel.NONE) @Setter(AccessLevel.NONE)
+    @Getter(AccessLevel.NONE) @Setter(AccessLevel.NONE) @OptionTag("deepInfraKey")
     private String deepInfraKey = "";
-    @Getter(AccessLevel.NONE) @Setter(AccessLevel.NONE)
+    @Getter(AccessLevel.NONE) @Setter(AccessLevel.NONE) @OptionTag("geminiKey")
     private String geminiKey = "";
-    @Getter(AccessLevel.NONE) @Setter(AccessLevel.NONE)
+    @Getter(AccessLevel.NONE) @Setter(AccessLevel.NONE) @OptionTag("deepSeekKey")
     private String deepSeekKey = "";
-    @Getter(AccessLevel.NONE) @Setter(AccessLevel.NONE)
+    @Getter(AccessLevel.NONE) @Setter(AccessLevel.NONE) @OptionTag("openRouterKey")
     private String openRouterKey = "";
-    @Getter(AccessLevel.NONE) @Setter(AccessLevel.NONE)
+    @Getter(AccessLevel.NONE) @Setter(AccessLevel.NONE) @OptionTag("grokKey")
     private String grokKey = "";
-    @Getter(AccessLevel.NONE) @Setter(AccessLevel.NONE)
+    @Getter(AccessLevel.NONE) @Setter(AccessLevel.NONE) @OptionTag("kimiKey")
     private String kimiKey = "";
-    @Getter(AccessLevel.NONE) @Setter(AccessLevel.NONE)
+    @Getter(AccessLevel.NONE) @Setter(AccessLevel.NONE) @OptionTag("glmKey")
     private String glmKey = "";
     private String azureOpenAIEndpoint = "";
     private String azureOpenAIDeployment = "";
-    @Getter(AccessLevel.NONE) @Setter(AccessLevel.NONE)
+    @Getter(AccessLevel.NONE) @Setter(AccessLevel.NONE) @OptionTag("azureOpenAIKey")
     private String azureOpenAIKey = "";
-    @Getter(AccessLevel.NONE) @Setter(AccessLevel.NONE)
+    @Getter(AccessLevel.NONE) @Setter(AccessLevel.NONE) @OptionTag("awsAccessKeyId")
     private String awsAccessKeyId = "";
-    @Getter(AccessLevel.NONE) @Setter(AccessLevel.NONE)
+    @Getter(AccessLevel.NONE) @Setter(AccessLevel.NONE) @OptionTag("awsSecretKey")
     private String awsSecretKey = "";
-    @Getter(AccessLevel.NONE) @Setter(AccessLevel.NONE)
+    @Getter(AccessLevel.NONE) @Setter(AccessLevel.NONE) @OptionTag("awsBearerToken")
     private String awsBearerToken = "";
     private String awsProfileName = "";
     private String awsRegion = "";
@@ -206,11 +237,11 @@ public final class DevoxxGenieStateService implements PersistentStateComponent<D
     private boolean tavilySearchEnabled = false;
     private boolean googleSearchEnabled = false;
 
-    @Getter(AccessLevel.NONE) @Setter(AccessLevel.NONE)
+    @Getter(AccessLevel.NONE) @Setter(AccessLevel.NONE) @OptionTag("googleSearchKey")
     private String googleSearchKey = "";
-    @Getter(AccessLevel.NONE) @Setter(AccessLevel.NONE)
+    @Getter(AccessLevel.NONE) @Setter(AccessLevel.NONE) @OptionTag("googleCSIKey")
     private String googleCSIKey = "";
-    @Getter(AccessLevel.NONE) @Setter(AccessLevel.NONE)
+    @Getter(AccessLevel.NONE) @Setter(AccessLevel.NONE) @OptionTag("tavilySearchKey")
     private String tavilySearchKey = "";
     private Integer maxSearchResults = MAX_SEARCH_RESULTS;
 
@@ -738,9 +769,12 @@ public final class DevoxxGenieStateService implements PersistentStateComponent<D
     // ------------------------------------------------------------------
     // Credential accessors — delegate to PasswordSafe via CredentialService.
     // All 19 accessors below replace the Lombok-generated ones that have been
-    // disabled on the corresponding fields. They are marked @Transient so that
-    // XmlSerializer skips them on save (so the secret never ends up in
-    // DevoxxGenieSettingsPlugin.xml again).
+    // disabled on the corresponding fields. They carry
+    // @com.intellij.util.xmlb.annotations.Transient so that BeanBinding rejects
+    // them entirely. XmlSerializer therefore reads/writes only the underlying
+    // private fields (which are forced into the property map via @OptionTag).
+    // See the "LEGACY-XML CREDENTIAL LANDING PADS" comment block above for the
+    // full rationale.
     // ------------------------------------------------------------------
 
     /**
@@ -857,14 +891,17 @@ public final class DevoxxGenieStateService implements PersistentStateComponent<D
      * Walks every {@link CredentialKey}, reads the matching legacy field via reflection,
      * and — if non-blank — hands it to {@link CredentialService} (which writes it to
      * PasswordSafe) before wiping the legacy field. Sets {@link #credentialsMigratedV1}
-     * on success and asks IntelliJ to flush state so the now-blank XML hits disk
-     * immediately.
+     * <em>only when every key migrated cleanly</em>; on partial failure the flag stays
+     * {@code false} and the remaining plaintext fields are left in place so the next
+     * IDE startup can retry the migration.
      * <p>
-     * Non-fatal: any per-field failure is logged and skipped; the migration flag is only
-     * raised when the entire pass completes. Safe to call multiple times — calls are
-     * no-ops once the flag is set or when PasswordSafe is unavailable.
+     * The method is {@code synchronized} to be safe against concurrent project-open
+     * calls (the {@link com.devoxx.genie.startup.CredentialMigrationStartupActivity}
+     * fires once per project) and against the in-flight {@link #loadState} that
+     * triggered the first migration attempt. Safe to call multiple times — every call
+     * is a no-op once the flag is set or when PasswordSafe is unavailable.
      */
-    public void migrateCredentialsToPasswordSafe() {
+    public synchronized void migrateCredentialsToPasswordSafe() {
         if (credentialsMigratedV1) {
             return;
         }
@@ -903,13 +940,22 @@ public final class DevoxxGenieStateService implements PersistentStateComponent<D
                 LOG.warn("Failed to migrate credential field '" + key.getSubKey() + "' to PasswordSafe", t);
             }
         }
-        credentialsMigratedV1 = true;
-        try {
-            ApplicationManager.getApplication().saveSettings();
-        } catch (Throwable t) {
-            LOG.warn("Failed to flush settings after credential migration", t);
+        if (failed == 0) {
+            // All keys handled; mark migrated and ask IntelliJ to flush the now-sanitised XML.
+            credentialsMigratedV1 = true;
+            try {
+                ApplicationManager.getApplication().saveSettings();
+            } catch (Throwable t) {
+                LOG.warn("Failed to flush settings after credential migration", t);
+            }
+            LOG.info("Credential migration complete: migrated=" + migrated);
+        } else {
+            // Leave the flag false so the next startup retries. Do NOT call saveSettings():
+            // the un-wiped plaintext fields still hold the values we need on retry, and
+            // saving now would persist the partial state — fine for security but wasteful.
+            LOG.warn("Credential migration partially failed: migrated=" + migrated
+                    + " failed=" + failed + "; will retry on next startup");
         }
-        LOG.info("Credential migration complete: migrated=" + migrated + " failed=" + failed);
     }
 
     private static final Logger LOG = Logger.getInstance(DevoxxGenieStateService.class);

--- a/src/main/java/com/devoxx/genie/ui/settings/DevoxxGenieStateService.java
+++ b/src/main/java/com/devoxx/genie/ui/settings/DevoxxGenieStateService.java
@@ -912,13 +912,15 @@ public final class DevoxxGenieStateService implements PersistentStateComponent<D
             LOG.warn("CredentialService unavailable; deferring plaintext-credential migration", t);
             return;
         }
-        if (!service.isAvailable()) {
-            // PasswordSafe not reachable in this process — leave plaintext in place so the
-            // next normal IDE startup can complete the migration.
+        if (service == null || !service.isAvailable()) {
+            // CredentialService not registered (getService may return null on some IntelliJ
+            // versions / test environments) or PasswordSafe not reachable in this process —
+            // leave plaintext in place so the next normal IDE startup can complete the migration.
             return;
         }
 
         int migrated = 0;
+        int skipped = 0;
         int failed = 0;
         for (CredentialKey key : CredentialKey.values()) {
             try {
@@ -931,6 +933,9 @@ public final class DevoxxGenieStateService implements PersistentStateComponent<D
                     if (existing == null || existing.isEmpty()) {
                         service.setCredential(key, legacy);
                         migrated++;
+                    } else {
+                        // Already present in PasswordSafe (e.g. a retry after partial failure).
+                        skipped++;
                     }
                     // Wipe plaintext copy whether or not we overwrote PasswordSafe.
                     field.set(this, "");
@@ -948,13 +953,14 @@ public final class DevoxxGenieStateService implements PersistentStateComponent<D
             } catch (Throwable t) {
                 LOG.warn("Failed to flush settings after credential migration", t);
             }
-            LOG.info("Credential migration complete: migrated=" + migrated);
+            LOG.info("Credential migration complete: migrated=" + migrated
+                    + " skipped=" + skipped);
         } else {
             // Leave the flag false so the next startup retries. Do NOT call saveSettings():
             // the un-wiped plaintext fields still hold the values we need on retry, and
             // saving now would persist the partial state — fine for security but wasteful.
             LOG.warn("Credential migration partially failed: migrated=" + migrated
-                    + " failed=" + failed + "; will retry on next startup");
+                    + " skipped=" + skipped + " failed=" + failed + "; will retry on next startup");
         }
     }
 

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -644,6 +644,8 @@
                     factoryClass="com.devoxx.genie.ui.window.AgentMcpLogToolWindowFactory"/>
 
         <applicationService serviceImplementation="com.devoxx.genie.ui.settings.DevoxxGenieStateService"/>
+        <applicationService serviceInterface="com.devoxx.genie.service.credentials.CredentialService"
+                            serviceImplementation="com.devoxx.genie.service.credentials.PasswordSafeCredentialService"/>
         <applicationService serviceImplementation="com.devoxx.genie.service.conversations.ConversationStorageService"/>
         <applicationService serviceImplementation="com.devoxx.genie.service.prompt.response.nonstreaming.NonStreamingPromptExecutionService"/>
         <applicationService serviceImplementation="com.devoxx.genie.service.prompt.memory.ChatMemoryService"/>
@@ -716,6 +718,7 @@
     <extensions defaultExtensionNs="com.intellij">
         <notificationGroup id="com.devoxx.genie.notifications" displayType="BALLOON" />
         <postStartupActivity implementation="com.devoxx.genie.service.PostStartupActivity"/>
+        <postStartupActivity implementation="com.devoxx.genie.startup.CredentialMigrationStartupActivity"/>
     </extensions>
 
     <applicationListeners>


### PR DESCRIPTION
Supersedes #1046 with a **clean, minimal diff**. #1046's source fork is 37 commits behind `devoxx/master`, so it shows ~197 unrelated files. This branch is cut from current `master` with only the two credential commits cherry-picked, plus a commit addressing the code-review findings — so the diff is just the **7 credential files**.

## What this does
Moves all 19 credential fields (OpenAI, Anthropic, Mistral, Groq, Gemini, DeepSeek, OpenRouter, Grok, Kimi, GLM, Azure OpenAI, AWS access/secret/bearer, CustomOpenAI, Google Search, Google CSE, Tavily) out of plaintext `DevoxxGenieSettingsPlugin.xml` into IntelliJ's PasswordSafe (OS keychain / KeePass / KWallet).

- New `service/credentials` package: `CredentialKey` enum, `CredentialService` interface, `PasswordSafeCredentialService` impl with in-memory fallback for headless/test environments.
- `DevoxxGenieStateService`: Lombok accessors disabled on the 19 credential fields; hand-written `@Transient` accessors delegate to `CredentialService`; one-shot migration in `loadState` reads legacy plaintext, writes it to PasswordSafe, and wipes the XML fields.
- `CredentialMigrationStartupActivity`: belt-and-braces retry on every project open, idempotent via `credentialsMigratedV1`.
- `plugin.xml`: registers `CredentialService` and the startup activity.

## Review fixes (vs #1046)
Addresses the code-review findings on #1046:

1. **NPE guard** — `migrateCredentialsToPasswordSafe()` now checks `service == null || !service.isAvailable()`, since `getService()` can return `null` (rather than throw) on some IntelliJ versions / test environments.
2. **Migration log accuracy** — added a `skipped` counter so retry runs no longer report a misleading `migrated=0` when credentials were already safely in PasswordSafe.
3. **Javadoc** — fixed broken `{@link #subKey()}` → `{@link #getSubKey()}` in `CredentialKey`.
4. **Deprecation** — switched to the minimal `CredentialAttributes(serviceName)` constructor, away from the deprecated 4-arg form.
5. **Comment accuracy** — clarified that `memoryFallback` is a write-side cache (populated on `setCredential`, not on reads), not a read-through "write-through cache".

### Deliberately not changed
The review also flagged PasswordSafe I/O running on the EDT in `loadState()`. We **kept it synchronous** on purpose: the existing design guarantees callers never observe a window where the state holds plaintext but PasswordSafe does not yet. The `CredentialMigrationStartupActivity` already provides an async backstop on project open.

## Testing
`./gradlew compileJava` — green.

Closes #1046 once merged (can be closed manually in favour of this branch).

---
_Generated by [Claude Code](https://claude.ai/code/session_01JjnTkn1KwqHh17uMSThz28)_