### PR TITLE
build: remove duplicate nettyVersion declaration

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -271,7 +271,6 @@ dependencies {
     val jtokkitVersion = "1.1.0"
     val commonmarkVersion = "0.28.0"
     val jsoupVersion = "1.22.2"
-    val nettyVersion = "4.2.13.Final"
     // 0.38.1 is built with Kotlin 2.2.21 / CMP 1.9.2: the newest line that still runs on the
     // 2.2.20 stdlib bundled in IJ 2025.3. (0.39.x+ requires Kotlin 2.3 stdlib → 261+ only.)
     // Its CMP-1.9.2-compiled code runs on the platform's CMP 1.10.0 runtime via Compose's


### PR DESCRIPTION
## Summary

Fixes a Kotlin build-script compilation error introduced by a master merge:

```
Conflicting declarations: local val nettyVersion: String
```

A stale dependabot declaration (`4.2.13.Final`) was left in place alongside the bumped value (`4.2.15.Final`) from commit `78b33c50`, leaving two `val nettyVersion` declarations in `build.gradle.kts`. This removes the stale one and keeps `4.2.15.Final` — the value wired into `io.netty:netty-all`.

## Verification

- `./gradlew buildPlugin` → BUILD SUCCESSFUL (produces `DevoxxGenie-1.7.2.zip`)
- `./gradlew test` → BUILD SUCCESSFUL

🤖 Generated with [Claude Code](https://claude.com/claude-code)