### PR TITLE
fix(rag): migrate ChromaDB to v2 API and fix WSL volume path

### DIFF
--- a/backlog/tasks/task-231 - Fix-ChromaDB-v2-API-migration-and-add-e2e-tests-for-ChromaDB-interactions.md
+++ b/backlog/tasks/task-231 - Fix-ChromaDB-v2-API-migration-and-add-e2e-tests-for-ChromaDB-interactions.md
@@ -1,0 +1,60 @@
+---
+id: TASK-231
+title: Fix ChromaDB v2 API migration and add e2e tests for ChromaDB interactions
+status: In Progress
+assignee: []
+created_date: '2026-06-09 11:27'
+labels:
+  - bug
+  - rag
+  - chromadb
+  - testing
+dependencies: []
+references:
+  - 'https://github.com/devoxx/DevoxxGenieIDEAPlugin/issues/1085'
+  - src/main/java/com/devoxx/genie/service/chromadb/ChromaDBService.java
+  - src/main/java/com/devoxx/genie/service/chromadb/ChromaEmbeddingService.java
+  - src/main/java/com/devoxx/genie/service/chromadb/ChromaDBManager.java
+  - >-
+    src/test/java/com/devoxx/genie/service/rag/validator/ChromeDBValidatorTest.java
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+## Context
+
+GitHub issue #1085 reported that the RAG feature fails with ChromaDB 0.6+ because the plugin was using the deprecated v1 REST API (`/api/v1/`). ChromaDB 0.6.x deprecated v1 in favour of v2; ChromaDB 1.x removes it entirely.
+
+## Root Cause
+
+Two components used the v1 API:
+
+1. **`ChromaDBService.java`** — Retrofit interface with hardcoded `/api/v1/collections` paths used by `ChromaDBManager` for list, count, and delete operations shown in the RAG settings UI.
+2. **`ChromaEmbeddingService.java`** — `ChromaEmbeddingStore.builder()` defaulted to `ChromaApiVersion.V1` (langchain4j default). Langchain4J 1.7.0-beta13+ added `ChromaApiVersion.V2`.
+
+## Fix Applied (branch: fix/issue-1085-chromadb-v2-api)
+
+- `ChromaDBService.java`: Updated all three endpoints to `/api/v2/tenants/default_tenant/databases/default_database/collections/...`
+- `ChromaEmbeddingService.java`: Added `.apiVersion(ChromaApiVersion.V2).tenantName("default_tenant").databaseName("default_database")` to the store builder
+
+`default_tenant` and `default_database` are ChromaDB's server-side defaults, ensuring existing indexed data is preserved.
+
+## Remaining Work
+
+Write e2e / integration tests covering the ChromaDB REST interactions to prevent regressions when ChromaDB or langchain4j are upgraded again.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 ChromaDBService Retrofit interface uses /api/v2/ paths for all three operations (list, count, delete)
+- [ ] #2 ChromaEmbeddingService uses ChromaApiVersion.V2 with default_tenant and default_database
+- [ ] #3 No v1 API calls remain in the codebase (grep check)
+- [ ] #4 Integration/e2e tests cover ChromaDBManager.listCollections() against a real or WireMock ChromaDB v2 endpoint
+- [ ] #5 Integration/e2e tests cover ChromaDBManager.countDocuments() against the v2 count endpoint
+- [ ] #6 Integration/e2e tests cover ChromaDBManager.deleteCollection() against the v2 delete endpoint
+- [ ] #7 Integration/e2e tests cover ChromaEmbeddingService.init() and a round-trip embed+search using the v2 store
+- [ ] #8 All existing ChromaDB-related tests continue to pass
+- [ ] #9 Build compiles cleanly with no new errors
+<!-- AC:END -->

--- a/src/main/java/com/devoxx/genie/service/chromadb/ChromaDBManager.java
+++ b/src/main/java/com/devoxx/genie/service/chromadb/ChromaDBManager.java
@@ -70,12 +70,12 @@ public final class ChromaDBManager {
         }
     }
 
-    public void deleteCollection(String collectionId) throws IOException {
-        service.deleteCollection(collectionId).execute();
+    public void deleteCollection(String collectionName) throws IOException {
+        service.deleteCollection(collectionName).execute();
     }
 
-    public int countDocuments(String collectionName) throws IOException {
-        retrofit2.Response<Integer> execute = service.getCount(collectionName).execute();
+    public int countDocuments(String collectionId) throws IOException {
+        retrofit2.Response<Integer> execute = service.getCount(collectionId).execute();
         if (execute.isSuccessful() && execute.body() != null) {
             return execute.body();
         } else {

--- a/src/main/java/com/devoxx/genie/service/chromadb/ChromaDBService.java
+++ b/src/main/java/com/devoxx/genie/service/chromadb/ChromaDBService.java
@@ -7,12 +7,12 @@ import retrofit2.http.GET;
 import retrofit2.http.Path;
 
 public interface ChromaDBService {
-    @GET("/api/v1/collections")
+    @GET("/api/v2/tenants/default_tenant/databases/default_database/collections")
     Call<ChromaCollection[]> getCollections();
 
-    @GET("/api/v1/collections/{collectionName}/count")
-    Call<Integer> getCount(@Path("collectionName") String collectionName);
+    @GET("/api/v2/tenants/default_tenant/databases/default_database/collections/{collectionId}/count")
+    Call<Integer> getCount(@Path("collectionId") String collectionId);
 
-    @DELETE("/api/v1/collections/{collectionName}")
+    @DELETE("/api/v2/tenants/default_tenant/databases/default_database/collections/{collectionName}")
     Call<Void> deleteCollection(@Path("collectionName") String collectionName);
 }

--- a/src/main/java/com/devoxx/genie/service/chromadb/ChromaDockerService.java
+++ b/src/main/java/com/devoxx/genie/service/chromadb/ChromaDockerService.java
@@ -185,10 +185,12 @@ public final class ChromaDockerService {
 
             if (existingContainers.isEmpty()) {
                 Integer port = DevoxxGenieStateService.getInstance().getIndexerPort();
+                String daemonOs = dockerClient.infoCmd().exec().getOsType();
+                String dockerVolumePath = toDockerVolumePath(daemonOs, volumePath);
 
                 HostConfig hostConfig = new HostConfig()
                         .withPortBindings(new PortBinding(Ports.Binding.bindPort(8000), ExposedPort.tcp(port)))
-                        .withBinds(new Bind(volumePath, new Volume("/chroma/chroma")));
+                        .withBinds(new Bind(dockerVolumePath, new Volume("/chroma/chroma")));
 
                 // Create new container if none exists
                 String containerId;
@@ -251,6 +253,34 @@ public final class ChromaDockerService {
 
         ApplicationManager.getApplication().invokeLater(() ->
                 deleteCollectionData(collectionPath, collectionName));
+    }
+
+    /**
+     * Converts a JVM volume path to a Docker-daemon-compatible path.
+     *
+     * <p>When IntelliJ runs on Windows and Docker is backed by a WSL Linux daemon,
+     * {@code PathManager.getSystemPath()} returns a Windows-style path like
+     * {@code C:\Users\...\DevoxxGenie\chromadb\data-XYZ}. The Linux daemon rejects
+     * this as an invalid volume specification. WSL mounts Windows drives under
+     * {@code /mnt/<drive>/}, so the path is converted to {@code /mnt/c/Users/...}.
+     *
+     * <p>On a native Windows daemon or a native Linux JVM + daemon the path is
+     * returned unchanged.
+     *
+     * @param daemonOs  the OS type reported by {@code docker info} (e.g. "linux", "windows")
+     * @param jvmPath   the absolute path produced by the JVM (may be Windows- or Unix-style)
+     * @return a path the Docker daemon can mount as a bind volume
+     */
+    static String toDockerVolumePath(String daemonOs, String jvmPath) {
+        if ("linux".equalsIgnoreCase(daemonOs)
+                && jvmPath.length() >= 2
+                && Character.isLetter(jvmPath.charAt(0))
+                && jvmPath.charAt(1) == ':') {
+            char drive = Character.toLowerCase(jvmPath.charAt(0));
+            String rest = jvmPath.substring(2).replace('\\', '/');
+            return "/mnt/" + drive + rest;
+        }
+        return jvmPath;
     }
 
     private void deleteCollectionData(@NotNull Path collectionPath, @NotNull String collectionName) {

--- a/src/main/java/com/devoxx/genie/service/chromadb/ChromaEmbeddingService.java
+++ b/src/main/java/com/devoxx/genie/service/chromadb/ChromaEmbeddingService.java
@@ -8,6 +8,7 @@ import dev.langchain4j.data.segment.TextSegment;
 import dev.langchain4j.model.embedding.EmbeddingModel;
 import dev.langchain4j.model.ollama.OllamaEmbeddingModel;
 import dev.langchain4j.store.embedding.EmbeddingStore;
+import dev.langchain4j.store.embedding.chroma.ChromaApiVersion;
 import dev.langchain4j.store.embedding.chroma.ChromaEmbeddingStore;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
@@ -45,6 +46,9 @@ public final class ChromaEmbeddingService {
         String url = "http://localhost:" + stateService.getIndexerPort();
         try {
             this.embeddingStore = ChromaEmbeddingStore.builder()
+                    .apiVersion(ChromaApiVersion.V2)
+                    .tenantName("default_tenant")
+                    .databaseName("default_database")
                     .baseUrl(url)
                     .logRequests(true)
                     .logResponses(true)

--- a/src/main/java/com/devoxx/genie/ui/settings/rag/table/ButtonEditor.java
+++ b/src/main/java/com/devoxx/genie/ui/settings/rag/table/ButtonEditor.java
@@ -82,13 +82,13 @@ public class ButtonEditor extends DefaultCellEditor {
                     return DELETE_LABEL;
                 }
 
-                String collectionId = (String) tableModel.getValueAt(row, 0);
-                if (collectionId != null && confirmDeletion(collectionId)) {
+                String collectionName = (String) tableModel.getValueAt(row, 0);
+                if (collectionName != null && confirmDeletion(collectionName)) {
                     // Delete collection first
-                    ChromaDBManager.getInstance(project).deleteCollection(collectionId);
+                    ChromaDBManager.getInstance(project).deleteCollection(collectionName);
 
                     // Delete the associated volume data
-                    dockerService.deleteCollectionData(project, collectionId);
+                    dockerService.deleteCollectionData(project, collectionName);
 
                     // Then reload table data
                     safeLoadCollections();

--- a/src/test/java/com/devoxx/genie/service/chromadb/ChromaDBServiceV2ApiTest.java
+++ b/src/test/java/com/devoxx/genie/service/chromadb/ChromaDBServiceV2ApiTest.java
@@ -1,0 +1,249 @@
+package com.devoxx.genie.service.chromadb;
+
+import com.devoxx.genie.service.chromadb.model.ChromaCollection;
+import okhttp3.OkHttpClient;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import retrofit2.Response;
+import retrofit2.Retrofit;
+import retrofit2.converter.gson.GsonConverterFactory;
+
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Verifies that {@link ChromaDBService} Retrofit endpoints use the ChromaDB v2 REST API
+ * ({@code /api/v2/tenants/default_tenant/databases/default_database/...}) and not the
+ * deprecated v1 API ({@code /api/v1/...}).
+ *
+ * <p>Each test wires a real Retrofit instance against a {@link MockWebServer} and checks
+ * both the outgoing request path and the deserialized response.
+ */
+class ChromaDBServiceV2ApiTest {
+
+    private static final String COLLECTION_JSON =
+            "[{\"id\":\"uuid-abc\",\"name\":\"my-project\",\"tenant\":\"default_tenant\",\"database\":\"default_database\"}]";
+
+    private MockWebServer server;
+    private ChromaDBService service;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        server = new MockWebServer();
+        server.start();
+
+        Retrofit retrofit = new Retrofit.Builder()
+                .baseUrl(server.url("/"))
+                .client(new OkHttpClient())
+                .addConverterFactory(GsonConverterFactory.create())
+                .build();
+        service = retrofit.create(ChromaDBService.class);
+    }
+
+    @AfterEach
+    void tearDown() throws IOException {
+        server.shutdown();
+    }
+
+    // ── getCollections ──────────────────────────────────────────────────────────
+
+    @Test
+    void getCollections_usesV2Path() throws IOException, InterruptedException {
+        server.enqueue(new MockResponse()
+                .addHeader("Content-Type", "application/json")
+                .setBody("[]"));
+
+        service.getCollections().execute();
+
+        RecordedRequest request = server.takeRequest(5, TimeUnit.SECONDS);
+        assertThat(request).isNotNull();
+        assertThat(request.getMethod()).isEqualTo("GET");
+        assertThat(request.getPath())
+                .isEqualTo("/api/v2/tenants/default_tenant/databases/default_database/collections");
+    }
+
+    @Test
+    void getCollections_pathDoesNotContainV1() throws IOException, InterruptedException {
+        server.enqueue(new MockResponse()
+                .addHeader("Content-Type", "application/json")
+                .setBody("[]"));
+
+        service.getCollections().execute();
+
+        RecordedRequest request = server.takeRequest(5, TimeUnit.SECONDS);
+        assertThat(request).isNotNull();
+        assertThat(request.getPath())
+                .as("must not use the deprecated /api/v1/ prefix")
+                .doesNotContain("/api/v1/");
+    }
+
+    @Test
+    void getCollections_parsesCollectionFields() throws IOException {
+        server.enqueue(new MockResponse()
+                .addHeader("Content-Type", "application/json")
+                .setBody(COLLECTION_JSON));
+
+        Response<ChromaCollection[]> response = service.getCollections().execute();
+
+        assertThat(response.isSuccessful()).isTrue();
+        ChromaCollection[] collections = response.body();
+        assertThat(collections).hasSize(1);
+        assertThat(collections[0].id()).isEqualTo("uuid-abc");
+        assertThat(collections[0].name()).isEqualTo("my-project");
+        assertThat(collections[0].tenant()).isEqualTo("default_tenant");
+        assertThat(collections[0].database()).isEqualTo("default_database");
+    }
+
+    @Test
+    void getCollections_emptyArrayParsesCorrectly() throws IOException {
+        server.enqueue(new MockResponse()
+                .addHeader("Content-Type", "application/json")
+                .setBody("[]"));
+
+        Response<ChromaCollection[]> response = service.getCollections().execute();
+
+        assertThat(response.isSuccessful()).isTrue();
+        assertThat(response.body()).isEmpty();
+    }
+
+    // ── getCount ───────────────────────────────────────────────────────────────
+
+    @Test
+    void getCount_usesV2PathWithCollectionId() throws IOException, InterruptedException {
+        server.enqueue(new MockResponse()
+                .addHeader("Content-Type", "application/json")
+                .setBody("42"));
+
+        service.getCount("col-uuid-123").execute();
+
+        RecordedRequest request = server.takeRequest(5, TimeUnit.SECONDS);
+        assertThat(request).isNotNull();
+        assertThat(request.getMethod()).isEqualTo("GET");
+        assertThat(request.getPath()).isEqualTo(
+                "/api/v2/tenants/default_tenant/databases/default_database/collections/col-uuid-123/count");
+    }
+
+    @Test
+    void getCount_pathDoesNotContainV1() throws IOException, InterruptedException {
+        server.enqueue(new MockResponse()
+                .addHeader("Content-Type", "application/json")
+                .setBody("0"));
+
+        service.getCount("any-id").execute();
+
+        RecordedRequest request = server.takeRequest(5, TimeUnit.SECONDS);
+        assertThat(request).isNotNull();
+        assertThat(request.getPath()).doesNotContain("/api/v1/");
+    }
+
+    @Test
+    void getCount_substitutesCollectionIdInPath() throws IOException, InterruptedException {
+        server.enqueue(new MockResponse()
+                .addHeader("Content-Type", "application/json")
+                .setBody("7"));
+
+        service.getCount("specific-uuid-xyz").execute();
+
+        RecordedRequest request = server.takeRequest(5, TimeUnit.SECONDS);
+        assertThat(request).isNotNull();
+        assertThat(request.getPath()).contains("specific-uuid-xyz");
+    }
+
+    @Test
+    void getCount_parsesIntegerResponse() throws IOException {
+        server.enqueue(new MockResponse()
+                .addHeader("Content-Type", "application/json")
+                .setBody("99"));
+
+        Response<Integer> response = service.getCount("col-uuid-123").execute();
+
+        assertThat(response.isSuccessful()).isTrue();
+        assertThat(response.body()).isEqualTo(99);
+    }
+
+    // ── deleteCollection ────────────────────────────────────────────────────────
+
+    @Test
+    void deleteCollection_usesV2DeletePath() throws IOException, InterruptedException {
+        server.enqueue(new MockResponse().setResponseCode(200));
+
+        service.deleteCollection("my-project").execute();
+
+        RecordedRequest request = server.takeRequest(5, TimeUnit.SECONDS);
+        assertThat(request).isNotNull();
+        assertThat(request.getMethod()).isEqualTo("DELETE");
+        assertThat(request.getPath()).isEqualTo(
+                "/api/v2/tenants/default_tenant/databases/default_database/collections/my-project");
+    }
+
+    @Test
+    void deleteCollection_pathDoesNotContainV1() throws IOException, InterruptedException {
+        server.enqueue(new MockResponse().setResponseCode(200));
+
+        service.deleteCollection("any-collection").execute();
+
+        RecordedRequest request = server.takeRequest(5, TimeUnit.SECONDS);
+        assertThat(request).isNotNull();
+        assertThat(request.getPath()).doesNotContain("/api/v1/");
+    }
+
+    @Test
+    void deleteCollection_substitutesCollectionNameInPath() throws IOException, InterruptedException {
+        server.enqueue(new MockResponse().setResponseCode(200));
+
+        service.deleteCollection("my-specific-project").execute();
+
+        RecordedRequest request = server.takeRequest(5, TimeUnit.SECONDS);
+        assertThat(request).isNotNull();
+        assertThat(request.getPath()).contains("my-specific-project");
+    }
+
+    // ── Cross-endpoint regression guard ────────────────────────────────────────
+
+    @Test
+    void noEndpointUsesDeprecatedV1Api() throws IOException, InterruptedException {
+        server.enqueue(new MockResponse().addHeader("Content-Type", "application/json").setBody("[]"));
+        server.enqueue(new MockResponse().addHeader("Content-Type", "application/json").setBody("0"));
+        server.enqueue(new MockResponse().setResponseCode(200));
+
+        service.getCollections().execute();
+        service.getCount("any-id").execute();
+        service.deleteCollection("any-name").execute();
+
+        for (int i = 0; i < 3; i++) {
+            RecordedRequest request = server.takeRequest(5, TimeUnit.SECONDS);
+            assertThat(request).isNotNull();
+            assertThat(request.getPath())
+                    .as("endpoint %d must not use the deprecated /api/v1/ path", i + 1)
+                    .doesNotContain("/api/v1/");
+        }
+    }
+
+    @Test
+    void allEndpointsUseDefaultTenantAndDatabase() throws IOException, InterruptedException {
+        server.enqueue(new MockResponse().addHeader("Content-Type", "application/json").setBody("[]"));
+        server.enqueue(new MockResponse().addHeader("Content-Type", "application/json").setBody("0"));
+        server.enqueue(new MockResponse().setResponseCode(200));
+
+        service.getCollections().execute();
+        service.getCount("any-id").execute();
+        service.deleteCollection("any-name").execute();
+
+        for (int i = 0; i < 3; i++) {
+            RecordedRequest request = server.takeRequest(5, TimeUnit.SECONDS);
+            assertThat(request).isNotNull();
+            assertThat(request.getPath())
+                    .as("endpoint %d must reference default_tenant", i + 1)
+                    .contains("default_tenant");
+            assertThat(request.getPath())
+                    .as("endpoint %d must reference default_database", i + 1)
+                    .contains("default_database");
+        }
+    }
+}

--- a/src/test/java/com/devoxx/genie/service/chromadb/ChromaDockerServiceVolumePathTest.java
+++ b/src/test/java/com/devoxx/genie/service/chromadb/ChromaDockerServiceVolumePathTest.java
@@ -1,0 +1,130 @@
+package com.devoxx.genie.service.chromadb;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests for {@link ChromaDockerService#toDockerVolumePath(String, String)}.
+ *
+ * <p>Covers the WSL bind-mount bug (GitHub issue #1085): when IntelliJ runs on
+ * Windows and Docker is backed by a WSL Linux daemon, the JVM produces a
+ * Windows-style path ({@code C:\Users\...}) which the Linux daemon rejects.
+ * The method must convert such paths to the WSL {@code /mnt/<drive>/...} format.
+ */
+class ChromaDockerServiceVolumePathTest {
+
+    // ── Linux daemon + Windows JVM path (WSL scenario) ─────────────────────────
+
+    @Test
+    void linuxDaemon_windowsPathWithBackslashes_convertsToMntFormat() {
+        String result = ChromaDockerService.toDockerVolumePath(
+                "linux",
+                "C:\\Users\\abc\\AppData\\Local\\DevoxxGenie\\chromadb\\data-123");
+
+        assertThat(result)
+                .isEqualTo("/mnt/c/Users/abc/AppData/Local/DevoxxGenie/chromadb/data-123");
+    }
+
+    @Test
+    void linuxDaemon_windowsPathWithForwardSlashes_convertsToMntFormat() {
+        String result = ChromaDockerService.toDockerVolumePath(
+                "linux",
+                "C:/Users/abc/AppData/Local/DevoxxGenie/chromadb/data-123");
+
+        assertThat(result)
+                .isEqualTo("/mnt/c/Users/abc/AppData/Local/DevoxxGenie/chromadb/data-123");
+    }
+
+    @Test
+    void linuxDaemon_windowsPathDriveLetterLowercased() {
+        String upper = ChromaDockerService.toDockerVolumePath("linux", "D:\\some\\path");
+        String lower = ChromaDockerService.toDockerVolumePath("linux", "d:\\some\\path");
+
+        assertThat(upper).isEqualTo("/mnt/d/some/path");
+        assertThat(lower).isEqualTo("/mnt/d/some/path");
+    }
+
+    @Test
+    void linuxDaemon_daemonOsIsCaseInsensitive() {
+        String linux  = ChromaDockerService.toDockerVolumePath("Linux",  "C:\\path\\dir");
+        String LINUX  = ChromaDockerService.toDockerVolumePath("LINUX",  "C:\\path\\dir");
+        String linuxl = ChromaDockerService.toDockerVolumePath("linux",  "C:\\path\\dir");
+
+        assertThat(linux).isEqualTo(LINUX).isEqualTo(linuxl)
+                .isEqualTo("/mnt/c/path/dir");
+    }
+
+    @Test
+    void linuxDaemon_exactPathFromIssue1085_convertsCorrectly() {
+        // The exact path that appeared in the bug report
+        String input = "C:\\Users\\abc\\AppData\\Local\\Google\\AndroidStudio2026.1.1" +
+                       "\\DevoxxGenie\\chromadb\\data-1446501950";
+
+        String result = ChromaDockerService.toDockerVolumePath("linux", input);
+
+        assertThat(result)
+                .startsWith("/mnt/c/")
+                .doesNotContain("\\")
+                .doesNotContain("C:");
+    }
+
+    // ── Linux daemon + already-Linux path ──────────────────────────────────────
+
+    @Test
+    void linuxDaemon_linuxPath_returnedUnchanged() {
+        String path = "/home/user/.local/share/DevoxxGenie/chromadb/data-123";
+
+        String result = ChromaDockerService.toDockerVolumePath("linux", path);
+
+        assertThat(result).isEqualTo(path);
+    }
+
+    @Test
+    void linuxDaemon_mntPath_returnedUnchanged() {
+        String path = "/mnt/c/Users/already-converted/data-123";
+
+        String result = ChromaDockerService.toDockerVolumePath("linux", path);
+
+        assertThat(result).isEqualTo(path);
+    }
+
+    // ── Windows daemon + Windows JVM path ──────────────────────────────────────
+
+    @Test
+    void windowsDaemon_windowsPath_returnedUnchanged() {
+        String path = "C:\\Users\\abc\\AppData\\Local\\DevoxxGenie\\chromadb\\data-123";
+
+        String result = ChromaDockerService.toDockerVolumePath("windows", path);
+
+        assertThat(result).isEqualTo(path);
+    }
+
+    @Test
+    void windowsDaemonCaseInsensitive_windowsPath_returnedUnchanged() {
+        String path = "C:\\Users\\abc\\data-123";
+
+        assertThat(ChromaDockerService.toDockerVolumePath("Windows", path)).isEqualTo(path);
+        assertThat(ChromaDockerService.toDockerVolumePath("WINDOWS", path)).isEqualTo(path);
+    }
+
+    // ── Null / unknown daemon OS ────────────────────────────────────────────────
+
+    @Test
+    void unknownDaemonOs_windowsPath_returnedUnchanged() {
+        String path = "C:\\Users\\abc\\data-123";
+
+        String result = ChromaDockerService.toDockerVolumePath("unknown", path);
+
+        assertThat(result).isEqualTo(path);
+    }
+
+    @Test
+    void nullDaemonOs_windowsPath_returnedUnchanged() {
+        String path = "C:\\Users\\abc\\data-123";
+
+        String result = ChromaDockerService.toDockerVolumePath(null, path);
+
+        assertThat(result).isEqualTo(path);
+    }
+}

--- a/src/test/java/com/devoxx/genie/service/chromadb/ChromaEmbeddingServiceInitV2Test.java
+++ b/src/test/java/com/devoxx/genie/service/chromadb/ChromaEmbeddingServiceInitV2Test.java
@@ -1,0 +1,298 @@
+package com.devoxx.genie.service.chromadb;
+
+import com.devoxx.genie.ui.settings.DevoxxGenieStateService;
+import com.intellij.openapi.project.Project;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+/**
+ * Verifies that {@link ChromaEmbeddingService#init(Project)} wires the underlying
+ * {@code ChromaEmbeddingStore} to use the ChromaDB <em>v2</em> REST API, not the
+ * deprecated v1 API.
+ *
+ * <p>The test points the service at a {@link MockWebServer} and records every HTTP
+ * request made during initialization so that paths can be asserted without a real
+ * ChromaDB or Ollama instance.
+ *
+ * <p><strong>ChromaDB v2 initialization sequence (warm-start / all resources exist):</strong>
+ * <ol>
+ *   <li>{@code GET /api/v2/tenants/default_tenant} — check tenant</li>
+ *   <li>{@code GET /api/v2/tenants/default_tenant/databases/default_database} — check database</li>
+ *   <li>{@code GET /api/v2/tenants/default_tenant/databases/default_database/collections/{name}} — check collection</li>
+ * </ol>
+ *
+ * <p><strong>Cold-start (resources must be created):</strong> each missing resource
+ * causes a {@code POST} to create it before the next {@code GET}.
+ */
+@ExtendWith(MockitoExtension.class)
+class ChromaEmbeddingServiceInitV2Test {
+
+    private MockWebServer server;
+    private MockedStatic<DevoxxGenieStateService> stateServiceStatic;
+
+    @Mock
+    private DevoxxGenieStateService stateService;
+
+    @Mock
+    private Project project;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        server = new MockWebServer();
+        server.start();
+
+        stateServiceStatic = mockStatic(DevoxxGenieStateService.class);
+        stateServiceStatic.when(DevoxxGenieStateService::getInstance).thenReturn(stateService);
+        when(stateService.getIndexerPort()).thenReturn(server.getPort());
+        when(project.getName()).thenReturn("Test Project");
+    }
+
+    @AfterEach
+    void tearDown() throws IOException {
+        stateServiceStatic.close();
+        server.shutdown();
+    }
+
+    /**
+     * Enqueues MockWebServer responses for the warm-start case: tenant, database, and
+     * collection all exist in ChromaDB already. Produces exactly 3 GET requests.
+     */
+    private void enqueueWarmStart() {
+        server.enqueue(new MockResponse()
+                .addHeader("Content-Type", "application/json")
+                .setBody("{\"name\":\"default_tenant\"}"));
+        server.enqueue(new MockResponse()
+                .addHeader("Content-Type", "application/json")
+                .setBody("{\"name\":\"default_database\",\"tenant\":\"default_tenant\"}"));
+        server.enqueue(new MockResponse()
+                .addHeader("Content-Type", "application/json")
+                .setBody("{\"id\":\"col-uuid-123\",\"name\":\"test-project\"," +
+                         "\"tenant\":\"default_tenant\",\"database\":\"default_database\"}"));
+    }
+
+    /**
+     * Enqueues MockWebServer responses for the cold-start case: tenant, database, and
+     * collection must all be created. Produces 6 requests (3 GET + 3 POST).
+     */
+    private void enqueueColdStart() {
+        // Tenant not found (ChromaDB returns 500 for missing tenant)
+        server.enqueue(new MockResponse().setResponseCode(500));
+        // Create tenant
+        server.enqueue(new MockResponse()
+                .addHeader("Content-Type", "application/json")
+                .setBody("{\"name\":\"default_tenant\"}"));
+        // Database not found
+        server.enqueue(new MockResponse().setResponseCode(500));
+        // Create database
+        server.enqueue(new MockResponse()
+                .addHeader("Content-Type", "application/json")
+                .setBody("{\"name\":\"default_database\",\"tenant\":\"default_tenant\"}"));
+        // Collection not found
+        server.enqueue(new MockResponse().setResponseCode(500));
+        // Create collection
+        server.enqueue(new MockResponse()
+                .addHeader("Content-Type", "application/json")
+                .setBody("{\"id\":\"new-col-uuid\",\"name\":\"test-project\"," +
+                         "\"tenant\":\"default_tenant\",\"database\":\"default_database\"}"));
+    }
+
+    private List<RecordedRequest> drainRequests(int expectedCount) throws InterruptedException {
+        List<RecordedRequest> requests = new ArrayList<>();
+        for (int i = 0; i < expectedCount; i++) {
+            RecordedRequest req = server.takeRequest(5, TimeUnit.SECONDS);
+            assertThat(req).as("expected request %d of %d was not received", i + 1, expectedCount).isNotNull();
+            requests.add(req);
+        }
+        return requests;
+    }
+
+    // ── Warm-start (all resources exist) ───────────────────────────────────────
+
+    @Test
+    void init_warmStart_allRequestsUseV2Api() throws Exception {
+        enqueueWarmStart();
+
+        new ChromaEmbeddingService().init(project);
+
+        List<RecordedRequest> requests = drainRequests(3);
+        for (RecordedRequest req : requests) {
+            assertThat(req.getPath())
+                    .as("init() must not call any deprecated /api/v1/ path")
+                    .doesNotContain("/api/v1/");
+            assertThat(req.getPath())
+                    .as("init() must use the /api/v2/ prefix")
+                    .startsWith("/api/v2/");
+        }
+    }
+
+    @Test
+    void init_warmStart_allRequestsReferenceDefaultTenant() throws Exception {
+        enqueueWarmStart();
+
+        new ChromaEmbeddingService().init(project);
+
+        List<RecordedRequest> requests = drainRequests(3);
+        assertThat(requests)
+                .extracting(RecordedRequest::getPath)
+                .as("every v2 request must scope to default_tenant")
+                .allMatch(p -> p.contains("default_tenant"));
+    }
+
+    @Test
+    void init_warmStart_databaseAndCollectionRequestsReferenceDefaultDatabase() throws Exception {
+        enqueueWarmStart();
+
+        new ChromaEmbeddingService().init(project);
+
+        List<RecordedRequest> requests = drainRequests(3);
+        // Requests 2 and 3 are database- and collection-scoped; request 1 is tenant-only.
+        assertThat(requests.subList(1, 3))
+                .extracting(RecordedRequest::getPath)
+                .as("database and collection paths must reference default_database")
+                .allMatch(p -> p.contains("default_database"));
+    }
+
+    @Test
+    void init_warmStart_firstRequestChecksTenant() throws Exception {
+        enqueueWarmStart();
+
+        new ChromaEmbeddingService().init(project);
+
+        RecordedRequest tenantRequest = server.takeRequest(5, TimeUnit.SECONDS);
+        assertThat(tenantRequest).isNotNull();
+        assertThat(tenantRequest.getMethod()).isEqualTo("GET");
+        assertThat(tenantRequest.getPath()).isEqualTo("/api/v2/tenants/default_tenant");
+    }
+
+    @Test
+    void init_warmStart_secondRequestChecksDatabase() throws Exception {
+        enqueueWarmStart();
+
+        new ChromaEmbeddingService().init(project);
+
+        server.takeRequest(5, TimeUnit.SECONDS); // skip tenant request
+        RecordedRequest dbRequest = server.takeRequest(5, TimeUnit.SECONDS);
+        assertThat(dbRequest).isNotNull();
+        assertThat(dbRequest.getMethod()).isEqualTo("GET");
+        assertThat(dbRequest.getPath())
+                .isEqualTo("/api/v2/tenants/default_tenant/databases/default_database");
+    }
+
+    @Test
+    void init_warmStart_thirdRequestChecksCollection() throws Exception {
+        enqueueWarmStart();
+
+        new ChromaEmbeddingService().init(project);
+
+        server.takeRequest(5, TimeUnit.SECONDS); // skip tenant
+        server.takeRequest(5, TimeUnit.SECONDS); // skip database
+        RecordedRequest collectionRequest = server.takeRequest(5, TimeUnit.SECONDS);
+        assertThat(collectionRequest).isNotNull();
+        assertThat(collectionRequest.getMethod()).isEqualTo("GET");
+        assertThat(collectionRequest.getPath())
+                .startsWith("/api/v2/tenants/default_tenant/databases/default_database/collections/");
+    }
+
+    @Test
+    void init_warmStart_embeddingStoreIsNonNullAfterInit() throws Exception {
+        enqueueWarmStart();
+
+        ChromaEmbeddingService service = new ChromaEmbeddingService();
+        service.init(project);
+
+        assertThat(service.getEmbeddingStore())
+                .as("getEmbeddingStore() must return a non-null store after init()")
+                .isNotNull();
+    }
+
+    @Test
+    void init_warmStart_collectionPathContainsNormalisedProjectName() throws Exception {
+        // Project name "Test Project" → normalised to "test-project" (lower-case, spaces → dashes)
+        enqueueWarmStart();
+
+        new ChromaEmbeddingService().init(project);
+
+        List<RecordedRequest> requests = drainRequests(3);
+        RecordedRequest collectionRequest = requests.get(2);
+        assertThat(collectionRequest.getPath())
+                .as("collection path must contain the normalised project name")
+                .contains("test-project");
+    }
+
+    // ── Cold-start (all resources must be created) ─────────────────────────────
+
+    @Test
+    void init_coldStart_allRequestsUseV2Api() throws Exception {
+        enqueueColdStart();
+
+        new ChromaEmbeddingService().init(project);
+
+        List<RecordedRequest> requests = drainRequests(6);
+        for (RecordedRequest req : requests) {
+            assertThat(req.getPath())
+                    .as("cold-start init() must not call any deprecated /api/v1/ path")
+                    .doesNotContain("/api/v1/");
+            assertThat(req.getPath())
+                    .as("cold-start init() must use the /api/v2/ prefix")
+                    .startsWith("/api/v2/");
+        }
+    }
+
+    @Test
+    void init_coldStart_createsTenantAndDatabase() throws Exception {
+        enqueueColdStart();
+
+        new ChromaEmbeddingService().init(project);
+
+        List<RecordedRequest> requests = drainRequests(6);
+
+        // Request sequence: GET tenant → POST tenant → GET db → POST db → GET col → POST col
+        assertThat(requests.get(0).getMethod()).as("1st: check tenant").isEqualTo("GET");
+        assertThat(requests.get(1).getMethod()).as("2nd: create tenant").isEqualTo("POST");
+        assertThat(requests.get(2).getMethod()).as("3rd: check database").isEqualTo("GET");
+        assertThat(requests.get(3).getMethod()).as("4th: create database").isEqualTo("POST");
+        assertThat(requests.get(4).getMethod()).as("5th: check collection").isEqualTo("GET");
+        assertThat(requests.get(5).getMethod()).as("6th: create collection").isEqualTo("POST");
+    }
+
+    @Test
+    void init_coldStart_createTenantUsesCorrectPath() throws Exception {
+        enqueueColdStart();
+
+        new ChromaEmbeddingService().init(project);
+
+        List<RecordedRequest> requests = drainRequests(6);
+        assertThat(requests.get(1).getPath())
+                .as("create-tenant POST must target /api/v2/tenants")
+                .isEqualTo("/api/v2/tenants");
+    }
+
+    @Test
+    void init_coldStart_embeddingStoreIsNonNullAfterInit() throws Exception {
+        enqueueColdStart();
+
+        ChromaEmbeddingService service = new ChromaEmbeddingService();
+        service.init(project);
+
+        assertThat(service.getEmbeddingStore())
+                .as("getEmbeddingStore() must return a non-null store even after cold-start creation")
+                .isNotNull();
+    }
+}


### PR DESCRIPTION
## Summary

- **ChromaDB v2 API migration**: Updates `ChromaDBService` Retrofit interface and `ChromaEmbeddingStore` builder from the deprecated `/api/v1/` paths to `/api/v2/tenants/default_tenant/databases/default_database/...`, fixing the deprecation warnings reported in #1085 and forward-compatibility with ChromaDB 1.x which removes v1 entirely
- **WSL volume path fix**: When IntelliJ runs on Windows with a WSL Linux Docker daemon, the JVM produces a Windows-style path (`C:\Users\...`) the Linux daemon rejects; the path is now converted to `/mnt/c/...` format by detecting the daemon OS via `docker info`
- **Naming cleanup**: Corrects misleading parameter names — `countDocuments` now takes a `collectionId` (UUID, as the v2 count endpoint requires) and `deleteCollection` takes a `collectionName`

## Test plan

- [x] `ChromaDBServiceV2ApiTest` (13 tests) — all three Retrofit endpoints use `/api/v2/` paths with `default_tenant`/`default_database`, never `/api/v1/`
- [x] `ChromaEmbeddingServiceInitV2Test` (12 tests) — `init()` calls correct v2 API paths for both warm-start and cold-start scenarios via MockWebServer
- [x] `ChromaDockerServiceVolumePathTest` (11 tests) — Windows→WSL path conversion covers backslash/forward-slash input, drive-letter casing, null/unknown daemon OS, and the exact path from the bug report
- [x] `ChromeDBValidatorTest` (10 existing tests) — all still pass

Closes #1085

🤖 Generated with [Claude Code](https://claude.com/claude-code)