### PR TITLE
refactor(chatmodel): replace provider switch with EnumMap registry

### DIFF
--- a/src/main/java/com/devoxx/genie/chatmodel/ChatModelFactoryProvider.java
+++ b/src/main/java/com/devoxx/genie/chatmodel/ChatModelFactoryProvider.java
@@ -5,72 +5,101 @@ import com.devoxx.genie.chatmodel.cloud.azureopenai.AzureOpenAIChatModelFactory;
 import com.devoxx.genie.chatmodel.cloud.bedrock.BedrockModelFactory;
 import com.devoxx.genie.chatmodel.cloud.deepinfra.DeepInfraChatModelFactory;
 import com.devoxx.genie.chatmodel.cloud.deepseek.DeepSeekChatModelFactory;
+import com.devoxx.genie.chatmodel.cloud.glm.GLMChatModelFactory;
 import com.devoxx.genie.chatmodel.cloud.google.GoogleChatModelFactory;
 import com.devoxx.genie.chatmodel.cloud.grok.GrokChatModelFactory;
-import com.devoxx.genie.chatmodel.cloud.glm.GLMChatModelFactory;
-import com.devoxx.genie.chatmodel.cloud.kimi.KimiChatModelFactory;
 import com.devoxx.genie.chatmodel.cloud.groq.GroqChatModelFactory;
+import com.devoxx.genie.chatmodel.cloud.kimi.KimiChatModelFactory;
 import com.devoxx.genie.chatmodel.cloud.mistral.MistralChatModelFactory;
 import com.devoxx.genie.chatmodel.cloud.openai.OpenAIChatModelFactory;
 import com.devoxx.genie.chatmodel.cloud.openrouter.OpenRouterChatModelFactory;
+import com.devoxx.genie.chatmodel.local.acprunners.AcpRunnersChatModelFactory;
+import com.devoxx.genie.chatmodel.local.clirunners.CliRunnersChatModelFactory;
 import com.devoxx.genie.chatmodel.local.customopenai.CustomOpenAIChatModelFactory;
 import com.devoxx.genie.chatmodel.local.exo.ExoChatModelFactory;
 import com.devoxx.genie.chatmodel.local.gpt4all.GPT4AllChatModelFactory;
 import com.devoxx.genie.chatmodel.local.jan.JanChatModelFactory;
-import com.devoxx.genie.chatmodel.local.acprunners.AcpRunnersChatModelFactory;
-import com.devoxx.genie.chatmodel.local.clirunners.CliRunnersChatModelFactory;
 import com.devoxx.genie.chatmodel.local.llamacpp.LlamaChatModelFactory;
 import com.devoxx.genie.chatmodel.local.lmstudio.LMStudioChatModelFactory;
 import com.devoxx.genie.chatmodel.local.ollama.OllamaChatModelFactory;
+import com.devoxx.genie.model.enumarations.ModelProvider;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 
+import java.util.EnumMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Supplier;
 
+/**
+ * Resolves the {@link ChatModelFactory} for a given provider.
+ * <p>
+ * The single source of truth for the set of providers is the {@link ModelProvider} enum; this
+ * class only wires each provider to its factory constructor. Suppliers are stored un-invoked so
+ * factories are instantiated lazily (and then cached) on first use — no factory is built until its
+ * provider is actually requested.
+ * <p>
+ * Lookups accept <em>either</em> the enum constant name ({@link ModelProvider#name()}, used by
+ * {@code ChatModelProvider} and {@code LlmProviderPanel}) <em>or</em> the display name
+ * ({@link ModelProvider#getName()}, used by {@code AgentSettingsComponent}). These differ for
+ * {@code LLaMA} ("LLaMA.c++"), {@code CLIRunners} ("CLI Runners") and {@code ACPRunners}
+ * ("ACP Runners"); accepting both keeps every existing caller working regardless of which key it
+ * passes. Matching is case-sensitive.
+ */
 public final class ChatModelFactoryProvider {
 
     private ChatModelFactoryProvider() {
     }
 
-    private static final Map<String, ChatModelFactory> factoryCache = new ConcurrentHashMap<>();
+    /**
+     * Provider → factory-constructor registry. Adding a provider is a single entry here; the
+     * {@code ChatModelFactoryProviderTest} completeness check fails if a {@link ModelProvider}
+     * constant is added to the enum but not wired here.
+     */
+    private static final Map<ModelProvider, Supplier<ChatModelFactory>> FACTORY_SUPPLIERS =
+            new EnumMap<>(ModelProvider.class);
+
+    static {
+        FACTORY_SUPPLIERS.put(ModelProvider.Anthropic, AnthropicChatModelFactory::new);
+        FACTORY_SUPPLIERS.put(ModelProvider.AzureOpenAI, AzureOpenAIChatModelFactory::new);
+        FACTORY_SUPPLIERS.put(ModelProvider.Bedrock, BedrockModelFactory::new);
+        FACTORY_SUPPLIERS.put(ModelProvider.CustomOpenAI, CustomOpenAIChatModelFactory::new);
+        FACTORY_SUPPLIERS.put(ModelProvider.Exo, ExoChatModelFactory::new);
+        FACTORY_SUPPLIERS.put(ModelProvider.DeepInfra, DeepInfraChatModelFactory::new);
+        FACTORY_SUPPLIERS.put(ModelProvider.DeepSeek, DeepSeekChatModelFactory::new);
+        FACTORY_SUPPLIERS.put(ModelProvider.Google, GoogleChatModelFactory::new);
+        FACTORY_SUPPLIERS.put(ModelProvider.Groq, GroqChatModelFactory::new);
+        FACTORY_SUPPLIERS.put(ModelProvider.GPT4All, GPT4AllChatModelFactory::new);
+        FACTORY_SUPPLIERS.put(ModelProvider.Jan, JanChatModelFactory::new);
+        FACTORY_SUPPLIERS.put(ModelProvider.LLaMA, LlamaChatModelFactory::new);
+        FACTORY_SUPPLIERS.put(ModelProvider.LMStudio, LMStudioChatModelFactory::new);
+        FACTORY_SUPPLIERS.put(ModelProvider.Mistral, MistralChatModelFactory::new);
+        FACTORY_SUPPLIERS.put(ModelProvider.Ollama, OllamaChatModelFactory::new);
+        FACTORY_SUPPLIERS.put(ModelProvider.OpenAI, OpenAIChatModelFactory::new);
+        FACTORY_SUPPLIERS.put(ModelProvider.OpenRouter, OpenRouterChatModelFactory::new);
+        FACTORY_SUPPLIERS.put(ModelProvider.Grok, GrokChatModelFactory::new);
+        FACTORY_SUPPLIERS.put(ModelProvider.Kimi, KimiChatModelFactory::new);
+        FACTORY_SUPPLIERS.put(ModelProvider.GLM, GLMChatModelFactory::new);
+        FACTORY_SUPPLIERS.put(ModelProvider.CLIRunners, CliRunnersChatModelFactory::new);
+        FACTORY_SUPPLIERS.put(ModelProvider.ACPRunners, AcpRunnersChatModelFactory::new);
+    }
+
+    /** Lazily-instantiated factory instances, keyed by the resolved provider. */
+    private static final Map<ModelProvider, ChatModelFactory> factoryCache = new ConcurrentHashMap<>();
 
     public static @NotNull Optional<ChatModelFactory> getFactoryByProvider(@NotNull String modelProvider) {
-        return Optional.ofNullable(factoryCache.computeIfAbsent(modelProvider, ChatModelFactoryProvider::createFactory));
+        return resolveProvider(modelProvider)
+                .map(provider -> factoryCache.computeIfAbsent(provider, p -> FACTORY_SUPPLIERS.get(p).get()));
     }
 
     /**
-     * Get the factory by provider.
-     *
-     * @param modelProvider the model provider
-     * @return the factory
+     * Resolve a provider key to its {@link ModelProvider}, matching either the enum constant name
+     * or the display name (case-sensitive). Only providers present in {@link #FACTORY_SUPPLIERS}
+     * are returned, so the result maps directly to an available factory.
      */
-    private static @Nullable ChatModelFactory createFactory(@NotNull String modelProvider) {
-        return switch (modelProvider) {
-            case "Anthropic" -> new AnthropicChatModelFactory();
-            case "AzureOpenAI" -> new AzureOpenAIChatModelFactory();
-            case "Bedrock" -> new BedrockModelFactory();
-            case "CustomOpenAI" -> new CustomOpenAIChatModelFactory();
-            case "Exo" -> new ExoChatModelFactory();
-            case "DeepInfra" -> new DeepInfraChatModelFactory();
-            case "DeepSeek" -> new DeepSeekChatModelFactory();
-            case "Google" -> new GoogleChatModelFactory();
-            case "Groq" -> new GroqChatModelFactory();
-            case "GPT4All" -> new GPT4AllChatModelFactory();
-            case "Jan" -> new JanChatModelFactory();
-            case "LLaMA" -> new LlamaChatModelFactory();
-            case "LMStudio" -> new LMStudioChatModelFactory();
-            case "Mistral" -> new MistralChatModelFactory();
-            case "Ollama" -> new OllamaChatModelFactory();
-            case "OpenAI" -> new OpenAIChatModelFactory();
-            case "OpenRouter" -> new OpenRouterChatModelFactory();
-            case "Grok" -> new GrokChatModelFactory();
-            case "Kimi" -> new KimiChatModelFactory();
-            case "GLM" -> new GLMChatModelFactory();
-            case "CLI Runners" -> new CliRunnersChatModelFactory();
-            case "ACP Runners" -> new AcpRunnersChatModelFactory();
-            default -> null;
-        };
+    private static @NotNull Optional<ModelProvider> resolveProvider(@NotNull String key) {
+        return FACTORY_SUPPLIERS.keySet().stream()
+                .filter(provider -> provider.name().equals(key) || provider.getName().equals(key))
+                .findFirst();
     }
 }

--- a/src/test/java/com/devoxx/genie/chatmodel/ChatModelFactoryProviderTest.java
+++ b/src/test/java/com/devoxx/genie/chatmodel/ChatModelFactoryProviderTest.java
@@ -21,10 +21,12 @@ import com.devoxx.genie.chatmodel.local.clirunners.CliRunnersChatModelFactory;
 import com.devoxx.genie.chatmodel.local.llamacpp.LlamaChatModelFactory;
 import com.devoxx.genie.chatmodel.local.lmstudio.LMStudioChatModelFactory;
 import com.devoxx.genie.chatmodel.local.ollama.OllamaChatModelFactory;
+import com.devoxx.genie.model.enumarations.ModelProvider;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -129,5 +131,32 @@ class ChatModelFactoryProviderTest {
                     .as("Factory for local provider '%s' should be present", provider)
                     .isPresent();
         }
+    }
+
+    /**
+     * Completeness guarantee: every {@link ModelProvider} constant must resolve to a factory
+     * via its enum constant name (the {@code provider.name()} key used by ChatModelProvider and
+     * LlmProviderPanel). This is the regression net that catches a provider being added to the
+     * enum but forgotten in the factory registry.
+     */
+    @ParameterizedTest(name = "ModelProvider.{0}.name() resolves to a factory")
+    @EnumSource(ModelProvider.class)
+    void everyModelProviderResolvesByConstantName(ModelProvider provider) {
+        assertThat(ChatModelFactoryProvider.getFactoryByProvider(provider.name()))
+                .as("Factory for provider constant name '%s'", provider.name())
+                .isPresent();
+    }
+
+    /**
+     * The other half of the dual-key contract: every provider must also resolve via its display
+     * name ({@code provider.getName()}, the key used by AgentSettingsComponent). This is what
+     * differs for LLaMA ("LLaMA.c++"), CLI Runners and ACP Runners.
+     */
+    @ParameterizedTest(name = "ModelProvider.{0}.getName() resolves to a factory")
+    @EnumSource(ModelProvider.class)
+    void everyModelProviderResolvesByDisplayName(ModelProvider provider) {
+        assertThat(ChatModelFactoryProvider.getFactoryByProvider(provider.getName()))
+                .as("Factory for provider display name '%s'", provider.getName())
+                .isPresent();
     }
 }


### PR DESCRIPTION
Replace the 22-branch switch in ChatModelFactoryProvider with an EnumMap<ModelProvider, Supplier<ChatModelFactory>> registry keyed off the existing ModelProvider enum, so the enum stays the single source of truth for the provider set and adding a provider is a single registry entry.

The registry lives in the chatmodel package (not as fields on ModelProvider) to avoid inverting the layering: ChatModelFactory and ~10 factories already import ModelProvider, so putting factory references on the enum would create a model->impl dependency cycle.

Suppliers are stored un-invoked and instances cached on first use, preserving the previous lazy instantiation. Lookups now accept either the enum constant name (provider.name()) or the display name (provider.getName()); these differ for LLaMA ("LLaMA.c++"), CLI Runners and ACP Runners, so the old switch silently missed Llama-by-display-name and the runners-by-constant-name depending on the caller. Accepting both fixes those latent misses.

Add EnumSource completeness tests asserting every ModelProvider resolves by both keys -- the regression net that catches a provider added to the enum but forgotten in the registry.

# Pull Request

## 📚 Documentation

Before submitting, please review our [Contributing Guide](https://genie.devoxx.com/docs/contributing).

## Description

<!-- Provide a clear description of your changes -->

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test addition/improvement

## Related Issue

<!-- Link to the issue this PR addresses -->
Fixes #
Closes #
Related to #

## Changes Made

<!-- List the specific changes made in this PR -->
-
-
-

## Testing

**How has this been tested?**

- [ ] Unit tests
- [ ] Integration tests
- [ ] Manual testing in IntelliJ IDEA
- [ ] Tested with local LLM (Ollama/LMStudio/GPT4All)
- [ ] Tested with cloud LLM (OpenAI/Anthropic/Gemini)
- [ ] Tested with MCP servers
- [ ] Tested with RAG enabled

**Test Configuration:**
- IntelliJ IDEA version:
- JDK version:
- OS:

## Documentation

- [ ] I have updated the documentation at [genie.devoxx.com](https://genie.devoxx.com) if needed
- [ ] I have updated CLAUDE.md if architecture/patterns changed
- [ ] I have added/updated code comments for complex logic
- [ ] I have updated the README.md if needed

## Checklist

- [ ] My code follows the existing code style
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Screenshots/Videos (if applicable)

<!-- Add screenshots or videos demonstrating the changes, especially for UI changes -->

## Additional Notes

<!-- Any additional information that reviewers should know -->

## Breaking Changes

<!-- If this PR introduces breaking changes, describe them here and update the version accordingly -->

---

By submitting this pull request, I confirm that my contribution is made under the terms of the project's license.
