### PR TITLE
fix(agent): show intermediate reasoning & gate tool activity in chat

### DIFF
--- a/src/main/java/com/devoxx/genie/service/agent/tool/psi/FindImplementationsToolExecutor.java
+++ b/src/main/java/com/devoxx/genie/service/agent/tool/psi/FindImplementationsToolExecutor.java
@@ -74,15 +74,8 @@ public class FindImplementationsToolExecutor implements ToolExecutor {
         List<String> results = new ArrayList<>();
         for (PsiElement impl : DefinitionsScopedSearch.search(target).findAll()) {
             if (results.size() >= MAX_RESULTS) break;
-
-            String location = PsiToolUtils.formatLocation(impl, projectBase);
-            if (location == null) continue;
-
-            String name = (impl instanceof PsiNameIdentifierOwner owner) ? owner.getName() : impl.getText();
-            String kind = (impl instanceof PsiNameIdentifierOwner owner)
-                    ? PsiToolUtils.getElementKind(owner) : "symbol";
-
-            results.add(String.format("  [%s] %s  %s", kind, name, location));
+            String entry = formatImplementation(impl, projectBase);
+            if (entry != null) results.add(entry);
         }
 
         if (results.isEmpty()) {
@@ -91,12 +84,26 @@ public class FindImplementationsToolExecutor implements ToolExecutor {
 
         StringBuilder sb = new StringBuilder();
         sb.append("Found ").append(results.size()).append(" implementation(s) of '").append(target.getName()).append("':\n\n");
-        for (String r : results) {
-            sb.append(r).append("\n");
-        }
+        sb.append(String.join("\n", results)).append("\n");
         if (results.size() >= MAX_RESULTS) {
             sb.append("\n... (truncated at ").append(MAX_RESULTS).append(" results)");
         }
         return sb.toString();
+    }
+
+    private @org.jetbrains.annotations.Nullable String formatImplementation(@NotNull PsiElement impl,
+                                                                             @NotNull VirtualFile projectBase) {
+        String location = PsiToolUtils.formatLocation(impl, projectBase);
+        if (location == null) return null;
+        String name;
+        String kind;
+        if (impl instanceof PsiNameIdentifierOwner owner) {
+            name = owner.getName();
+            kind = PsiToolUtils.getElementKind(owner);
+        } else {
+            name = impl.getText();
+            kind = "symbol";
+        }
+        return String.format("  [%s] %s  %s", kind, name, location);
     }
 }

--- a/src/main/java/com/devoxx/genie/service/prompt/memory/ChatMemoryManager.java
+++ b/src/main/java/com/devoxx/genie/service/prompt/memory/ChatMemoryManager.java
@@ -334,17 +334,18 @@ public class ChatMemoryManager {
     }
 
     public static @NotNull String buildAugmentedSystemPrompt(@NotNull Project project) {
-        String systemPrompt = DevoxxGenieStateService.getInstance().getSystemPrompt() + MARKDOWN;
+        DevoxxGenieStateService state = DevoxxGenieStateService.getInstance();
+        String systemPrompt = state.getSystemPrompt() + MARKDOWN;
         String projectPath = project.getBasePath();
 
         // Always tell the LLM the project root when tools are active
-        if (Boolean.TRUE.equals(DevoxxGenieStateService.getInstance().getAgentModeEnabled())) {
+        if (Boolean.TRUE.equals(state.getAgentModeEnabled())) {
             systemPrompt += "\n<PROJECT_ROOT>" + projectPath + "</PROJECT_ROOT>" +
                     "\nAll file paths in tool calls are relative to this project root directory.\n";
         }
 
         // Add test execution instruction if enabled
-        if (Boolean.TRUE.equals(DevoxxGenieStateService.getInstance().getTestExecutionEnabled())) {
+        if (Boolean.TRUE.equals(state.getTestExecutionEnabled())) {
             systemPrompt += """
                     <TESTING_INSTRUCTION>
                     After modifying code using write_file or edit_file, run relevant tests
@@ -368,8 +369,8 @@ public class ChatMemoryManager {
         // unless they're told the project has a semantic index; tool descriptions alone
         // aren't enough signal. This mirrors the <TESTING_INSTRUCTION> / <MCP_INSTRUCTION>
         // pattern used for other tools that need an explicit nudge.
-        if (Boolean.TRUE.equals(DevoxxGenieStateService.getInstance().getAgentModeEnabled())
-                && Boolean.TRUE.equals(DevoxxGenieStateService.getInstance().getRagEnabled())) {
+        if (Boolean.TRUE.equals(state.getAgentModeEnabled())
+                && Boolean.TRUE.equals(state.getRagEnabled())) {
             systemPrompt += """
                     <RAG_INSTRUCTION>
                     This project has a semantic vector index of its content. For any user
@@ -383,41 +384,49 @@ public class ChatMemoryManager {
                     """;
         }
 
-        // Add DEVOXXGENIE.md content to system prompt (once per conversation)
-        if (Boolean.TRUE.equals(DevoxxGenieStateService.getInstance().getUseDevoxxGenieMdInPrompt())) {
-            String devoxxGenieMdContent = readDevoxxGenieMdFile(project);
-            if (devoxxGenieMdContent != null && !devoxxGenieMdContent.isEmpty()) {
-                systemPrompt += "\n<ProjectContext>\n" + devoxxGenieMdContent + "\n</ProjectContext>\n";
-            }
-        }
-
-        // Add CLAUDE.md or AGENTS.md content to system prompt (once per conversation)
-        if (Boolean.TRUE.equals(DevoxxGenieStateService.getInstance().getUseClaudeOrAgentsMdInPrompt())) {
-            String claudeOrAgentsMdContent = readClaudeOrAgentsMdFile(project);
-            if (claudeOrAgentsMdContent != null && !claudeOrAgentsMdContent.isEmpty()) {
-                systemPrompt += "\n<ProjectContext>\n" + claudeOrAgentsMdContent + "\n</ProjectContext>\n";
-            }
-        }
-
-        // Append langchain4j Skills system-prompt fragment (issue #1040). Only when agent
-        // mode is enabled — skills are wired into the agent tool chain, so listing them
-        // outside agent mode would be misleading.
-        if (Boolean.TRUE.equals(DevoxxGenieStateService.getInstance().getAgentModeEnabled()) && !project.isDefault()) {
-            try {
-                String skillsFragment = SkillRegistry.getInstance(project).getSystemPromptFragment();
-                if (skillsFragment != null && !skillsFragment.isEmpty()) {
-                    systemPrompt += "\nYou have access to the following skills:\n"
-                            + skillsFragment
-                            + "\nWhen the user's request relates to one of these skills, activate it first using the `"
-                            + SkillRegistry.ACTIVATE_SKILL_TOOL_NAME
-                            + "` tool before proceeding.\n";
-                }
-            } catch (Exception e) {
-                log.warn("Failed to append Skills system-prompt fragment", e);
-            }
-        }
+        systemPrompt += getDevoxxGenieMdSection(project, state);
+        systemPrompt += getClaudeOrAgentsMdSection(project, state);
+        systemPrompt += getSkillsSection(project, state);
 
         return TemplateVariableEscaper.escape(systemPrompt);
+    }
+
+    private static String getDevoxxGenieMdSection(@NotNull Project project, @NotNull DevoxxGenieStateService state) {
+        if (!Boolean.TRUE.equals(state.getUseDevoxxGenieMdInPrompt())) {
+            return "";
+        }
+        String content = readDevoxxGenieMdFile(project);
+        return (content != null && !content.isEmpty()) ? "\n<ProjectContext>\n" + content + "\n</ProjectContext>\n" : "";
+    }
+
+    private static String getClaudeOrAgentsMdSection(@NotNull Project project, @NotNull DevoxxGenieStateService state) {
+        if (!Boolean.TRUE.equals(state.getUseClaudeOrAgentsMdInPrompt())) {
+            return "";
+        }
+        String content = readClaudeOrAgentsMdFile(project);
+        return (content != null && !content.isEmpty()) ? "\n<ProjectContext>\n" + content + "\n</ProjectContext>\n" : "";
+    }
+
+    // Append langchain4j Skills system-prompt fragment (issue #1040). Only when agent
+    // mode is enabled — skills are wired into the agent tool chain, so listing them
+    // outside agent mode would be misleading.
+    private static String getSkillsSection(@NotNull Project project, @NotNull DevoxxGenieStateService state) {
+        if (!Boolean.TRUE.equals(state.getAgentModeEnabled()) || project.isDefault()) {
+            return "";
+        }
+        try {
+            String fragment = SkillRegistry.getInstance(project).getSystemPromptFragment();
+            if (!fragment.isEmpty()) {
+                return "\nYou have access to the following skills:\n"
+                        + fragment
+                        + "\nWhen the user's request relates to one of these skills, activate it first using the `"
+                        + SkillRegistry.ACTIVATE_SKILL_TOOL_NAME
+                        + "` tool before proceeding.\n";
+            }
+        } catch (Exception e) {
+            log.warn("Failed to append Skills system-prompt fragment", e);
+        }
+        return "";
     }
 
     /**

--- a/src/main/java/com/devoxx/genie/service/prompt/response/streaming/StreamingResponseHandler.java
+++ b/src/main/java/com/devoxx/genie/service/prompt/response/streaming/StreamingResponseHandler.java
@@ -90,6 +90,24 @@ public class StreamingResponseHandler implements StreamingChatResponseHandler {
         }
     }
 
+    /**
+     * Invoked at each agent-loop turn boundary — i.e. when the LLM returns an intermediate
+     * response that requests tool execution. langchain4j keeps streaming the next turn's
+     * text through {@link #onPartialResponse(String)} into the same accumulator, so without
+     * a marker here the reasoning of one turn would run straight into the next. We append a
+     * blank-line separator so each turn renders as its own paragraph in the chat panel.
+     */
+    public void onIntermediateResponse(ChatResponse response) {
+        if (isStopped) {
+            return;
+        }
+        // Only separate turns that actually produced reasoning text; a tool-only turn
+        // (empty text) shouldn't leave a dangling blank line.
+        if (!accumulatedResponse.isEmpty() && !accumulatedResponse.toString().endsWith("\n\n")) {
+            accumulatedResponse.append("\n\n");
+        }
+    }
+
     @Override
     public void onCompleteResponse(ChatResponse response) {
         if (isStopped) {
@@ -99,7 +117,19 @@ public class StreamingResponseHandler implements StreamingChatResponseHandler {
         try {
             long endTime = System.currentTimeMillis();
             context.setExecutionTimeMs(endTime - startTime);
-            context.setAiMessage(response.aiMessage());
+
+            // In agent mode the LLM streams intermediate reasoning (e.g. "Let me take a
+            // look...") before each tool call. langchain4j delivers those tokens through
+            // onPartialResponse (so they accumulate here), but the final ChatResponse only
+            // carries the LAST turn's AiMessage. Using response.aiMessage() directly would
+            // therefore erase all intermediate reasoning from the chat panel. Prefer the
+            // accumulated text whenever we streamed partials, so the full visible turn is
+            // what we render and persist.
+            if (hasAddedInitialMessage && !accumulatedResponse.isEmpty()) {
+                context.setAiMessage(dev.langchain4j.data.message.AiMessage.from(accumulatedResponse.toString()));
+            } else {
+                context.setAiMessage(response.aiMessage());
+            }
 
             // Update the view with the final response (if viewController is available)
             if (conversationViewController != null) {

--- a/src/main/java/com/devoxx/genie/service/prompt/strategy/StreamingPromptStrategy.java
+++ b/src/main/java/com/devoxx/genie/service/prompt/strategy/StreamingPromptStrategy.java
@@ -181,6 +181,7 @@ public class StreamingPromptStrategy extends AbstractPromptExecutionStrategy {
 
             assistant.chat(cleanText)
                 .onPartialResponse(handler::onPartialResponse)
+                .onIntermediateResponse(handler::onIntermediateResponse)
                 .onToolExecuted(this::logToolExecution)
                 .onCompleteResponse(handler::onCompleteResponse)
                 .onError(handler::onError)

--- a/src/main/kotlin/com/devoxx/genie/ui/compose/viewmodel/ConversationViewModel.kt
+++ b/src/main/kotlin/com/devoxx/genie/ui/compose/viewmodel/ConversationViewModel.kt
@@ -27,6 +27,18 @@ class ConversationViewModel(
      * stays empty and the section is hidden.
      */
     private val project: Project? = null,
+    /**
+     * Whether tool-call activity (tool requests/responses, MCP messages) should be shown
+     * in the chat output. Pure agent reasoning text is always shown regardless. Defaults to
+     * the "Show tool activity in chat output" setting; injectable for tests.
+     */
+    private val showToolActivityInChat: () -> Boolean = {
+        try {
+            DevoxxGenieStateService.getInstance().showToolActivityInChat == true
+        } catch (_: Exception) {
+            false
+        }
+    },
 ) {
 
     var state: ConversationState by mutableStateOf(
@@ -212,6 +224,11 @@ class ConversationViewModel(
             }
             return
         }
+
+        // Everything else (tool requests/responses, MCP messages, approvals) is "tool
+        // activity" — only surfaced in the chat output when the user opted in. Pure agent
+        // reasoning above is always shown.
+        if (!showToolActivityInChat()) return
 
         val entry = ActivityEntryUiModel(
             source = message.source?.name ?: "UNKNOWN",

--- a/src/test/java/com/devoxx/genie/service/prompt/response/streaming/StreamingResponseHandlerTest.java
+++ b/src/test/java/com/devoxx/genie/service/prompt/response/streaming/StreamingResponseHandlerTest.java
@@ -19,6 +19,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.MockitoAnnotations;
@@ -169,6 +170,55 @@ class StreamingResponseHandlerTest {
         verify(mockContext).setAiMessage(aiMessage);
         assertThat(onCompleteCalled.get()).isTrue();
         assertThat(completedResponse.get()).isEqualTo(response);
+    }
+
+    @Test
+    void onCompleteResponse_afterIntermediateAgentText_preservesFullStreamedText() {
+        StreamingResponseHandler handler = createHandler();
+
+        // Agent mode: the LLM streams intermediate reasoning before a tool call (turn 1)...
+        handler.onPartialResponse("Great question! Let me take a look at the code first.");
+        // ...the tool executes, then the final answer is streamed (turn 2).
+        handler.onPartialResponse("\n\nHere is the improved factory.");
+
+        // langchain4j delivers onCompleteResponse with ONLY the final turn's AiMessage.
+        AiMessage finalTurnOnly = AiMessage.from("Here is the improved factory.");
+        ChatResponse response = ChatResponse.builder()
+            .aiMessage(finalTurnOnly)
+            .build();
+
+        handler.onCompleteResponse(response);
+
+        // The chat panel reads context.aiMessage; it must keep the intermediate reasoning,
+        // not just the final turn (otherwise "Great question!..." disappears from the chat).
+        ArgumentCaptor<AiMessage> captor = ArgumentCaptor.forClass(AiMessage.class);
+        verify(mockContext, atLeastOnce()).setAiMessage(captor.capture());
+        assertThat(captor.getValue().text())
+            .contains("Great question! Let me take a look at the code first.")
+            .contains("Here is the improved factory.");
+    }
+
+    @Test
+    void onIntermediateResponse_insertsSeparatorBetweenAgentTurns() {
+        StreamingResponseHandler handler = createHandler();
+
+        // Turn 1: intermediate reasoning streamed before a tool call.
+        handler.onPartialResponse("Great question! Let me take a look.");
+        // Turn boundary: langchain4j signals the intermediate (tool-calling) response.
+        handler.onIntermediateResponse(ChatResponse.builder()
+            .aiMessage(AiMessage.from("Great question! Let me take a look."))
+            .build());
+        // Turn 2: the final answer streamed (no separator in the raw tokens).
+        handler.onPartialResponse("Here is the improved factory.");
+
+        AiMessage finalTurnOnly = AiMessage.from("Here is the improved factory.");
+        handler.onCompleteResponse(ChatResponse.builder().aiMessage(finalTurnOnly).build());
+
+        ArgumentCaptor<AiMessage> captor = ArgumentCaptor.forClass(AiMessage.class);
+        verify(mockContext, atLeastOnce()).setAiMessage(captor.capture());
+        // Turns must be visually separated by a blank line, not run together.
+        assertThat(captor.getValue().text())
+            .isEqualTo("Great question! Let me take a look.\n\nHere is the improved factory.");
     }
 
     @Test

--- a/src/test/kotlin/com/devoxx/genie/ui/compose/viewmodel/ConversationViewModelTest.kt
+++ b/src/test/kotlin/com/devoxx/genie/ui/compose/viewmodel/ConversationViewModelTest.kt
@@ -1,5 +1,8 @@
 package com.devoxx.genie.ui.compose.viewmodel
 
+import com.devoxx.genie.model.activity.ActivityMessage
+import com.devoxx.genie.model.activity.ActivitySource
+import com.devoxx.genie.model.agent.AgentType
 import com.devoxx.genie.model.request.ChatMessageContext
 import com.devoxx.genie.ui.compose.model.ConversationState
 import dev.langchain4j.data.message.AiMessage
@@ -31,4 +34,52 @@ class ConversationViewModelTest {
         val afterThemeChange = viewModel.state as ConversationState.Chat
         assertThat(afterThemeChange.messages).containsExactlyElementsOf(beforeThemeChange.messages)
     }
+
+    @Test
+    fun `when show tool activity is off only agent reasoning is shown not tool calls`() {
+        val viewModel = ConversationViewModel(showToolActivityInChat = { false })
+        viewModel.addUserPromptMessage(ChatMessageContext.builder().id("msg-1").userPrompt("hi").build())
+
+        viewModel.onActivityMessage(toolRequest("list_files", "src/main/java"))
+        viewModel.onActivityMessage(intermediateResponse("I'll explore the project structure first."))
+
+        val entries = activeMessageEntries(viewModel)
+        assertThat(entries).hasSize(1)
+        assertThat(entries[0].source).isEqualTo("AGENT")
+        assertThat(entries[0].content).isEqualTo("I'll explore the project structure first.")
+        assertThat(entries[0].toolName).isNull()
+    }
+
+    @Test
+    fun `when show tool activity is on both tool calls and agent reasoning are shown`() {
+        val viewModel = ConversationViewModel(showToolActivityInChat = { true })
+        viewModel.addUserPromptMessage(ChatMessageContext.builder().id("msg-1").userPrompt("hi").build())
+
+        viewModel.onActivityMessage(toolRequest("list_files", "src/main/java"))
+        viewModel.onActivityMessage(intermediateResponse("I'll explore the project structure first."))
+
+        val entries = activeMessageEntries(viewModel)
+        assertThat(entries).hasSize(2)
+        assertThat(entries.map { it.toolName }).contains("list_files")
+    }
+
+    private fun activeMessageEntries(viewModel: ConversationViewModel) =
+        (viewModel.state as ConversationState.Chat).messages.first { it.id == "msg-1" }.activityEntries
+
+    private fun toolRequest(toolName: String, arguments: String): ActivityMessage =
+        ActivityMessage.builder()
+            .source(ActivitySource.AGENT)
+            .agentType(AgentType.TOOL_REQUEST)
+            .toolName(toolName)
+            .arguments(arguments)
+            .callNumber(1)
+            .maxCalls(50)
+            .build()
+
+    private fun intermediateResponse(text: String): ActivityMessage =
+        ActivityMessage.builder()
+            .source(ActivitySource.AGENT)
+            .agentType(AgentType.INTERMEDIATE_RESPONSE)
+            .result(text)
+            .build()
 }


### PR DESCRIPTION
## Summary
- **Keep intermediate reasoning visible (streaming agent mode):** the LLM's reasoning text before each tool call ("Let me take a look…") was streamed and logged but vanished from the chat panel at completion, because langchain4j's final `ChatResponse` only carries the last turn's `AiMessage` and `onCompleteResponse` overwrote the accumulated text. Now the full accumulated streamed text is preserved, with a blank-line separator between agent turns via `onIntermediateResponse`.
- **Respect "Show tool activity in chat output":** the setting was dead after the Compose migration, so `[AGENT] tool_name …` entries always appeared. `ConversationViewModel.onActivityMessage` now always shows pure agent reasoning but only renders tool/MCP activity when the setting is enabled.
- Two small unrelated refactors carried in the working tree: extract a formatting helper in `FindImplementationsToolExecutor`, and split `ChatMemoryManager.buildAugmentedSystemPrompt` into focused section builders.

## Test plan
- [x] `StreamingResponseHandlerTest` — new tests for preserving multi-turn text and inserting turn separators
- [x] `ConversationViewModelTest` — new tests for tool-activity gating (on/off)
- [x] Full `./gradlew test` suite green (JDK 21)
- [ ] Manual: agent mode + tool-calling model, verify reasoning shows in chat; toggle "Show tool activity in chat output" off and confirm only agent text (no tool names) appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)