### PR TITLE
build: migrate to platform-bundled Compose, raise minimum IDE to 2025.3.3

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,9 +4,12 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
     java
-    kotlin("jvm") version "2.1.10"
-    kotlin("plugin.lombok") version "2.1.10"
-    kotlin("plugin.compose") version "2.1.10"
+    // Kotlin 2.2.20 matches the stdlib bundled in IntelliJ 2025.3, the minimum supported IDE.
+    // Do NOT bump beyond the bundled stdlib of the lowest supported IDE line: the plugin runs
+    // on the IDE-provided stdlib (see binaryIncompatibleRuntimeJarPatterns below).
+    kotlin("jvm") version "2.2.20"
+    kotlin("plugin.lombok") version "2.2.20"
+    kotlin("plugin.compose") version "2.2.20"
     id("org.jetbrains.intellij.platform") version "2.13.1"
     jacoco
 }
@@ -36,7 +39,7 @@ val binaryIncompatibleRuntimeJarPatterns = listOf(
 )
 val packagedPluginDirName = "DevoxxGenie"
 val pluginVerifierUnifiedIdeVersions = listOf(
-    "2025.1",             // 251 line — minimum supported (sinceBuild)
+    "2025.3.3",           // 253 line — minimum supported (sinceBuild); first build with CMP 1.10.0 stable (Jewel 0.34)
     "2026.1"              // 261 line
     // "2026.2-EAP-SNAPSHOT" // 262 line — not yet available
 )
@@ -248,7 +251,14 @@ dependencies {
         intellijIdea(providers.gradleProperty("ideVersion").orElse("2025.3.3"))
         bundledPlugin("com.intellij.java")
         bundledPlugin("org.intellij.plugins.markdown")  // Required by markdown renderer
+        // Use the Compose + Skiko runtime BUNDLED in the IDE (Jewel infrastructure, IJP 251+).
+        // The platform guarantees a consistent Compose/Skiko/Kotlin/coroutines set per IDE line:
+        // 2025.3.3+ and 2026.1 both ship Compose Multiplatform 1.10.0. We therefore no longer
+        // package our own Compose or Skiko jars (see the removed runtimeOnly block below).
+        // NOTE: these modules must also be declared in plugin.xml (<dependencies><module .../>).
         composeUI()
+        bundledModule("intellij.libraries.compose.foundation.desktop")
+        bundledModule("intellij.libraries.skiko")
         testFramework(TestFrameworkType.Platform)
     }
     
@@ -262,9 +272,11 @@ dependencies {
     val commonmarkVersion = "0.28.0"
     val jsoupVersion = "1.22.2"
     val nettyVersion = "4.2.13.Final"
-    val composeCompileVersion = "1.7.3"
-    val markdownRendererVersion = "0.28.0"
-    val skikoVersion = "0.8.18"
+    // 0.38.1 is built with Kotlin 2.2.21 / CMP 1.9.2: the newest line that still runs on the
+    // 2.2.20 stdlib bundled in IJ 2025.3. (0.39.x+ requires Kotlin 2.3 stdlib → 261+ only.)
+    // Its CMP-1.9.2-compiled code runs on the platform's CMP 1.10.0 runtime via Compose's
+    // backwards binary compatibility guarantee.
+    val markdownRendererVersion = "0.38.1"
     val logbackVersion = "1.5.32"
     val gitignoreReaderVersion = "1.14.1"
     val junitJupiterVersion = "6.1.0-RC1"
@@ -310,19 +322,29 @@ dependencies {
     implementation("org.commonmark:commonmark:$commonmarkVersion")
     implementation("org.jsoup:jsoup:$jsoupVersion")
     implementation("io.netty:netty-all:$nettyVersion")
-    // Compose Markdown Renderer aligned with the 251 Compose/Kotlin toolchain
+    // Compose Markdown Renderer aligned with the 253 Compose/Kotlin toolchain
     implementation("com.mikepenz:multiplatform-markdown-renderer-jvm:$markdownRendererVersion") {
-        // The IntelliJ Platform provides coroutines at runtime. Bundling our own copy makes the
-        // plugin classloader load kotlinx.coroutines.flow.FlowCollector while the platform loads
-        // SafeCollector, causing a cross-classloader ClassCastException (issue #1054).
+        // The IntelliJ Platform provides coroutines, stdlib, Compose and Skiko at runtime.
+        // Bundling our own copies causes cross-classloader conflicts (issue #1054) and the
+        // Compose/Skiko ABI crashes that motivated the 253 migration.
         exclude(group = "org.jetbrains.kotlinx", module = "kotlinx-coroutines-core")
         exclude(group = "org.jetbrains.kotlinx", module = "kotlinx-coroutines-core-jvm")
         exclude(group = "org.jetbrains", module = "markdown")
+        exclude(group = "org.jetbrains.kotlin", module = "kotlin-stdlib")
+        exclude(group = "org.jetbrains.compose.runtime")
+        exclude(group = "org.jetbrains.compose.foundation")
+        exclude(group = "org.jetbrains.compose.ui")
+        exclude(group = "org.jetbrains.skiko")
     }
     implementation("com.mikepenz:multiplatform-markdown-renderer-code-jvm:$markdownRendererVersion") {
         exclude(group = "org.jetbrains.kotlinx", module = "kotlinx-coroutines-core")
         exclude(group = "org.jetbrains.kotlinx", module = "kotlinx-coroutines-core-jvm")
         exclude(group = "org.jetbrains", module = "markdown")
+        exclude(group = "org.jetbrains.kotlin", module = "kotlin-stdlib")
+        exclude(group = "org.jetbrains.compose.runtime")
+        exclude(group = "org.jetbrains.compose.foundation")
+        exclude(group = "org.jetbrains.compose.ui")
+        exclude(group = "org.jetbrains.skiko")
     }
     // Logging
     implementation("ch.qos.logback:logback-classic:$logbackVersion")
@@ -333,54 +355,13 @@ dependencies {
     implementation("org.junit.jupiter:junit-jupiter-engine:$junitJupiterVersion")
     implementation("org.junit.platform:junit-platform-launcher:$junitPlatformVersion")
 
-    // Compile against and package the 251-era Compose desktop API jars.
-    compileOnly("org.jetbrains.compose.runtime:runtime-desktop:$composeCompileVersion")
-    compileOnly("org.jetbrains.compose.foundation:foundation-desktop:$composeCompileVersion")
-    compileOnly("org.jetbrains.compose.ui:ui-desktop:$composeCompileVersion")
-    compileOnly("org.jetbrains.compose.components:components-animatedimage-desktop:$composeCompileVersion")
-    runtimeOnly("org.jetbrains.compose.runtime:runtime-desktop:$composeCompileVersion") {
-        exclude(group = "org.jetbrains.skiko")
-        exclude(group = "org.jetbrains.kotlin", module = "kotlin-stdlib")
-        exclude(group = "org.jetbrains.kotlin", module = "kotlin-stdlib-jdk7")
-        exclude(group = "org.jetbrains.kotlin", module = "kotlin-stdlib-jdk8")
-        exclude(group = "org.jetbrains.kotlinx", module = "kotlinx-coroutines-core")
-        exclude(group = "org.jetbrains.kotlinx", module = "kotlinx-coroutines-core-jvm")
-    }
-    runtimeOnly("org.jetbrains.compose.foundation:foundation-desktop:$composeCompileVersion") {
-        exclude(group = "org.jetbrains.skiko")
-        exclude(group = "org.jetbrains.kotlin", module = "kotlin-stdlib")
-        exclude(group = "org.jetbrains.kotlin", module = "kotlin-stdlib-jdk7")
-        exclude(group = "org.jetbrains.kotlin", module = "kotlin-stdlib-jdk8")
-        exclude(group = "org.jetbrains.kotlinx", module = "kotlinx-coroutines-core")
-        exclude(group = "org.jetbrains.kotlinx", module = "kotlinx-coroutines-core-jvm")
-    }
-    runtimeOnly("org.jetbrains.compose.ui:ui-desktop:$composeCompileVersion") {
-        exclude(group = "org.jetbrains.skiko")
-        exclude(group = "org.jetbrains.kotlin", module = "kotlin-stdlib")
-        exclude(group = "org.jetbrains.kotlin", module = "kotlin-stdlib-jdk7")
-        exclude(group = "org.jetbrains.kotlin", module = "kotlin-stdlib-jdk8")
-        exclude(group = "org.jetbrains.kotlinx", module = "kotlinx-coroutines-core")
-        exclude(group = "org.jetbrains.kotlinx", module = "kotlinx-coroutines-core-jvm")
-    }
-    runtimeOnly("org.jetbrains.compose.components:components-animatedimage-desktop:$composeCompileVersion") {
-        exclude(group = "org.jetbrains.skiko")
-        exclude(group = "org.jetbrains.kotlin", module = "kotlin-stdlib")
-        exclude(group = "org.jetbrains.kotlin", module = "kotlin-stdlib-jdk7")
-        exclude(group = "org.jetbrains.kotlin", module = "kotlin-stdlib-jdk8")
-        exclude(group = "org.jetbrains.kotlinx", module = "kotlinx-coroutines-core")
-        exclude(group = "org.jetbrains.kotlinx", module = "kotlinx-coroutines-core-jvm")
-    }
-    runtimeOnly("org.jetbrains.skiko:skiko-awt:$skikoVersion") {
-        exclude(group = "org.jetbrains.kotlin", module = "kotlin-stdlib")
-        exclude(group = "org.jetbrains.kotlin", module = "kotlin-stdlib-jdk7")
-        exclude(group = "org.jetbrains.kotlin", module = "kotlin-stdlib-jdk8")
-        exclude(group = "org.jetbrains.kotlinx", module = "kotlinx-coroutines-core")
-        exclude(group = "org.jetbrains.kotlinx", module = "kotlinx-coroutines-core-jvm")
-    }
-    runtimeOnly("org.jetbrains.skiko:skiko-awt-runtime-linux-x64:$skikoVersion")
-    runtimeOnly("org.jetbrains.skiko:skiko-awt-runtime-macos-arm64:$skikoVersion")
-    runtimeOnly("org.jetbrains.skiko:skiko-awt-runtime-macos-x64:$skikoVersion")
-    runtimeOnly("org.jetbrains.skiko:skiko-awt-runtime-windows-x64:$skikoVersion")
+    // Compose & Skiko are NO LONGER bundled with the plugin. Since IJP 251 the platform ships
+    // Compose/Skiko as bundled modules (Jewel infrastructure); 2025.3.3+ and 2026.1 both
+    // provide Compose Multiplatform 1.10.0. Compile classpath comes from composeUI() +
+    // bundledModule(...) in the intellijPlatform block above, and the runtime comes from the
+    // IDE itself — declared in plugin.xml as <module> dependencies. This removes the entire
+    // class of Compose/Skiko ABI mismatches and skiko native double-loading crashes, and
+    // shrinks the plugin distribution.
 
     compileOnly("org.projectlombok:lombok:$lombokVersion")
 
@@ -403,7 +384,11 @@ dependencies {
 intellijPlatform {
     pluginConfiguration {
         ideaVersion {
-            sinceBuild = "251"
+            // 253.31033 = IntelliJ 2025.3.3, the first 253 build shipping Compose Multiplatform
+            // 1.10.0 stable (Jewel 0.34). Earlier 253 builds carry CMP 1.10.0-beta/rc.
+            // 251/252 cannot be supported anymore: they bundle CMP 1.7.x-era runtimes that are
+            // ABI-incompatible with the 1.10 APIs this plugin now compiles against.
+            sinceBuild = "253.31033"
             untilBuild = "262.*"
         }
     }
@@ -427,7 +412,8 @@ intellijPlatform {
     }
 }
 
-// Filter unsupported Compose compiler plugin option (Kotlin 2.1.10 / IntelliJ platform incompatibility)
+// Filter unsupported Compose compiler plugin option (kept from the Kotlin 2.1.x toolchain;
+// harmless with 2.2.x — remove once verified unnecessary on the 253 toolchain)
 afterEvaluate {
     tasks.withType<KotlinCompile>().configureEach {
         val currentArgs = compilerOptions.freeCompilerArgs.get().toList()
@@ -481,9 +467,9 @@ tasks {
             html.required.set(true)
         }
 
-        // IntelliJ 2024.3 ships an older coroutines runtime than Compose 1.10 pulls in.
-        // Keeping the plugin's transitive coroutines jars on the test worker classpath
-        // causes IDE startup to fail inside LightPlatformTestCase before tests execute.
+        // The IDE provides its own coroutines runtime. Keeping the plugin's transitive
+        // coroutines jars on the test worker classpath causes IDE startup to fail inside
+        // LightPlatformTestCase before tests execute.
         classpath = classpath.filter { file ->
             !file.name.startsWith("kotlinx-coroutines-core")
         }

--- a/src/main/kotlin/com/devoxx/genie/ui/compose/components/AiBubble.kt
+++ b/src/main/kotlin/com/devoxx/genie/ui/compose/components/AiBubble.kt
@@ -82,7 +82,7 @@ private fun createHighlightsBuilder(isDark: Boolean): Highlights.Builder =
 private fun codeFenceWithCopy(isDark: Boolean): MarkdownComponent = { model ->
     val codeText = extractCodeText(model.content, model.node)
     Box(modifier = Modifier.fillMaxWidth()) {
-        MarkdownHighlightedCodeFence(model.content, model.node, createHighlightsBuilder(isDark))
+        MarkdownHighlightedCodeFence(model.content, model.node, highlightsBuilder = createHighlightsBuilder(isDark))
         CopyButton(
             textToCopy = codeText,
             modifier = Modifier.align(Alignment.TopEnd).padding(4.dp),
@@ -97,7 +97,7 @@ private fun codeFenceWithCopy(isDark: Boolean): MarkdownComponent = { model ->
 private fun codeBlockWithCopy(isDark: Boolean): MarkdownComponent = { model ->
     val codeText = extractCodeText(model.content, model.node)
     Box(modifier = Modifier.fillMaxWidth()) {
-        MarkdownHighlightedCodeBlock(model.content, model.node, createHighlightsBuilder(isDark))
+        MarkdownHighlightedCodeBlock(model.content, model.node, highlightsBuilder = createHighlightsBuilder(isDark))
         CopyButton(
             textToCopy = codeText,
             modifier = Modifier.align(Alignment.TopEnd).padding(4.dp),
@@ -141,15 +141,13 @@ fun AiBubble(
             val bodySize = typography.bodyFontSize.sp
             val codeSize = typography.codeFontSize.sp
 
+            // markdown-renderer 0.38+: text colors moved into typography TextStyles;
+            // link styling moved to MarkdownTypography.textLink.
             val mdColors = DefaultMarkdownColors(
                 text = textColor,
-                codeText = textColor,
-                inlineCodeText = DevoxxBlue,
-                linkText = DevoxxBlue,
                 codeBackground = codeBg,
                 inlineCodeBackground = codeBg,
                 dividerColor = secondaryColor,
-                tableText = textColor,
                 tableBackground = Color.Transparent,
             )
 
@@ -171,7 +169,8 @@ fun AiBubble(
                 ordered = baseStyle,
                 bullet = baseStyle,
                 list = baseStyle,
-                link = baseStyle.copy(color = DevoxxBlue),
+                textLink = TextLinkStyles(style = SpanStyle(color = DevoxxBlue)),
+                table = baseStyle,
             )
 
             SelectionContainer {

--- a/src/main/kotlin/com/devoxx/genie/ui/compose/components/UserBubble.kt
+++ b/src/main/kotlin/com/devoxx/genie/ui/compose/components/UserBubble.kt
@@ -43,15 +43,13 @@ fun UserBubble(
     val bodySize = typography.bodyFontSize.sp
     val codeSize = typography.codeFontSize.sp
 
+    // markdown-renderer 0.38+: text colors moved into typography TextStyles;
+    // link styling moved to MarkdownTypography.textLink.
     val mdColors = DefaultMarkdownColors(
         text = textColor,
-        codeText = textColor,
-        inlineCodeText = DevoxxOrange,
-        linkText = DevoxxOrange,
         codeBackground = codeBg,
         inlineCodeBackground = codeBg,
         dividerColor = secondaryColor,
-        tableText = textColor,
         tableBackground = Color.Transparent,
     )
 
@@ -73,20 +71,21 @@ fun UserBubble(
         ordered = baseStyle,
         bullet = baseStyle,
         list = baseStyle,
-        link = baseStyle.copy(color = DevoxxOrange),
+        textLink = TextLinkStyles(style = SpanStyle(color = DevoxxOrange)),
+        table = baseStyle,
     )
 
     val highlightsBuilder = Highlights.Builder().theme(SyntaxThemes.default(darkMode = colors.isDark))
 
     val codeFence: com.mikepenz.markdown.compose.components.MarkdownComponent = { model ->
         Box(modifier = Modifier.fillMaxWidth()) {
-            MarkdownHighlightedCodeFence(model.content, model.node, highlightsBuilder)
+            MarkdownHighlightedCodeFence(model.content, model.node, highlightsBuilder = highlightsBuilder)
         }
     }
 
     val codeBlock: com.mikepenz.markdown.compose.components.MarkdownComponent = { model ->
         Box(modifier = Modifier.fillMaxWidth()) {
-            MarkdownHighlightedCodeBlock(model.content, model.node, highlightsBuilder)
+            MarkdownHighlightedCodeBlock(model.content, model.node, highlightsBuilder = highlightsBuilder)
         }
     }
 

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -541,6 +541,14 @@
          Read more: https://plugins.jetbrains.com/docs/intellij/plugin-compatibility.html -->
     <depends>com.intellij.modules.platform</depends>
 
+    <!-- Use the Compose + Skiko runtime bundled in the IDE (Jewel infrastructure).
+         The plugin no longer packages its own Compose/Skiko jars; these modules must match
+         the bundledModule(...) entries in build.gradle.kts. Requires 2025.3.3+ (CMP 1.10.0). -->
+    <dependencies>
+        <module name="intellij.libraries.compose.foundation.desktop"/>
+        <module name="intellij.libraries.skiko"/>
+    </dependencies>
+
     <!-- Extension points defined by the plugin.
          Read more: https://plugins.jetbrains.com/docs/intellij/plugin-extension-points.html -->
     <extensions defaultExtensionNs="com.intellij">


### PR DESCRIPTION
## Why

Upgrading Compose/Skiko crashed the plugin in every IDE. Root cause: the plugin bundled its own Compose 1.7.3 + Skiko 0.8.18, which had to stay ABI-locked to the IntelliJ 2025.1 runtime (Kotlin 2.1 stdlib, old coroutines, Skiko native lib). Any newer pair — including the attempted latest Compose + Skiko 0.148.1, which no Compose release even uses (CMP 1.11.1 pairs with Skiko 0.144.6) — broke at runtime.

## What

- Use the **platform-bundled Compose Multiplatform 1.10.0** (Jewel infrastructure, shipped since 2025.3.3) instead of bundling Compose/Skiko jars
- `sinceBuild` 251 → **253.31033**; Kotlin toolchain 2.1.10 → **2.2.20** (matches 253's bundled stdlib)
- Declare `intellij.libraries.compose.foundation.desktop` + `intellij.libraries.skiko` as plugin.xml module dependencies and Gradle `bundledModule`s
- markdown-renderer 0.28.0 → **0.38.1** (Kotlin 2.2.x line); adapted `AiBubble`/`UserBubble` to the 0.38 API
- Removes the Compose/Skiko exclusion blocks and shrinks the distribution (~50 MB of jars no longer packaged)

## Trade-off

Drops 2025.1/2025.2 support — those IDEs only carry the CMP 1.7.x-era runtime, which is exactly what made any upgrade impossible.

## Testing

- `./gradlew runIde` (2025.3.3) and `./gradlew runIde -PideVersion=2026.1`
- Verify chat markdown rendering: code fences with copy button, links (orange/blue), tables
- `./gradlew test` and `./gradlew verifyPlugin`