### PR TITLE
feat(task-229): PSI call-graph tools + fine-grained PSI toggles

### DIFF
--- a/backlog/tasks/task-229 - Extend-PSI-agent-tools-with-call-graph-navigation-find_callees-trace_call_chains-complexity-dead_code.md
+++ b/backlog/tasks/task-229 - Extend-PSI-agent-tools-with-call-graph-navigation-find_callees-trace_call_chains-complexity-dead_code.md
@@ -1,10 +1,12 @@
 ---
 id: TASK-229
-title: Extend PSI agent tools with call-graph navigation (find_callees, trace_call_chains, complexity, dead_code)
-status: To Do
+title: >-
+  Extend PSI agent tools with call-graph navigation (find_callees,
+  trace_call_chains, complexity, dead_code)
+status: In Progress
 assignee: []
 created_date: '2026-06-06 12:00'
-updated_date: '2026-06-06 12:00'
+updated_date: '2026-06-08 14:32'
 labels:
   - enhancement
   - agent-tools
@@ -13,13 +15,38 @@ labels:
 dependencies: []
 references:
   - src/main/java/com/devoxx/genie/service/agent/tool/BuiltInToolProvider.java
-  - src/main/java/com/devoxx/genie/service/agent/tool/psi/FindReferencesToolExecutor.java
-  - src/main/java/com/devoxx/genie/service/agent/tool/psi/FindImplementationsToolExecutor.java
-  - src/main/java/com/devoxx/genie/service/agent/tool/psi/FindDefinitionToolExecutor.java
-  - src/main/java/com/devoxx/genie/service/agent/tool/psi/FindSymbolsToolExecutor.java
-  - src/main/java/com/devoxx/genie/service/agent/tool/psi/DocumentSymbolsToolExecutor.java
+  - >-
+    src/main/java/com/devoxx/genie/service/agent/tool/psi/FindReferencesToolExecutor.java
+  - >-
+    src/main/java/com/devoxx/genie/service/agent/tool/psi/FindImplementationsToolExecutor.java
+  - >-
+    src/main/java/com/devoxx/genie/service/agent/tool/psi/FindDefinitionToolExecutor.java
+  - >-
+    src/main/java/com/devoxx/genie/service/agent/tool/psi/FindSymbolsToolExecutor.java
+  - >-
+    src/main/java/com/devoxx/genie/service/agent/tool/psi/DocumentSymbolsToolExecutor.java
   - src/main/java/com/devoxx/genie/service/agent/tool/psi/PsiToolUtils.java
   - 'https://github.com/CodeGraphContext/CodeGraphContext'
+modified_files:
+  - src/main/java/com/devoxx/genie/service/agent/tool/psi/PsiToolUtils.java
+  - >-
+    src/main/java/com/devoxx/genie/service/agent/tool/psi/FindCalleesToolExecutor.java
+  - >-
+    src/main/java/com/devoxx/genie/service/agent/tool/psi/TraceCallChainsToolExecutor.java
+  - >-
+    src/main/java/com/devoxx/genie/service/agent/tool/psi/CalculateComplexityToolExecutor.java
+  - >-
+    src/main/java/com/devoxx/genie/service/agent/tool/psi/FindDeadCodeToolExecutor.java
+  - src/main/java/com/devoxx/genie/service/agent/tool/BuiltInToolProvider.java
+  - >-
+    src/test/java/com/devoxx/genie/service/agent/tool/psi/FindCalleesToolExecutorTest.java
+  - >-
+    src/test/java/com/devoxx/genie/service/agent/tool/psi/TraceCallChainsToolExecutorTest.java
+  - >-
+    src/test/java/com/devoxx/genie/service/agent/tool/psi/CalculateComplexityToolExecutorTest.java
+  - >-
+    src/test/java/com/devoxx/genie/service/agent/tool/psi/FindDeadCodeToolExecutorTest.java
+  - docusaurus/docs/features/agent-mode.md
 priority: medium
 ---
 
@@ -59,34 +86,31 @@ What CGC has that we **don't** yet, and that is cheap to add on top of PSI / the
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 `find_callees` tool registered in `BuiltInToolProvider.registerPsiTools`: given `file` + `line` of a method definition (with optional `symbol` disambiguator), returns the resolved outgoing method calls with their definition locations, bounded to a `MAX_RESULTS` cap
-- [ ] #2 `trace_call_chains` tool registered: given a start symbol (file + line), an optional target symbol, a `direction` (`callers` | `callees`, default `callers`), and a bounded `depth` (default 5, hard max 10), returns the call path(s) found, capped in both depth and number of paths
-- [ ] #3 `calculate_complexity` tool registered: given a `file` (and optional `line` to target a single method), returns per-method cyclomatic complexity scores and flags methods exceeding a configurable threshold
-- [ ] #4 `find_dead_code` tool registered: returns symbols with zero project-scope references, clearly labelled as heuristic "candidates", with documented exclusions (entry points, `@Override`, public API, framework-annotated, reflection/serialization, tests)
-- [ ] #5 All four tools run inside a `ReadAction`, reuse `PsiToolUtils` helpers (`resolvePsiFile`, `findNamedElementOnLine`, `formatLocation`, `getProjectBase`), and return the same friendly `Error: ...` strings on bad input as the existing PSI tools — never throw to the LLM
-- [ ] #6 All four tools are gated behind `psiToolsEnabled` and honour the `disabledAgentTools` list, matching the existing PSI tool registration
-- [ ] #7 Languages without call-body/complexity support return a clear "not supported for <language>" message rather than failing; Java is supported in v1 (Kotlin via UAST if feasible within scope)
-- [ ] #8 Unit/platform tests (extending `AbstractLightPlatformTestCase`, mirroring existing PSI tool tests) cover, per supported language fixture: callees of a method are resolved; a known caller chain is traced within the depth bound; complexity of a method with known decision points matches the expected count; an unreferenced private method is reported as dead-code candidate while an `@Override`/entry-point method is not
-- [ ] #9 Tool descriptions explain when to prefer each tool over `search_files`/`find_references`, and the `find_dead_code` description states results are candidates requiring human confirmation
+- [x] #1 `find_callees` tool registered in `BuiltInToolProvider.registerPsiTools`: given `file` + `line` of a method definition (with optional `symbol` disambiguator), returns the resolved outgoing method calls with their definition locations, bounded to a `MAX_RESULTS` cap
+- [x] #2 `trace_call_chains` tool registered: given a start symbol (file + line), an optional target symbol, a `direction` (`callers` | `callees`, default `callers`), and a bounded `depth` (default 5, hard max 10), returns the call path(s) found, capped in both depth and number of paths
+- [x] #3 `calculate_complexity` tool registered: given a `file` (and optional `line` to target a single method), returns per-method cyclomatic complexity scores and flags methods exceeding a configurable threshold
+- [x] #4 `find_dead_code` tool registered: returns symbols with zero project-scope references, clearly labelled as heuristic "candidates", with documented exclusions (entry points, `@Override`, public API, framework-annotated, reflection/serialization, tests)
+- [x] #5 All four tools run inside a `ReadAction`, reuse `PsiToolUtils` helpers (`resolvePsiFile`, `findNamedElementOnLine`, `formatLocation`, `getProjectBase`), and return the same friendly `Error: ...` strings on bad input as the existing PSI tools — never throw to the LLM
+- [x] #6 All four tools are gated behind `psiToolsEnabled` and honour the `disabledAgentTools` list, matching the existing PSI tool registration
+- [x] #7 Languages without call-body/complexity support return a clear "not supported for <language>" message rather than failing; Java is supported in v1 (Kotlin via UAST if feasible within scope)
+- [x] #8 Unit/platform tests (extending `AbstractLightPlatformTestCase`, mirroring existing PSI tool tests) cover, per supported language fixture: callees of a method are resolved; a known caller chain is traced within the depth bound; complexity of a method with known decision points matches the expected count; an unreferenced private method is reported as dead-code candidate while an `@Override`/entry-point method is not
+- [x] #9 Tool descriptions explain when to prefer each tool over `search_files`/`find_references`, and the `find_dead_code` description states results are candidates requiring human confirmation
 <!-- AC:END -->
 
 ## Implementation Notes
 
 <!-- SECTION:NOTES:BEGIN -->
-Origin: feasibility investigation of CodeGraphContext (CGC). Verdict was "extend PSI, don't port CGC" — PSI already is a live code graph inside the IDE, and it is more accurate than CGC's tree-sitter heuristics for the indexed project. This task captures the genuinely-missing call-graph *direction* and *analysis* primitives.
+Implemented four new PSI ToolExecutors under service/agent/tool/psi/, registered in BuiltInToolProvider.registerPsiTools (gated by psiToolsEnabled; disabledAgentTools honoured automatically by provideTools).
 
-Follow the existing pattern exactly:
-- One `ToolExecutor` per tool under `service/agent/tool/psi/`, registered in `BuiltInToolProvider.registerPsiTools`.
-- Reuse `PsiToolUtils` for file/element resolution and location formatting; copy the `MAX_RESULTS` bounding and `ReadAction.compute(...)` wrapping from `FindReferencesToolExecutor`.
-- Guard optional language support with a reflection check like `JavaProjectScannerExtension.isJavaAvailable()` so the plugin still loads when a language plugin is absent.
+Key decisions:
+- Java only in v1 (per AC #7). Each tool guards with PsiToolUtils.isJavaAvailable() (reflection on JavaPsiFacade) + isJavaFile() (language ID == "JAVA"), returning a clear "not supported for <language>" message otherwise. Java is an OPTIONAL plugin dependency (<depends optional="true">com.intellij.modules.java</depends>), so Java-PSI calls are isolated in helper methods invoked only after the guard — lazy classloading keeps the executors loadable in non-Java IDEs. Kotlin-via-UAST deferred to a follow-up.
+- trace_call_chains: implemented as a depth/path/node-bounded DFS over PSI primitives (ReferencesSearch for caller direction, method-body call resolution for callee direction) rather than the UI-bound com.intellij.ide.hierarchy.call API, which is fragile headlessly inside a ReadAction. Bounds: depth default 5 / hard max 10, MAX_PATHS=20, NODE_BUDGET=500. Optional target stops early.
+- find_dead_code: scoped per-file (bounded, matches existing per-file PSI tools) rather than whole-project. Conservative exclusions (public, constructors/main, @Override + any annotation, serialization members) to minimise false positives; output explicitly labelled heuristic CANDIDATES.
+- calculate_complexity: McCabe count via PsiTreeUtil collection of decision points (if/for/foreach/while/do/case/catch/ternary/&&/||); complexityOf(PsiMethod) is package-visible static for direct unit testing.
 
-Suggested building blocks:
-- `find_callees`: walk the target `PsiMethod` body for `PsiMethodCallExpression`/`PsiCallExpression`, call `.resolveMethod()`, dedupe, format target locations. For Kotlin, prefer UAST (`UMethod`/`UCallExpression`) so the same executor can serve both.
-- `trace_call_chains`: use `com.intellij.ide.hierarchy.call.{CallerMethodsTreeStructure,CalleeMethodsTreeStructure}` (or `CallHierarchyProvider`) and BFS/DFS with the depth + path caps. Stop early if the optional target symbol is reached and return that path.
-- `calculate_complexity`: a `PsiRecursiveElementVisitor` counting decision points; start complexity at 1 and increment per branch/loop/case/catch/boolean-operator/ternary. Keep the rule set documented in code.
-- `find_dead_code`: enumerate declared symbols in scope, run `ReferencesSearch.search(..., GlobalSearchScope.projectScope(project))`, report zero-reference symbols minus the exclusion set. Be conservative — false positives erode trust, so label as candidates.
+Testing: 27 fixture+validation tests (BasePlatformTestCase + Jupiter @Test, with @AfterEach tearDown() to avoid platform injector-leak failures). All pass; full suite green.
 
-Validation strategy mirrors CGC's own tools but stays IDE-native. Consider whether `trace_call_chains` and `find_dead_code` should be opt-in (heavier) versus `find_callees`/`calculate_complexity` (cheap), but default to gating all four behind the single existing `psiToolsEnabled` flag for simplicity; revisit per-tool toggles only if performance demands it.
+Added docs to docusaurus/docs/features/agent-mode.md (tool table + per-tool sections). NOTE: the requested docs note that power users wanting CGC's graph for polyglot/non-indexed repos can run codegraphcontext as an external MCP server was NOT yet added — capture in a follow-up docs PR.
 
-Separately (not code in this task): add a short docs note that power users wanting CGC's graph for **polyglot or non-indexed** repos, or its web graph visualization, can run `codegraphcontext` as an external MCP server and point DevoxxGenie's MCP client at it — no migration required.
+Docs note for CGC-as-external-MCP (polyglot/non-indexed repos) WAS added — admonition in docusaurus/docs/features/agent-mode.md linking to mcp_expanded.md. (Supersedes the earlier 'NOT yet added' line above.)
 <!-- SECTION:NOTES:END -->

--- a/docs/superpowers/specs/2026-06-09-fine-grained-psi-tools-design.md
+++ b/docs/superpowers/specs/2026-06-09-fine-grained-psi-tools-design.md
@@ -1,0 +1,96 @@
+# Fine-grained PSI tool control — Design
+
+**Date:** 2026-06-09
+**Task:** task-229 (Extend PSI agent tools with call-graph navigation)
+**Status:** Approved
+
+## Problem
+
+The Agent settings expose a single master checkbox, **"Enable PSI Tools"**, that turns
+all PSI (Program Structure Interface) code-intelligence tools on or off as a group. Its
+label is also stale: it enumerates only the original five tools
+(`find_symbols`, `document_symbols`, `find_references`, `find_definition`,
+`find_implementations`) and omits the four added under task-229
+(`find_callees`, `trace_call_chains`, `calculate_complexity`, `find_dead_code`).
+
+Developers want **fine-grained control** — the ability to enable/disable each PSI tool
+individually — and the new tools must be listed.
+
+## Key insight
+
+The enforcement plumbing already exists. `BuiltInToolProvider.provideTools()` filters
+**every** registered tool (PSI tools included, since they share the same `tools` map)
+against the `disabledAgentTools` list:
+
+```java
+for (Map.Entry<ToolSpecification, ToolExecutor> entry : tools.entrySet()) {
+    if (!disabledSet.contains(entry.getKey().name())) {
+        builder.add(entry.getKey(), entry.getValue());
+    }
+}
+```
+
+The "Built-in Tools" settings section already renders per-tool checkboxes wired to that
+same `disabledAgentTools` list via the `toolCheckboxes` map. `apply()`, `isModified()`,
+and `reset()` all derive `disabledAgentTools` by iterating `toolCheckboxes`.
+
+Therefore this is a **UI-only** change. No change to `BuiltInToolProvider`, and no new
+state field.
+
+## Scope
+
+- **In scope:** `AgentSettingsComponent` PSI section UI.
+- **Out of scope:** `BuiltInToolProvider`, `DevoxxGenieStateService` schema, any change to
+  the PSI tool executors themselves.
+
+## Behavior
+
+- The master **"Enable PSI Tools"** checkbox keeps its current meaning: when off,
+  `registerPsiTools()` is never called, so no PSI tool is registered (group gate).
+  Its label drops the stale parenthetical tool list.
+- Below it, **9 indented per-tool checkboxes** — one per PSI tool — each with a short
+  description:
+  - `find_symbols` — search definitions
+  - `document_symbols` — list file structure
+  - `find_references` — find usages
+  - `find_definition` — go to definition
+  - `find_implementations` — find interface/class implementations
+  - `find_callees` — outgoing calls from a method
+  - `trace_call_chains` — caller/callee call paths
+  - `calculate_complexity` — cyclomatic complexity
+  - `find_dead_code` — unreferenced-symbol candidates
+- Unchecking a sub-tool adds its name to `disabledAgentTools` →
+  `provideTools()` filters it out on the next agent run.
+- When the master is **off**, the 9 sub-checkboxes grey out (`setEnabled(false)`) but keep
+  their checked-state, so per-tool preferences survive toggling the group off and on.
+
+## Implementation approach
+
+1. Add a `PSI_TOOLS` `String[][]` constant (tool name + short description) mirroring the
+   existing `CORE_AGENT_TOOLS`.
+2. In the PSI settings section, after the master checkbox, loop `PSI_TOOLS` creating an
+   **indented** `JBCheckBox` for each, initialized from `!disabledSet.contains(name)`, and
+   register it in the **same `toolCheckboxes` map** the Built-in Tools section uses.
+3. Add an `ItemListener` on the master checkbox to enable/disable the 9 sub-checkboxes;
+   set their initial enabled-state from the master's loaded value.
+4. `apply()` / `isModified()` / `reset()` require **no changes** — they already iterate
+   `toolCheckboxes`. The master `psiToolsEnabled` modified-check also already exists.
+5. Add a small indented-row helper (or reuse `addFullWidthRow` with a left inset).
+
+## Testing
+
+- State round-trip test: an unchecked PSI sub-tool ends up in `disabledAgentTools` after
+  `apply()`, and a re-check removes it; `isModified()` flips correctly.
+- `provideTools()` filtering of disabled PSI tools is already exercised by the existing
+  disabled-tool filter; add an assertion that a disabled PSI tool name is excluded from
+  the provided tools.
+- UI layout (indentation, grey-out) is verified manually in `runIde`; not unit-tested.
+
+## Risks / notes
+
+- The `disabledAgentTools` list is shared between the Built-in Tools and PSI sections.
+  Registering PSI checkboxes into the same `toolCheckboxes` map is what makes the shared
+  `apply()`/`isModified()`/`reset()` correct; do **not** introduce a separate map (it would
+  cause `apply()` to clobber one section's entries).
+- No migration needed: existing installs have `psiToolsEnabled=true` and an empty/unrelated
+  `disabledAgentTools`, so all PSI sub-tools render as checked by default.

--- a/docusaurus/docs/features/agent-mode.md
+++ b/docusaurus/docs/features/agent-mode.md
@@ -34,6 +34,10 @@ When Agent Mode is enabled, the LLM gains access to a set of **built-in tools** 
 | `find_references` | Find all usages of a symbol using semantic reference search |
 | `find_definition` | Navigate from a symbol usage to its definition |
 | `find_implementations` | Find all implementations of an interface, abstract class, or method |
+| `find_callees` | List the methods a given method calls (outgoing edges — the inverse of `find_references`) |
+| `trace_call_chains` | Trace caller→callee (or callee→caller) chains between methods, depth-bounded |
+| `calculate_complexity` | Compute cyclomatic complexity per method and flag methods over a threshold |
+| `find_dead_code` | Report unreferenced symbols as heuristic dead-code *candidates* (require human confirmation) |
 
 ### Write Tools
 
@@ -164,6 +168,30 @@ Find all implementations of an interface, abstract class, or abstract method. Us
 
 **Example prompt**: *"Find all implementations of ChatModelFactory"*
 
+#### `find_callees`
+
+List the methods a given method calls — the **outgoing** edges of the call graph, and the inverse of `find_references`. Each call target is resolved through the semantic index, so overloads and inheritance are understood (more accurate than grepping the method body). Java in v1; other languages return a clear "not supported" message.
+
+**Example prompt**: *"What methods does executeQuery call?"*
+
+#### `trace_call_chains`
+
+Trace call chains from a start method, walking caller→callee or callee→caller edges up to a bounded depth, and return the path(s). Answers "how does execution reach X" or "what chain of calls does X trigger" — questions a single `find_references`/`find_callees` call can't. Bounded in depth (default 5, max 10) and number of paths. Java in v1.
+
+**Example prompt**: *"Trace how a user prompt reaches the streaming executor"*
+
+#### `calculate_complexity`
+
+Compute cyclomatic (McCabe) complexity per Java method by counting decision points (`if`/`for`/`while`/`case`/`catch`/`&&`/`||`/ternary), flagging methods over a configurable threshold (default 10). Useful for finding the riskiest methods to refactor or test.
+
+**Example prompt**: *"Which methods in PromptExecutionService are the most complex?"*
+
+#### `find_dead_code`
+
+Report symbols in a file with zero project-scope references as **heuristic dead-code candidates** — never certainties. Reflection, serialization, dependency injection, and out-of-project callers are invisible to reference search, so every result requires human confirmation. Conservatively excludes public members, constructors/`main`, `@Override` and any annotated member, and serialization members to keep false positives low. Java in v1.
+
+**Example prompt**: *"Are there any unused private methods in this file?"*
+
 ### Why PSI Tools Matter
 
 With PSI tools, the agent can navigate your codebase the same way you do in the IDE — jumping to definitions, finding usages, and exploring type hierarchies. This is significantly more accurate than text-based grep for tasks like:
@@ -179,6 +207,10 @@ PSI tools are **enabled by default**. You can toggle them in **Settings > Tools 
 
 :::tip
 PSI tools are read-only and don't require user approval. They are also available to parallel sub-agents for deeper exploration.
+:::
+
+:::note Polyglot or non-indexed repositories
+PSI tools (including the call-graph tools) operate on IntelliJ's live semantic index, so they are most accurate for languages your IDE indexes — and `find_callees`, `trace_call_chains`, `calculate_complexity`, and `find_dead_code` are Java-only in v1. If you need a cross-language code graph for **polyglot** or **non-indexed** repositories (or a web graph visualization), you can run [CodeGraphContext](https://github.com/CodeGraphContext/CodeGraphContext) as an external MCP server and point DevoxxGenie's [MCP client](mcp_expanded.md) at it — no migration required. For the indexed project itself, the built-in PSI tools are preferred: they ride a live, language-aware index rather than a separately-maintained graph DB.
 :::
 
 ---

--- a/src/main/java/com/devoxx/genie/service/agent/tool/BuiltInToolProvider.java
+++ b/src/main/java/com/devoxx/genie/service/agent/tool/BuiltInToolProvider.java
@@ -336,6 +336,86 @@ public class BuiltInToolProvider implements ToolProvider {
                         .build(),
                 new FindImplementationsToolExecutor(project)
         );
+
+        // find_callees — outgoing calls from a method (inverse of find_references)
+        tools.put(
+                ToolSpecification.builder()
+                        .name("find_callees")
+                        .description("List the methods that a given method calls (outgoing edges). " +
+                                "This is the inverse of find_references: find_references answers 'who calls X', " +
+                                "find_callees answers 'what does X call'. Each call target is resolved through the " +
+                                "IDE's semantic index, so overloads, inheritance, and imports are understood — more " +
+                                "accurate than grepping the method body with search_files. " +
+                                "Currently supports Java; other languages return a clear 'not supported' message.")
+                        .parameters(JsonObjectSchema.builder()
+                                .addStringProperty("file", "File path relative to project root where the method is defined")
+                                .addIntegerProperty("line", "1-based line number where the method is declared")
+                                .addStringProperty("symbol", "Optional: method name to disambiguate if multiple definitions are on the same line")
+                                .required("file", "line")
+                                .build())
+                        .build(),
+                new FindCalleesToolExecutor(project)
+        );
+
+        // trace_call_chains — bounded traversal of caller/callee edges
+        tools.put(
+                ToolSpecification.builder()
+                        .name("trace_call_chains")
+                        .description("Trace call chains from a start method, walking caller→callee or callee→caller " +
+                                "edges up to a bounded depth, and return the path(s). Use this to answer 'how does " +
+                                "execution reach X' or 'what chain of calls does X trigger' — questions that need the " +
+                                "path between two methods, which a single find_references/find_callees call cannot give. " +
+                                "Provide an optional 'target' to stop as soon as a named method is reached. " +
+                                "Bounded in depth (default 5, hard max 10) and number of paths. Java only in v1.")
+                        .parameters(JsonObjectSchema.builder()
+                                .addStringProperty("file", "File path relative to project root where the start method is defined")
+                                .addIntegerProperty("line", "1-based line number where the start method is declared")
+                                .addStringProperty("symbol", "Optional: method name to disambiguate if multiple definitions are on the same line")
+                                .addStringProperty("direction", "'callers' (who reaches this method, default) or 'callees' (what this method reaches)")
+                                .addStringProperty("target", "Optional: stop and return the chain when a method with this name is reached")
+                                .addIntegerProperty("depth", "Maximum chain depth (default 5, hard max 10)")
+                                .required("file", "line")
+                                .build())
+                        .build(),
+                new TraceCallChainsToolExecutor(project)
+        );
+
+        // calculate_complexity — cyclomatic complexity per method
+        tools.put(
+                ToolSpecification.builder()
+                        .name("calculate_complexity")
+                        .description("Compute cyclomatic (McCabe) complexity for Java methods by counting decision " +
+                                "points (if/for/while/case/catch/&&/||/ternary). With 'line' it scores a single " +
+                                "method; without it, scores every method in the file and flags those over a " +
+                                "threshold. Use this to find the riskiest methods to refactor or test — something " +
+                                "search_files cannot measure. Java only in v1.")
+                        .parameters(JsonObjectSchema.builder()
+                                .addStringProperty("file", "File path relative to project root")
+                                .addIntegerProperty("line", "Optional: 1-based line of a single method to score; omit to score the whole file")
+                                .addIntegerProperty("threshold", "Optional: flag methods whose complexity exceeds this (default 10)")
+                                .required("file")
+                                .build())
+                        .build(),
+                new CalculateComplexityToolExecutor(project)
+        );
+
+        // find_dead_code — zero-reference symbols (heuristic candidates)
+        tools.put(
+                ToolSpecification.builder()
+                        .name("find_dead_code")
+                        .description("Report symbols in a file with zero project-scope references — HEURISTIC " +
+                                "dead-code CANDIDATES, not certainties. Results require human confirmation before " +
+                                "deletion: reflection, serialization, dependency injection, and out-of-project " +
+                                "callers can reference a symbol invisibly. Conservatively excludes public members, " +
+                                "constructors/main, @Override and any annotated member, and serialization members " +
+                                "to keep false positives low. Java only in v1.")
+                        .parameters(JsonObjectSchema.builder()
+                                .addStringProperty("file", "File path relative to project root to scan for unreferenced symbols")
+                                .required("file")
+                                .build())
+                        .build(),
+                new FindDeadCodeToolExecutor(project)
+        );
     }
 
     private void registerBacklogTools(@NotNull Project project) {

--- a/src/main/java/com/devoxx/genie/service/agent/tool/psi/CalculateComplexityToolExecutor.java
+++ b/src/main/java/com/devoxx/genie/service/agent/tool/psi/CalculateComplexityToolExecutor.java
@@ -1,0 +1,149 @@
+package com.devoxx.genie.service.agent.tool.psi;
+
+import com.devoxx.genie.service.agent.tool.ToolArgumentParser;
+import com.intellij.openapi.application.ReadAction;
+import com.intellij.openapi.project.Project;
+import com.intellij.psi.JavaTokenType;
+import com.intellij.psi.PsiCatchSection;
+import com.intellij.psi.PsiConditionalExpression;
+import com.intellij.psi.PsiDoWhileStatement;
+import com.intellij.psi.PsiFile;
+import com.intellij.psi.PsiForStatement;
+import com.intellij.psi.PsiForeachStatement;
+import com.intellij.psi.PsiIfStatement;
+import com.intellij.psi.PsiMethod;
+import com.intellij.psi.PsiNameIdentifierOwner;
+import com.intellij.psi.PsiPolyadicExpression;
+import com.intellij.psi.PsiSwitchLabelStatementBase;
+import com.intellij.psi.PsiWhileStatement;
+import com.intellij.psi.util.PsiTreeUtil;
+import dev.langchain4j.agent.tool.ToolExecutionRequest;
+import dev.langchain4j.service.tool.ToolExecutor;
+import lombok.extern.slf4j.Slf4j;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * PSI-based tool that computes cyclomatic complexity for Java methods by counting
+ * decision points over the PSI tree. With a {@code line} it targets a single method;
+ * otherwise it scores every method in the file and flags those over a threshold.
+ *
+ * <p>Complexity counting rule (McCabe), starting at 1 and adding one for each:
+ * {@code if}, {@code for}, {@code foreach}, {@code while}, {@code do/while},
+ * each non-default {@code case} label, each {@code catch}, the ternary {@code ?:},
+ * and each {@code &&} / {@code ||} operator. Decision points inside nested
+ * anonymous classes/lambdas are included in the enclosing method's score. Java only in v1.
+ */
+@Slf4j
+public class CalculateComplexityToolExecutor implements ToolExecutor {
+
+    private static final int DEFAULT_THRESHOLD = 10;
+
+    private final Project project;
+
+    public CalculateComplexityToolExecutor(@NotNull Project project) {
+        this.project = project;
+    }
+
+    @Override
+    public String execute(ToolExecutionRequest request, Object memoryId) {
+        try {
+            String file = ToolArgumentParser.getString(request.arguments(), "file");
+            int line = ToolArgumentParser.getInt(request.arguments(), "line", -1);
+            int threshold = ToolArgumentParser.getInt(request.arguments(), "threshold", DEFAULT_THRESHOLD);
+
+            if (file == null || file.isBlank()) {
+                return "Error: 'file' parameter is required.";
+            }
+            int effectiveThreshold = threshold > 0 ? threshold : DEFAULT_THRESHOLD;
+
+            return ReadAction.compute(() -> compute(file, line, effectiveThreshold));
+        } catch (Exception e) {
+            log.error("Error calculating complexity", e);
+            return "Error: Failed to calculate complexity - " + e.getMessage();
+        }
+    }
+
+    private @NotNull String compute(String filePath, int line, int threshold) {
+        PsiFile psiFile = PsiToolUtils.resolvePsiFile(project, filePath);
+        if (psiFile == null) {
+            return "Error: File not found or cannot be parsed: " + filePath;
+        }
+
+        if (!PsiToolUtils.isJavaAvailable() || !PsiToolUtils.isJavaFile(psiFile)) {
+            return "calculate_complexity is not supported for " + PsiToolUtils.languageName(psiFile)
+                    + " in this version (Java only).";
+        }
+
+        List<PsiMethod> methods = new ArrayList<>();
+        if (line >= 1) {
+            PsiNameIdentifierOwner owner = PsiToolUtils.findNamedElementOnLine(psiFile, line, null);
+            if (!(owner instanceof PsiMethod method)) {
+                return "Error: No method definition found at " + filePath + ":" + line + ".";
+            }
+            methods.add(method);
+        } else {
+            methods.addAll(PsiTreeUtil.collectElementsOfType(psiFile, PsiMethod.class));
+        }
+
+        if (methods.isEmpty()) {
+            return "No methods found in " + filePath + ".";
+        }
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("Cyclomatic complexity for ").append(filePath)
+                .append(" (threshold ").append(threshold).append("):\n\n");
+        int flagged = 0;
+        for (PsiMethod method : methods) {
+            int complexity = complexityOf(method);
+            boolean over = complexity > threshold;
+            if (over) flagged++;
+            sb.append("  ").append(over ? "⚠ " : "  ")
+                    .append(signature(method)).append("  →  ").append(complexity)
+                    .append(over ? "  (over threshold)" : "")
+                    .append("\n");
+        }
+        if (line < 1) {
+            sb.append("\n").append(flagged).append(" of ").append(methods.size())
+                    .append(" method(s) exceed the threshold of ").append(threshold).append(".");
+        }
+        return sb.toString();
+    }
+
+    /**
+     * McCabe cyclomatic complexity over a single method's subtree. Starts at 1 and
+     * adds one decision point per branch/loop/case/catch/ternary, plus one per
+     * {@code &&}/{@code ||} operator (an N-operand chain contributes N-1).
+     */
+    static int complexityOf(@NotNull PsiMethod method) {
+        int complexity = 1;
+        complexity += PsiTreeUtil.collectElementsOfType(method, PsiIfStatement.class).size();
+        complexity += PsiTreeUtil.collectElementsOfType(method, PsiForStatement.class).size();
+        complexity += PsiTreeUtil.collectElementsOfType(method, PsiForeachStatement.class).size();
+        complexity += PsiTreeUtil.collectElementsOfType(method, PsiWhileStatement.class).size();
+        complexity += PsiTreeUtil.collectElementsOfType(method, PsiDoWhileStatement.class).size();
+        complexity += PsiTreeUtil.collectElementsOfType(method, PsiCatchSection.class).size();
+        complexity += PsiTreeUtil.collectElementsOfType(method, PsiConditionalExpression.class).size();
+
+        for (PsiSwitchLabelStatementBase label : PsiTreeUtil.collectElementsOfType(method, PsiSwitchLabelStatementBase.class)) {
+            if (!label.isDefaultCase()) complexity++;
+        }
+        for (PsiPolyadicExpression expr : PsiTreeUtil.collectElementsOfType(method, PsiPolyadicExpression.class)) {
+            if (expr.getOperationTokenType() == JavaTokenType.ANDAND
+                    || expr.getOperationTokenType() == JavaTokenType.OROR) {
+                complexity += expr.getOperands().length - 1;
+            }
+        }
+        return complexity;
+    }
+
+    private @NotNull String signature(@NotNull PsiMethod method) {
+        String owner = method.getContainingClass() != null && method.getContainingClass().getName() != null
+                ? method.getContainingClass().getName() + "."
+                : "";
+        int paramCount = method.getParameterList().getParametersCount();
+        return owner + method.getName() + "(" + paramCount + " param" + (paramCount == 1 ? "" : "s") + ")";
+    }
+}

--- a/src/main/java/com/devoxx/genie/service/agent/tool/psi/FindCalleesToolExecutor.java
+++ b/src/main/java/com/devoxx/genie/service/agent/tool/psi/FindCalleesToolExecutor.java
@@ -1,0 +1,131 @@
+package com.devoxx.genie.service.agent.tool.psi;
+
+import com.devoxx.genie.service.agent.tool.ToolArgumentParser;
+import com.intellij.openapi.application.ReadAction;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.psi.PsiCallExpression;
+import com.intellij.psi.PsiFile;
+import com.intellij.psi.PsiMethod;
+import com.intellij.psi.PsiNameIdentifierOwner;
+import com.intellij.psi.util.PsiTreeUtil;
+import dev.langchain4j.agent.tool.ToolExecutionRequest;
+import dev.langchain4j.service.tool.ToolExecutor;
+import lombok.extern.slf4j.Slf4j;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * PSI-based tool that lists the methods called (outgoing edges) from a method
+ * defined at a given file and line. This is the inverse of {@code find_references}:
+ * where {@code find_references} answers "who calls X", {@code find_callees} answers
+ * "what does X call". Each call target is resolved through the IDE's semantic index,
+ * so it understands overloads, inheritance, and imports.
+ *
+ * <p>v1 supports Java. Other languages return a clear "not supported" message.
+ */
+@Slf4j
+public class FindCalleesToolExecutor implements ToolExecutor {
+
+    private static final int MAX_RESULTS = 50;
+
+    private final Project project;
+
+    public FindCalleesToolExecutor(@NotNull Project project) {
+        this.project = project;
+    }
+
+    @Override
+    public String execute(ToolExecutionRequest request, Object memoryId) {
+        try {
+            String file = ToolArgumentParser.getString(request.arguments(), "file");
+            int line = ToolArgumentParser.getInt(request.arguments(), "line", -1);
+            String symbol = ToolArgumentParser.getString(request.arguments(), "symbol");
+
+            if (file == null || file.isBlank()) {
+                return "Error: 'file' parameter is required.";
+            }
+            if (line < 1) {
+                return "Error: 'line' parameter is required (1-based line number of the method).";
+            }
+
+            return ReadAction.compute(() -> findCallees(file, line, symbol));
+        } catch (Exception e) {
+            log.error("Error finding callees", e);
+            return "Error: Failed to find callees - " + e.getMessage();
+        }
+    }
+
+    private @NotNull String findCallees(String filePath, int line, String symbol) {
+        VirtualFile projectBase = PsiToolUtils.getProjectBase(project);
+        if (projectBase == null) {
+            return "Error: Project base directory not found.";
+        }
+
+        PsiFile psiFile = PsiToolUtils.resolvePsiFile(project, filePath);
+        if (psiFile == null) {
+            return "Error: File not found or cannot be parsed: " + filePath;
+        }
+
+        if (!PsiToolUtils.isJavaAvailable() || !PsiToolUtils.isJavaFile(psiFile)) {
+            return "find_callees is not supported for " + PsiToolUtils.languageName(psiFile)
+                    + " in this version (Java only). Use find_references for caller direction across languages.";
+        }
+
+        PsiNameIdentifierOwner target = PsiToolUtils.findNamedElementOnLine(psiFile, line, symbol);
+        if (!(target instanceof PsiMethod method)) {
+            return "Error: No method definition found at " + filePath + ":" + line
+                    + (symbol != null ? " matching '" + symbol + "'" : "")
+                    + ". Ensure the line contains a method declaration.";
+        }
+
+        return collectCallees(method, filePath, line, projectBase);
+    }
+
+    private @NotNull String collectCallees(@NotNull PsiMethod method,
+                                           String filePath,
+                                           int line,
+                                           @NotNull VirtualFile projectBase) {
+        // Preserve first-seen order while deduping by resolved target.
+        Map<PsiMethod, String> calleeToLocation = new LinkedHashMap<>();
+
+        for (PsiCallExpression call : PsiTreeUtil.collectElementsOfType(method, PsiCallExpression.class)) {
+            if (calleeToLocation.size() >= MAX_RESULTS) break;
+
+            PsiMethod callee = call.resolveMethod();
+            if (callee == null || calleeToLocation.containsKey(callee)) continue;
+
+            String location = PsiToolUtils.formatLocation(
+                    callee.getNameIdentifier() != null ? callee.getNameIdentifier() : callee, projectBase);
+            String signature = describe(callee);
+            calleeToLocation.put(callee, location != null
+                    ? signature + "  " + location
+                    : signature + "  (no source — library/binary)");
+        }
+
+        if (calleeToLocation.isEmpty()) {
+            return "No resolved method calls found in '" + method.getName() + "' at " + filePath + ":" + line + ".";
+        }
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("'").append(method.getName()).append("' calls ")
+                .append(calleeToLocation.size()).append(" distinct method(s):\n\n");
+        for (String entry : calleeToLocation.values()) {
+            sb.append("  ").append(entry).append("\n");
+        }
+        if (calleeToLocation.size() >= MAX_RESULTS) {
+            sb.append("\n... (truncated at ").append(MAX_RESULTS).append(" results)");
+        }
+        return sb.toString();
+    }
+
+    private @NotNull String describe(@NotNull PsiMethod callee) {
+        PsiMethod containing = callee;
+        String owner = (containing.getContainingClass() != null)
+                ? containing.getContainingClass().getName() + "."
+                : "";
+        return owner + callee.getName() + "()";
+    }
+}

--- a/src/main/java/com/devoxx/genie/service/agent/tool/psi/FindDeadCodeToolExecutor.java
+++ b/src/main/java/com/devoxx/genie/service/agent/tool/psi/FindDeadCodeToolExecutor.java
@@ -1,0 +1,163 @@
+package com.devoxx.genie.service.agent.tool.psi;
+
+import com.devoxx.genie.service.agent.tool.ToolArgumentParser;
+import com.intellij.openapi.application.ReadAction;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.psi.PsiClass;
+import com.intellij.psi.PsiField;
+import com.intellij.psi.PsiFile;
+import com.intellij.psi.PsiMember;
+import com.intellij.psi.PsiMethod;
+import com.intellij.psi.PsiModifier;
+import com.intellij.psi.PsiModifierListOwner;
+import com.intellij.psi.search.GlobalSearchScope;
+import com.intellij.psi.search.searches.ReferencesSearch;
+import com.intellij.psi.util.PsiTreeUtil;
+import dev.langchain4j.agent.tool.ToolExecutionRequest;
+import dev.langchain4j.service.tool.ToolExecutor;
+import lombok.extern.slf4j.Slf4j;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * PSI-based tool that reports symbols in a file with zero project-scope references —
+ * <strong>heuristic dead-code candidates, not certainties</strong>. Reflection,
+ * serialization, dependency-injection frameworks, and external (out-of-project)
+ * callers can all reference a symbol invisibly, so every result must be confirmed
+ * by a human before deletion.
+ *
+ * <p>To keep false positives low (false positives erode trust), the following are
+ * conservatively excluded: {@code public} members (potential API), constructors and
+ * {@code main}, {@code @Override} and any annotated member (frameworks reach these
+ * reflectively), and serialization members ({@code serialVersionUID},
+ * {@code readObject}/{@code writeObject}/{@code readResolve}/{@code writeReplace}).
+ * Java only in v1.
+ */
+@Slf4j
+public class FindDeadCodeToolExecutor implements ToolExecutor {
+
+    private static final int MAX_RESULTS = 50;
+    private static final Set<String> SERIALIZATION_METHODS =
+            Set.of("readObject", "writeObject", "readResolve", "writeReplace", "readObjectNoData");
+
+    private final Project project;
+
+    public FindDeadCodeToolExecutor(@NotNull Project project) {
+        this.project = project;
+    }
+
+    @Override
+    public String execute(ToolExecutionRequest request, Object memoryId) {
+        try {
+            String file = ToolArgumentParser.getString(request.arguments(), "file");
+            if (file == null || file.isBlank()) {
+                return "Error: 'file' parameter is required.";
+            }
+            return ReadAction.compute(() -> findDeadCode(file));
+        } catch (Exception e) {
+            log.error("Error finding dead code", e);
+            return "Error: Failed to find dead code - " + e.getMessage();
+        }
+    }
+
+    private @NotNull String findDeadCode(String filePath) {
+        VirtualFile projectBase = PsiToolUtils.getProjectBase(project);
+        if (projectBase == null) {
+            return "Error: Project base directory not found.";
+        }
+
+        PsiFile psiFile = PsiToolUtils.resolvePsiFile(project, filePath);
+        if (psiFile == null) {
+            return "Error: File not found or cannot be parsed: " + filePath;
+        }
+
+        if (!PsiToolUtils.isJavaAvailable() || !PsiToolUtils.isJavaFile(psiFile)) {
+            return "find_dead_code is not supported for " + PsiToolUtils.languageName(psiFile)
+                    + " in this version (Java only).";
+        }
+
+        List<String> candidates = new ArrayList<>();
+
+        for (PsiMethod method : PsiTreeUtil.collectElementsOfType(psiFile, PsiMethod.class)) {
+            if (candidates.size() >= MAX_RESULTS) break;
+            if (isExcludedMethod(method)) continue;
+            if (isUnreferenced(method)) {
+                candidates.add(format("method", method.getName(), method, projectBase));
+            }
+        }
+        for (PsiField field : PsiTreeUtil.collectElementsOfType(psiFile, PsiField.class)) {
+            if (candidates.size() >= MAX_RESULTS) break;
+            if (isExcludedField(field)) continue;
+            if (isUnreferenced(field)) {
+                candidates.add(format("field", field.getName(), field, projectBase));
+            }
+        }
+        for (PsiClass clazz : PsiTreeUtil.collectElementsOfType(psiFile, PsiClass.class)) {
+            if (candidates.size() >= MAX_RESULTS) break;
+            if (isExcludedClass(clazz)) continue;
+            if (isUnreferenced(clazz)) {
+                candidates.add(format("class", clazz.getName(), clazz, projectBase));
+            }
+        }
+
+        if (candidates.isEmpty()) {
+            return "No dead-code candidates found in " + filePath
+                    + " (every analysed symbol has at least one project-scope reference, or was conservatively excluded).";
+        }
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("Dead-code CANDIDATES in ").append(filePath)
+                .append(" — heuristic only; confirm before deleting. Reflection, serialization, DI, ")
+                .append("and out-of-project callers are invisible to this search:\n\n");
+        for (String c : candidates) {
+            sb.append("  ").append(c).append("\n");
+        }
+        if (candidates.size() >= MAX_RESULTS) {
+            sb.append("\n... (truncated at ").append(MAX_RESULTS).append(" candidates)");
+        }
+        return sb.toString();
+    }
+
+    private boolean isUnreferenced(@NotNull PsiMember member) {
+        return ReferencesSearch.search(member, GlobalSearchScope.projectScope(project)).findFirst() == null;
+    }
+
+    private boolean isExcludedMethod(@NotNull PsiMethod method) {
+        if (method.getName().isBlank()) return true;
+        if (method.isConstructor()) return true;
+        if (method.hasModifierProperty(PsiModifier.PUBLIC)) return true;
+        if (isAnnotated(method)) return true;                              // @Override and any framework annotation
+        if (SERIALIZATION_METHODS.contains(method.getName())) return true;
+        return "main".equals(method.getName());
+    }
+
+    private boolean isExcludedField(@NotNull PsiField field) {
+        if (field.getName().isBlank()) return true;
+        if (field.hasModifierProperty(PsiModifier.PUBLIC)) return true;
+        if (isAnnotated(field)) return true;
+        return "serialVersionUID".equals(field.getName());
+    }
+
+    private boolean isExcludedClass(@NotNull PsiClass clazz) {
+        if (clazz.getName() == null) return true;
+        if (clazz.hasModifierProperty(PsiModifier.PUBLIC)) return true;
+        return isAnnotated(clazz);
+    }
+
+    private boolean isAnnotated(@NotNull PsiModifierListOwner owner) {
+        return owner.getModifierList() != null && owner.getModifierList().getAnnotations().length > 0;
+    }
+
+    private @NotNull String format(@NotNull String kind, String name, @NotNull PsiMember member,
+                                   @NotNull VirtualFile projectBase) {
+        String location = PsiToolUtils.formatLocation(
+                member instanceof com.intellij.psi.PsiNameIdentifierOwner owner && owner.getNameIdentifier() != null
+                        ? owner.getNameIdentifier() : member,
+                projectBase);
+        return "[" + kind + "] " + name + (location != null ? "  " + location : "");
+    }
+}

--- a/src/main/java/com/devoxx/genie/service/agent/tool/psi/PsiToolCatalog.java
+++ b/src/main/java/com/devoxx/genie/service/agent/tool/psi/PsiToolCatalog.java
@@ -1,0 +1,43 @@
+package com.devoxx.genie.service.agent.tool.psi;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
+
+/**
+ * Single source of truth for the set of PSI (Program Structure Interface) agent tools and
+ * their short, human-facing labels.
+ *
+ * <p>The Agent settings UI builds one fine-grained enable/disable checkbox per entry here,
+ * and {@code BuiltInToolProvider} registers a tool for each of these names. A regression
+ * test asserts the two stay in sync, so adding a new PSI tool to the provider without
+ * listing it here (leaving it without a settings toggle) fails the build.
+ *
+ * <p>The descriptions are deliberately short — they are UI labels, not the detailed
+ * LLM-facing tool descriptions, which live in {@code BuiltInToolProvider}.
+ */
+public final class PsiToolCatalog {
+
+    /** A PSI tool's stable name and the short description shown next to its settings checkbox. */
+    public record PsiTool(@NotNull String name, @NotNull String description) {
+    }
+
+    public static final List<PsiTool> TOOLS = List.of(
+            new PsiTool("find_symbols", "Search for symbol definitions by name"),
+            new PsiTool("document_symbols", "List the symbol structure of a file"),
+            new PsiTool("find_references", "Find all usages of a symbol"),
+            new PsiTool("find_definition", "Navigate from a usage to its definition"),
+            new PsiTool("find_implementations", "Find implementations of an interface/abstract class"),
+            new PsiTool("find_callees", "List the methods a given method calls"),
+            new PsiTool("trace_call_chains", "Trace caller/callee call chains between methods"),
+            new PsiTool("calculate_complexity", "Compute cyclomatic complexity of Java methods"),
+            new PsiTool("find_dead_code", "Report unreferenced symbols (heuristic candidates)")
+    );
+
+    public static @NotNull List<String> toolNames() {
+        return TOOLS.stream().map(PsiTool::name).toList();
+    }
+
+    private PsiToolCatalog() {
+    }
+}

--- a/src/main/java/com/devoxx/genie/service/agent/tool/psi/PsiToolUtils.java
+++ b/src/main/java/com/devoxx/genie/service/agent/tool/psi/PsiToolUtils.java
@@ -158,4 +158,35 @@ public final class PsiToolUtils {
     public static VirtualFile getProjectBase(@NotNull Project project) {
         return ProjectUtil.guessProjectDir(project);
     }
+
+    /**
+     * Returns true when the IntelliJ Java plugin (PSI) is present on the runtime classpath.
+     * Mirrors the reflection guard in {@code JavaProjectScannerExtension.isJavaAvailable()} so
+     * the plugin still loads in non-Java IDEs where {@code com.intellij.modules.java} is absent.
+     * Call this before touching any {@code com.intellij.psi.PsiMethod}/{@code PsiClass} API.
+     */
+    public static boolean isJavaAvailable() {
+        try {
+            Class.forName("com.intellij.psi.JavaPsiFacade");
+            return true;
+        } catch (ClassNotFoundException e) {
+            return false;
+        }
+    }
+
+    /**
+     * Returns true when the given file is a Java source file. Uses the language ID only, so it
+     * does not link any Java-plugin class and is safe to call when Java support is absent.
+     */
+    public static boolean isJavaFile(@NotNull PsiFile psiFile) {
+        return "JAVA".equals(psiFile.getLanguage().getID());
+    }
+
+    /**
+     * Human-readable language name for "not supported" messages (e.g. "Kotlin", "Python").
+     */
+    @NotNull
+    public static String languageName(@NotNull PsiFile psiFile) {
+        return psiFile.getLanguage().getDisplayName();
+    }
 }

--- a/src/main/java/com/devoxx/genie/service/agent/tool/psi/TraceCallChainsToolExecutor.java
+++ b/src/main/java/com/devoxx/genie/service/agent/tool/psi/TraceCallChainsToolExecutor.java
@@ -1,0 +1,231 @@
+package com.devoxx.genie.service.agent.tool.psi;
+
+import com.devoxx.genie.service.agent.tool.ToolArgumentParser;
+import com.intellij.openapi.application.ReadAction;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.psi.PsiCallExpression;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiFile;
+import com.intellij.psi.PsiMethod;
+import com.intellij.psi.PsiNameIdentifierOwner;
+import com.intellij.psi.PsiReference;
+import com.intellij.psi.search.GlobalSearchScope;
+import com.intellij.psi.search.searches.ReferencesSearch;
+import com.intellij.psi.util.PsiTreeUtil;
+import dev.langchain4j.agent.tool.ToolExecutionRequest;
+import dev.langchain4j.service.tool.ToolExecutor;
+import lombok.extern.slf4j.Slf4j;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * PSI-based tool that traces call chains from a start method, walking either
+ * caller→callee or callee→caller edges up to a bounded depth, and returns the
+ * paths found. Optionally stops as soon as an optional target symbol is reached.
+ *
+ * <p>Rather than the UI-bound {@code com.intellij.ide.hierarchy.call} APIs (which
+ * expect a browser/descriptor context and are fragile headlessly inside a
+ * {@code ReadAction}), this walks the same PSI primitives the other PSI tools use:
+ * {@code ReferencesSearch} for the caller direction and method-body call resolution
+ * for the callee direction. Java only in v1.
+ *
+ * <p>Bounded in every dimension to stay responsive and avoid context blow-up:
+ * depth (default 5, hard max 10), number of paths ({@link #MAX_PATHS}), and total
+ * nodes expanded ({@link #NODE_BUDGET}).
+ */
+@Slf4j
+public class TraceCallChainsToolExecutor implements ToolExecutor {
+
+    private static final int DEFAULT_DEPTH = 5;
+    private static final int MAX_DEPTH = 10;
+    private static final int MAX_PATHS = 20;
+    private static final int NODE_BUDGET = 500;
+
+    private final Project project;
+
+    public TraceCallChainsToolExecutor(@NotNull Project project) {
+        this.project = project;
+    }
+
+    @Override
+    public String execute(ToolExecutionRequest request, Object memoryId) {
+        try {
+            String file = ToolArgumentParser.getString(request.arguments(), "file");
+            int line = ToolArgumentParser.getInt(request.arguments(), "line", -1);
+            String symbol = ToolArgumentParser.getString(request.arguments(), "symbol");
+            String target = ToolArgumentParser.getString(request.arguments(), "target");
+            String direction = ToolArgumentParser.getString(request.arguments(), "direction");
+            int depth = ToolArgumentParser.getInt(request.arguments(), "depth", DEFAULT_DEPTH);
+
+            if (file == null || file.isBlank()) {
+                return "Error: 'file' parameter is required.";
+            }
+            if (line < 1) {
+                return "Error: 'line' parameter is required (1-based line number of the start method).";
+            }
+
+            boolean callees = "callees".equalsIgnoreCase(direction);
+            int boundedDepth = Math.max(1, Math.min(depth, MAX_DEPTH));
+
+            return ReadAction.compute(() -> trace(file, line, symbol, target, callees, boundedDepth));
+        } catch (Exception e) {
+            log.error("Error tracing call chains", e);
+            return "Error: Failed to trace call chains - " + e.getMessage();
+        }
+    }
+
+    private @NotNull String trace(String filePath, int line, String symbol, String target,
+                                  boolean callees, int maxDepth) {
+        VirtualFile projectBase = PsiToolUtils.getProjectBase(project);
+        if (projectBase == null) {
+            return "Error: Project base directory not found.";
+        }
+
+        PsiFile psiFile = PsiToolUtils.resolvePsiFile(project, filePath);
+        if (psiFile == null) {
+            return "Error: File not found or cannot be parsed: " + filePath;
+        }
+
+        if (!PsiToolUtils.isJavaAvailable() || !PsiToolUtils.isJavaFile(psiFile)) {
+            return "trace_call_chains is not supported for " + PsiToolUtils.languageName(psiFile)
+                    + " in this version (Java only).";
+        }
+
+        PsiNameIdentifierOwner owner = PsiToolUtils.findNamedElementOnLine(psiFile, line, symbol);
+        if (!(owner instanceof PsiMethod start)) {
+            return "Error: No method definition found at " + filePath + ":" + line
+                    + (symbol != null ? " matching '" + symbol + "'" : "")
+                    + ". Ensure the line contains a method declaration.";
+        }
+
+        String targetName = (target != null && !target.isBlank()) ? target.trim() : null;
+        Trace trace = new Trace(callees, maxDepth, targetName, projectBase);
+        List<String> path = new ArrayList<>();
+        path.add(label(start, projectBase));
+        trace.walk(start, path, new LinkedHashSet<>(List.of(start)), 1);
+
+        return trace.render(start, callees);
+    }
+
+    /**
+     * Holds mutable traversal state so the recursive DFS stays readable and the caps
+     * are enforced in one place.
+     */
+    private final class Trace {
+        private final boolean callees;
+        private final int maxDepth;
+        private final String targetName;
+        private final VirtualFile projectBase;
+        private final List<List<String>> paths = new ArrayList<>();
+        private int nodesExpanded = 0;
+        private boolean budgetExhausted = false;
+        private boolean targetReached = false;
+
+        Trace(boolean callees, int maxDepth, String targetName, VirtualFile projectBase) {
+            this.callees = callees;
+            this.maxDepth = maxDepth;
+            this.targetName = targetName;
+            this.projectBase = projectBase;
+        }
+
+        void walk(@NotNull PsiMethod current, @NotNull List<String> pathSoFar,
+                  @NotNull Set<PsiMethod> onPath, int depth) {
+            if (paths.size() >= MAX_PATHS || budgetExhausted) return;
+
+            if (targetName != null && targetName.equals(current.getName()) && depth > 1) {
+                paths.add(new ArrayList<>(pathSoFar));
+                targetReached = true;
+                return;
+            }
+
+            if (depth >= maxDepth) {
+                if (targetName == null) paths.add(new ArrayList<>(pathSoFar)); // record terminal chains only when not target-seeking
+                return;
+            }
+
+            if (++nodesExpanded > NODE_BUDGET) {
+                budgetExhausted = true;
+                return;
+            }
+
+            List<PsiMethod> neighbors = callees ? callees(current) : callers(current);
+            if (neighbors.isEmpty()) {
+                if (targetName == null) paths.add(new ArrayList<>(pathSoFar)); // leaf chain
+                return;
+            }
+
+            for (PsiMethod next : neighbors) {
+                if (paths.size() >= MAX_PATHS || budgetExhausted) return;
+                if (onPath.contains(next)) continue; // avoid cycles
+                pathSoFar.add(label(next, projectBase));
+                onPath.add(next);
+                walk(next, pathSoFar, onPath, depth + 1);
+                onPath.remove(next);
+                pathSoFar.remove(pathSoFar.size() - 1);
+            }
+        }
+
+        @NotNull String render(@NotNull PsiMethod start, boolean callees) {
+            String arrow = callees ? "calls →" : "called by ←";
+            if (paths.isEmpty()) {
+                return "No " + (callees ? "callee" : "caller") + " chains found from '"
+                        + start.getName() + "' within depth " + maxDepth + ".";
+            }
+            StringBuilder sb = new StringBuilder();
+            if (targetName != null) {
+                sb.append(targetReached
+                        ? "Found " + paths.size() + " chain(s) from '" + start.getName() + "' reaching '" + targetName + "':\n\n"
+                        : "No chain from '" + start.getName() + "' reached '" + targetName + "' within depth " + maxDepth + ".\n");
+                if (!targetReached) return sb.toString();
+            } else {
+                sb.append("Traced ").append(paths.size()).append(" ")
+                        .append(callees ? "callee" : "caller").append(" chain(s) from '")
+                        .append(start.getName()).append("' (").append(arrow).append("), depth ≤ ")
+                        .append(maxDepth).append(":\n\n");
+            }
+            int i = 1;
+            for (List<String> p : paths) {
+                sb.append(i++).append(". ").append(String.join(callees ? "  →  " : "  ←  ", p)).append("\n");
+            }
+            if (paths.size() >= MAX_PATHS) {
+                sb.append("\n... (truncated at ").append(MAX_PATHS).append(" paths)");
+            }
+            if (budgetExhausted) {
+                sb.append("\n(note: traversal stopped early after expanding ").append(NODE_BUDGET)
+                        .append(" nodes — results may be partial)");
+            }
+            return sb.toString();
+        }
+    }
+
+    private @NotNull List<PsiMethod> callees(@NotNull PsiMethod method) {
+        Set<PsiMethod> result = new LinkedHashSet<>();
+        for (PsiCallExpression call : PsiTreeUtil.collectElementsOfType(method, PsiCallExpression.class)) {
+            PsiMethod callee = call.resolveMethod();
+            if (callee != null) result.add(callee);
+        }
+        return new ArrayList<>(result);
+    }
+
+    private @NotNull List<PsiMethod> callers(@NotNull PsiMethod method) {
+        Set<PsiMethod> result = new LinkedHashSet<>();
+        for (PsiReference ref : ReferencesSearch.search(method, GlobalSearchScope.projectScope(project)).findAll()) {
+            PsiElement el = ref.getElement();
+            PsiMethod caller = PsiTreeUtil.getParentOfType(el, PsiMethod.class);
+            if (caller != null) result.add(caller);
+        }
+        return new ArrayList<>(result);
+    }
+
+    private @NotNull String label(@NotNull PsiMethod method, @NotNull VirtualFile projectBase) {
+        String owner = method.getContainingClass() != null ? method.getContainingClass().getName() + "." : "";
+        PsiElement anchor = method.getNameIdentifier() != null ? method.getNameIdentifier() : method;
+        String location = PsiToolUtils.formatLocation(anchor, projectBase);
+        return owner + method.getName() + "()" + (location != null ? " (" + location + ")" : "");
+    }
+}

--- a/src/main/java/com/devoxx/genie/ui/settings/agent/AgentSettingsComponent.java
+++ b/src/main/java/com/devoxx/genie/ui/settings/agent/AgentSettingsComponent.java
@@ -5,6 +5,7 @@ import com.devoxx.genie.model.LanguageModel;
 import com.devoxx.genie.model.agent.SubAgentConfig;
 import com.devoxx.genie.model.enumarations.ModelProvider;
 import com.devoxx.genie.service.LLMProviderService;
+import com.devoxx.genie.service.agent.tool.psi.PsiToolCatalog;
 import com.devoxx.genie.service.chromadb.ChromaDBManager;
 import com.devoxx.genie.service.chromadb.model.ChromaCollection;
 import com.devoxx.genie.ui.renderer.ModelInfoRenderer;
@@ -65,8 +66,10 @@ public class AgentSettingsComponent extends AbstractSettingsComponent {
 
     // PSI tools settings
     private final JBCheckBox enablePsiToolsCheckbox =
-            new JBCheckBox("Enable PSI Tools (find_symbols, document_symbols, find_references, find_definition, find_implementations)",
+            new JBCheckBox("Enable PSI Tools",
                     Boolean.TRUE.equals(stateService.getPsiToolsEnabled()));
+    // Per-PSI-tool checkboxes, greyed out when the master toggle above is off.
+    private final List<JBCheckBox> psiToolCheckboxes = new ArrayList<>();
 
     // Parallel exploration settings
     private final JBCheckBox enableParallelExploreCheckbox =
@@ -215,9 +218,22 @@ public class AgentSettingsComponent extends AbstractSettingsComponent {
                 "When enabled, the agent gets IDE-powered code intelligence tools that use the " +
                 "Program Structure Interface (PSI) for semantic code analysis. These tools understand " +
                 "language semantics (imports, types, inheritance) and work across all IDE-supported languages. " +
-                "Tools: find_symbols (search definitions), document_symbols (list file structure), " +
-                "find_references (find usages), find_definition (go to definition), " +
-                "find_implementations (find interface/class implementations).");
+                "Uncheck individual tools below to keep PSI on while hiding specific tools from the agent.");
+
+        // Fine-grained per-tool toggles. These share the disabledAgentTools list (and the
+        // toolCheckboxes map) with the Built-in Tools section, so apply()/isModified()/reset()
+        // handle them without special-casing. They are greyed out when the master toggle is off.
+        // 'disabledSet' was computed in the Built-in Tools section above and is reused here.
+        for (PsiToolCatalog.PsiTool psiTool : PsiToolCatalog.TOOLS) {
+            JBCheckBox cb = new JBCheckBox(psiTool.name() + " - " + psiTool.description(),
+                    !disabledSet.contains(psiTool.name()));
+            cb.setEnabled(enablePsiToolsCheckbox.isSelected());
+            toolCheckboxes.put(psiTool.name(), cb);
+            psiToolCheckboxes.add(cb);
+            addIndentedRow(contentPanel, gbc, cb);
+        }
+        enablePsiToolsCheckbox.addItemListener(e ->
+                psiToolCheckboxes.forEach(cb -> cb.setEnabled(enablePsiToolsCheckbox.isSelected())));
 
         // --- Parallel Exploration ---
         addSection(contentPanel, gbc, "Parallel Exploration");
@@ -833,6 +849,16 @@ public class AgentSettingsComponent extends AbstractSettingsComponent {
         gbc.gridy++;
     }
 
+    /** Like {@link #addFullWidthRow} but with extra left padding, to nest a control under a parent toggle. */
+    private void addIndentedRow(JPanel panel, GridBagConstraints gbc, JComponent component) {
+        gbc.gridwidth = 2;
+        gbc.gridx = 0;
+        gbc.insets = new Insets(2, 25, 2, 5);
+        panel.add(component, gbc);
+        gbc.insets = new Insets(4, 5, 4, 5);
+        gbc.gridy++;
+    }
+
     private void addHelpText(JPanel panel, GridBagConstraints gbc, String text) {
         gbc.gridwidth = 2;
         gbc.gridx = 0;
@@ -962,6 +988,8 @@ public class AgentSettingsComponent extends AbstractSettingsComponent {
         for (Map.Entry<String, JBCheckBox> entry : toolCheckboxes.entrySet()) {
             entry.getValue().setSelected(!disabledSet.contains(entry.getKey()));
         }
+        // Re-sync PSI sub-tool grey-out with the (just-reset) master toggle.
+        psiToolCheckboxes.forEach(cb -> cb.setEnabled(enablePsiToolsCheckbox.isSelected()));
 
         // customTestCommandField.setText() above triggers caret-based scrollRectToVisible,
         // which scrolls IntelliJ's viewport to mid-panel. Scroll back to top

--- a/src/test/java/com/devoxx/genie/service/agent/tool/BuiltInToolProviderTest.java
+++ b/src/test/java/com/devoxx/genie/service/agent/tool/BuiltInToolProviderTest.java
@@ -1,5 +1,6 @@
 package com.devoxx.genie.service.agent.tool;
 
+import com.devoxx.genie.service.agent.tool.psi.PsiToolCatalog;
 import com.devoxx.genie.ui.settings.DevoxxGenieStateService;
 import com.intellij.openapi.project.Project;
 import dev.langchain4j.agent.tool.ToolSpecification;
@@ -211,11 +212,12 @@ class BuiltInToolProviderTest {
         ToolProviderResult result = provider.provideTools(request);
 
         Set<String> toolNames = getToolNames(result);
-        // 7 base + 5 PSI tools
-        assertThat(result.tools()).hasSize(12);
+        // 7 base + 9 PSI tools
+        assertThat(result.tools()).hasSize(16);
         assertThat(toolNames).contains(
                 "find_symbols", "document_symbols", "find_references",
-                "find_definition", "find_implementations"
+                "find_definition", "find_implementations",
+                "find_callees", "trace_call_chains", "calculate_complexity", "find_dead_code"
         );
     }
 
@@ -227,11 +229,45 @@ class BuiltInToolProviderTest {
         ToolProviderResult result = provider.provideTools(request);
 
         Set<String> toolNames = getToolNames(result);
-        assertThat(toolNames).noneMatch(name ->
-                name.equals("find_symbols") || name.equals("document_symbols") ||
-                name.equals("find_references") || name.equals("find_definition") ||
-                name.equals("find_implementations")
-        );
+        assertThat(toolNames).doesNotContainAnyElementsOf(PsiToolCatalog.toolNames());
+    }
+
+    /**
+     * Regression guard for fine-grained PSI tool control: the settings UI builds one
+     * checkbox per entry in {@link PsiToolCatalog}, so every PSI tool actually registered
+     * by the provider MUST appear in the catalog — otherwise a newly added PSI tool would
+     * have no settings toggle. This fails the moment a PSI tool is registered without being
+     * listed in the catalog (or vice-versa).
+     */
+    @Test
+    void psiToolCatalog_listsExactlyTheRegisteredPsiTools() {
+        when(stateService.getPsiToolsEnabled()).thenReturn(true);
+        BuiltInToolProvider provider = createProvider();
+
+        Set<String> registeredPsiTools = new java.util.HashSet<>(getToolNames(provider.provideTools(request)));
+        registeredPsiTools.removeAll(BASE_TOOLS); // only PSI tools remain (no other features enabled)
+
+        assertThat(PsiToolCatalog.toolNames())
+                .containsExactlyInAnyOrderElementsOf(registeredPsiTools);
+    }
+
+    /**
+     * Each PSI tool must be individually disableable via the shared disabledAgentTools list
+     * (the mechanism the per-tool settings checkboxes write to). Disabling one PSI tool must
+     * exclude only that tool and leave the rest registered.
+     */
+    @Test
+    void provideTools_disablingSinglePsiTool_excludesOnlyThatTool() {
+        when(stateService.getPsiToolsEnabled()).thenReturn(true);
+        when(stateService.getDisabledAgentTools()).thenReturn(List.of("find_dead_code"));
+        BuiltInToolProvider provider = createProvider();
+
+        Set<String> toolNames = getToolNames(provider.provideTools(request));
+
+        assertThat(toolNames).doesNotContain("find_dead_code");
+        assertThat(toolNames).contains(
+                "find_symbols", "document_symbols", "find_references", "find_definition",
+                "find_implementations", "find_callees", "trace_call_chains", "calculate_complexity");
     }
 
     // --- All features enabled ---
@@ -246,8 +282,8 @@ class BuiltInToolProviderTest {
 
         ToolProviderResult result = provider.provideTools(request);
 
-        // 7 base + 1 run_tests + 1 parallel_explore + 20 backlog + 5 PSI = 34
-        assertThat(result.tools()).hasSize(34);
+        // 7 base + 1 run_tests + 1 parallel_explore + 20 backlog + 9 PSI = 38
+        assertThat(result.tools()).hasSize(38);
     }
 
     // --- Disabled tools filtering in provideTools() ---

--- a/src/test/java/com/devoxx/genie/service/agent/tool/psi/CalculateComplexityToolExecutorTest.java
+++ b/src/test/java/com/devoxx/genie/service/agent/tool/psi/CalculateComplexityToolExecutorTest.java
@@ -1,0 +1,104 @@
+package com.devoxx.genie.service.agent.tool.psi;
+
+import com.intellij.openapi.application.ReadAction;
+import com.intellij.psi.PsiFile;
+import com.intellij.psi.PsiMethod;
+import com.intellij.psi.util.PsiTreeUtil;
+import com.intellij.testFramework.fixtures.BasePlatformTestCase;
+import dev.langchain4j.agent.tool.ToolExecutionRequest;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CalculateComplexityToolExecutorTest extends BasePlatformTestCase {
+
+    private CalculateComplexityToolExecutor executor;
+
+    @BeforeEach
+    public void setUp() throws Exception {
+        super.setUp();
+        executor = new CalculateComplexityToolExecutor(getProject());
+    }
+
+    @AfterEach
+    public void tearDown() throws Exception {
+        super.tearDown();
+    }
+
+    private static ToolExecutionRequest request(String args) {
+        return ToolExecutionRequest.builder().name("calculate_complexity").arguments(args).build();
+    }
+
+    // --- Input validation ---
+
+    @Test
+    public void missingFile_returnsError() {
+        assertThat(executor.execute(request("{}"), null)).contains("Error").contains("file");
+    }
+
+    @Test
+    public void fileNotFound_returnsError() {
+        assertThat(executor.execute(request("{\"file\": \"Nope.java\"}"), null))
+                .contains("Error").contains("File not found");
+    }
+
+    // --- AC #8: complexity of a method with known decision points matches the expected count ---
+
+    @Test
+    public void complexityOfMatchesKnownDecisionPoints() {
+        // base 1 + if(1) + && (1) + for(1) + else-if(1) = 5
+        PsiFile file = myFixture.addFileToProject("Cx.java",
+                "public class Cx {\n" +
+                "    int m(int x) {\n" +
+                "        if (x > 0 && x < 10) {\n" +
+                "            for (int i = 0; i < x; i++) { }\n" +
+                "        } else if (x < 0) { }\n" +
+                "        return x;\n" +
+                "    }\n" +
+                "}\n");
+
+        int complexity = ReadAction.compute(() -> {
+            PsiMethod m = PsiTreeUtil.collectElementsOfType(file, PsiMethod.class).stream()
+                    .filter(x -> "m".equals(x.getName())).findFirst().orElseThrow();
+            return CalculateComplexityToolExecutor.complexityOf(m);
+        });
+
+        assertThat(complexity).isEqualTo(5);
+    }
+
+    @Test
+    public void trivialMethodHasComplexityOne() {
+        PsiFile file = myFixture.addFileToProject("Trivial.java",
+                "public class Trivial {\n" +
+                "    int id(int x) { return x; }\n" +
+                "}\n");
+
+        int complexity = ReadAction.compute(() -> {
+            PsiMethod m = PsiTreeUtil.collectElementsOfType(file, PsiMethod.class).stream()
+                    .filter(x -> "id".equals(x.getName())).findFirst().orElseThrow();
+            return CalculateComplexityToolExecutor.complexityOf(m);
+        });
+
+        assertThat(complexity).isEqualTo(1);
+    }
+
+    @Test
+    public void executeFlagsMethodsOverThreshold() {
+        myFixture.addFileToProject("Cx2.java",
+                "public class Cx2 {\n" +
+                "    int m(int x) {\n" +
+                "        if (x > 0 && x < 10) {\n" +
+                "            for (int i = 0; i < x; i++) { }\n" +
+                "        } else if (x < 0) { }\n" +
+                "        return x;\n" +
+                "    }\n" +
+                "}\n");
+
+        // threshold 3 → method (complexity 5) is flagged
+        String result = executor.execute(request("{\"file\": \"Cx2.java\", \"threshold\": 3}"), null);
+        assertThat(result).contains("Cx2.m");
+        assertThat(result).contains("over threshold");
+    }
+}

--- a/src/test/java/com/devoxx/genie/service/agent/tool/psi/FindCalleesToolExecutorTest.java
+++ b/src/test/java/com/devoxx/genie/service/agent/tool/psi/FindCalleesToolExecutorTest.java
@@ -1,0 +1,99 @@
+package com.devoxx.genie.service.agent.tool.psi;
+
+import com.intellij.testFramework.fixtures.BasePlatformTestCase;
+import dev.langchain4j.agent.tool.ToolExecutionRequest;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class FindCalleesToolExecutorTest extends BasePlatformTestCase {
+
+    private FindCalleesToolExecutor executor;
+
+    @BeforeEach
+    public void setUp() throws Exception {
+        super.setUp();
+        executor = new FindCalleesToolExecutor(getProject());
+    }
+
+    @AfterEach
+    public void tearDown() throws Exception {
+        super.tearDown();
+    }
+
+    private static ToolExecutionRequest request(String args) {
+        return ToolExecutionRequest.builder().name("find_callees").arguments(args).build();
+    }
+
+    // --- Input validation (no fixture needed) ---
+
+    @Test
+    public void missingFile_returnsError() {
+        assertThat(executor.execute(request("{\"line\": 2}"), null)).contains("Error").contains("file");
+    }
+
+    @Test
+    public void missingLine_returnsError() {
+        assertThat(executor.execute(request("{\"file\": \"Foo.java\"}"), null)).contains("Error").contains("line");
+    }
+
+    @Test
+    public void invalidJson_returnsError() {
+        assertThat(executor.execute(request("not json"), null)).contains("Error");
+    }
+
+    @Test
+    public void fileNotFound_returnsError() {
+        assertThat(executor.execute(request("{\"file\": \"Nope.java\", \"line\": 1}"), null))
+                .contains("Error").contains("File not found");
+    }
+
+    // --- Real PSI resolution (AC #8: callees of a method are resolved) ---
+
+    @Test
+    public void resolvesOutgoingCalls() {
+        // 1: public class Caller {
+        // 2:     void source() {
+        // 3:         target();
+        // 4:         helper();
+        // 5:     }
+        // 6:     void target() {}
+        // 7:     void helper() {}
+        // 8: }
+        myFixture.addFileToProject("Caller.java",
+                "public class Caller {\n" +
+                "    void source() {\n" +
+                "        target();\n" +
+                "        helper();\n" +
+                "    }\n" +
+                "    void target() {}\n" +
+                "    void helper() {}\n" +
+                "}\n");
+
+        String result = executor.execute(request("{\"file\": \"Caller.java\", \"line\": 2}"), null);
+
+        assertThat(result).contains("2 distinct method(s)");
+        assertThat(result).contains("target()");
+        assertThat(result).contains("helper()");
+    }
+
+    @Test
+    public void methodWithNoCalls_reportsNone() {
+        myFixture.addFileToProject("Leaf.java",
+                "public class Leaf {\n" +
+                "    int value() { return 42; }\n" +
+                "}\n");
+
+        String result = executor.execute(request("{\"file\": \"Leaf.java\", \"line\": 2}"), null);
+        assertThat(result).contains("No resolved method calls");
+    }
+
+    @Test
+    public void notAMethodLine_returnsError() {
+        myFixture.addFileToProject("Plain.java", "public class Plain {\n    int field = 1;\n}\n");
+        String result = executor.execute(request("{\"file\": \"Plain.java\", \"line\": 1}"), null);
+        assertThat(result).contains("Error").contains("method");
+    }
+}

--- a/src/test/java/com/devoxx/genie/service/agent/tool/psi/FindDeadCodeToolExecutorTest.java
+++ b/src/test/java/com/devoxx/genie/service/agent/tool/psi/FindDeadCodeToolExecutorTest.java
@@ -1,0 +1,73 @@
+package com.devoxx.genie.service.agent.tool.psi;
+
+import com.intellij.testFramework.fixtures.BasePlatformTestCase;
+import dev.langchain4j.agent.tool.ToolExecutionRequest;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class FindDeadCodeToolExecutorTest extends BasePlatformTestCase {
+
+    private FindDeadCodeToolExecutor executor;
+
+    @BeforeEach
+    public void setUp() throws Exception {
+        super.setUp();
+        executor = new FindDeadCodeToolExecutor(getProject());
+    }
+
+    @AfterEach
+    public void tearDown() throws Exception {
+        super.tearDown();
+    }
+
+    private static ToolExecutionRequest request(String args) {
+        return ToolExecutionRequest.builder().name("find_dead_code").arguments(args).build();
+    }
+
+    // --- Input validation ---
+
+    @Test
+    public void missingFile_returnsError() {
+        assertThat(executor.execute(request("{}"), null)).contains("Error").contains("file");
+    }
+
+    // --- AC #8: unreferenced private method is a candidate; @Override / entry-point is not ---
+
+    @Test
+    public void reportsUnreferencedPrivateButNotOverrideOrPublic() {
+        myFixture.addFileToProject("D.java",
+                "public class D {\n" +
+                "    private void unusedPrivate() {}\n" +
+                "    private void usedPrivate() {}\n" +
+                "    public void entry() { usedPrivate(); }\n" +
+                "    @Override public String toString() { return \"x\"; }\n" +
+                "}\n");
+
+        String result = executor.execute(request("{\"file\": \"D.java\"}"), null);
+
+        // The unreferenced private method is a candidate.
+        assertThat(result).contains("[method] unusedPrivate");
+        // Heuristic labelling is present.
+        assertThat(result).contains("CANDIDATES").contains("confirm before deleting");
+        // Referenced private method is NOT a candidate.
+        assertThat(result).doesNotContain("[method] usedPrivate");
+        // Public entry point and @Override toString are excluded.
+        assertThat(result).doesNotContain("[method] entry");
+        assertThat(result).doesNotContain("[method] toString");
+    }
+
+    @Test
+    public void allReferencedOrExcluded_reportsNone() {
+        myFixture.addFileToProject("Clean.java",
+                "public class Clean {\n" +
+                "    private int used() { return 1; }\n" +
+                "    public int api() { return used(); }\n" +
+                "}\n");
+
+        String result = executor.execute(request("{\"file\": \"Clean.java\"}"), null);
+        assertThat(result).contains("No dead-code candidates");
+    }
+}

--- a/src/test/java/com/devoxx/genie/service/agent/tool/psi/TraceCallChainsToolExecutorTest.java
+++ b/src/test/java/com/devoxx/genie/service/agent/tool/psi/TraceCallChainsToolExecutorTest.java
@@ -1,0 +1,90 @@
+package com.devoxx.genie.service.agent.tool.psi;
+
+import com.intellij.testFramework.fixtures.BasePlatformTestCase;
+import dev.langchain4j.agent.tool.ToolExecutionRequest;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TraceCallChainsToolExecutorTest extends BasePlatformTestCase {
+
+    private TraceCallChainsToolExecutor executor;
+
+    @BeforeEach
+    public void setUp() throws Exception {
+        super.setUp();
+        executor = new TraceCallChainsToolExecutor(getProject());
+    }
+
+    @AfterEach
+    public void tearDown() throws Exception {
+        super.tearDown();
+    }
+
+    private static ToolExecutionRequest request(String args) {
+        return ToolExecutionRequest.builder().name("trace_call_chains").arguments(args).build();
+    }
+
+    private void addChainFixture() {
+        // 1: public class Chain {
+        // 2:     void a() { b(); }
+        // 3:     void b() { c(); }
+        // 4:     void c() {}
+        // 5: }
+        myFixture.addFileToProject("Chain.java",
+                "public class Chain {\n" +
+                "    void a() { b(); }\n" +
+                "    void b() { c(); }\n" +
+                "    void c() {}\n" +
+                "}\n");
+    }
+
+    // --- Input validation ---
+
+    @Test
+    public void missingFile_returnsError() {
+        assertThat(executor.execute(request("{\"line\": 2}"), null)).contains("Error").contains("file");
+    }
+
+    @Test
+    public void missingLine_returnsError() {
+        assertThat(executor.execute(request("{\"file\": \"Foo.java\"}"), null)).contains("Error").contains("line");
+    }
+
+    // --- AC #8: a known caller chain is traced within the depth bound ---
+
+    @Test
+    public void tracesCallerChain() {
+        addChainFixture();
+        // start at c() (line 4), direction defaults to callers: c <- b <- a
+        String result = executor.execute(request("{\"file\": \"Chain.java\", \"line\": 4}"), null);
+
+        assertThat(result).contains("a()");
+        assertThat(result).contains("b()");
+        assertThat(result).contains("c()");
+        assertThat(result).contains("caller chain");
+    }
+
+    @Test
+    public void tracesCalleeChainToTarget() {
+        addChainFixture();
+        // start at a() (line 2), direction callees, target c: a -> b -> c
+        String result = executor.execute(
+                request("{\"file\": \"Chain.java\", \"line\": 2, \"direction\": \"callees\", \"target\": \"c\"}"), null);
+
+        assertThat(result).contains("reaching 'c'");
+        assertThat(result).contains("a()");
+        assertThat(result).contains("b()");
+        assertThat(result).contains("c()");
+    }
+
+    @Test
+    public void depthIsBounded() {
+        addChainFixture();
+        // depth 1 from c(): cannot reach a() two hops away
+        String result = executor.execute(request("{\"file\": \"Chain.java\", \"line\": 4, \"depth\": 1}"), null);
+        assertThat(result).doesNotContain("a()");
+    }
+}


### PR DESCRIPTION
## Summary
- Add four PSI call-graph agent tools: `find_callees`, `trace_call_chains`, `calculate_complexity`, `find_dead_code` (Java; heuristic dead-code is candidates-only).
- Introduce `PsiToolCatalog` as the single source of truth for PSI tools, guarded by a parity test that fails the build if a registered PSI tool isn't listed.
- Add fine-grained per-PSI-tool enable/disable checkboxes in Agent settings (indented under the master "Enable PSI Tools" toggle), reusing the existing `disabledAgentTools` filtering.

## Test plan
- [x] `./gradlew test` — full suite green
- [x] `BuiltInToolProviderTest` parity + per-tool disable tests pass; tool-count assertions updated (5→9 PSI tools)
- [x] Manual: Settings → Agent → PSI Tools shows 9 sub-checkboxes; unchecking the master greys them out
- [ ] Manual: disable a single PSI tool, confirm it's withheld from the agent on the next run

🤖 Generated with [Claude Code](https://claude.com/claude-code)