### PR TITLE
fix: don't read API keys from OS keychain at IDE startup

### DIFF
--- a/src/main/java/com/devoxx/genie/service/LLMProviderService.java
+++ b/src/main/java/com/devoxx/genie/service/LLMProviderService.java
@@ -50,7 +50,7 @@ public class LLMProviderService {
 
     public List<ModelProvider> getAvailableModelProviders() {
         List<ModelProvider> providers = new ArrayList<>();
-        providers.addAll(getModelProvidersWithApiKeyConfigured());
+        providers.addAll(getEnabledCloudModelProviders());
         providers.addAll(getLocalModelProviders());
         providers.addAll(getOptionalProviders());
         providers.addAll(getCliRunnersProvider());
@@ -64,20 +64,38 @@ public class LLMProviderService {
     }
 
     /**
-     * Get LLM providers for which an API Key is defined in the settings
+     * Get the cloud LLM providers the user has enabled in the settings.
+     *
+     * <p>Deliberately checks only the non-secret enabled flags, never the credential
+     * store: reading API keys here would hit the OS keychain (PasswordSafe) on every
+     * IDE startup just to populate the provider combo box, triggering macOS keychain
+     * dialogs. Keys are read lazily via {@link #getApiKey} when a prompt is executed.</p>
      *
      * @return List of LLM providers
      */
-    private List<ModelProvider> getModelProvidersWithApiKeyConfigured() {
+    private List<ModelProvider> getEnabledCloudModelProviders() {
+        DevoxxGenieStateService stateService = DevoxxGenieStateService.getInstance();
         return LLMModelRegistryService.getInstance().getModels()
             .stream()
             .filter(LanguageModel::isApiKeyUsed)
             .map(LanguageModel::getProvider)
             .distinct()
-            .filter(provider -> Optional.ofNullable(providerKeyMap.get(provider))
-                .map(Supplier::get)
-                .filter(key -> !key.isBlank())
-                .isPresent())
+            .filter(provider -> switch (provider) {
+                case OpenAI -> stateService.isOpenAIEnabled();
+                case Anthropic -> stateService.isAnthropicEnabled();
+                case Mistral -> stateService.isMistralEnabled();
+                case Groq -> stateService.isGroqEnabled();
+                case DeepInfra -> stateService.isDeepInfraEnabled();
+                case Google -> stateService.isGoogleEnabled();
+                case DeepSeek -> stateService.isDeepSeekEnabled();
+                case OpenRouter -> stateService.isOpenRouterEnabled();
+                case Grok -> stateService.isGrokEnabled();
+                case Kimi -> stateService.isKimiEnabled();
+                case GLM -> stateService.isGlmEnabled();
+                case AzureOpenAI -> stateService.isAzureOpenAIEnabled();
+                case Bedrock -> stateService.isAwsEnabled();
+                default -> false;
+            })
             .toList();
     }
 

--- a/src/test/java/com/devoxx/genie/service/LLMProviderServiceTest.java
+++ b/src/test/java/com/devoxx/genie/service/LLMProviderServiceTest.java
@@ -1,0 +1,118 @@
+package com.devoxx.genie.service;
+
+import com.devoxx.genie.model.LanguageModel;
+import com.devoxx.genie.model.enumarations.ModelProvider;
+import com.devoxx.genie.service.credentials.CredentialKey;
+import com.devoxx.genie.service.credentials.CredentialService;
+import com.devoxx.genie.service.models.LLMModelRegistryService;
+import com.devoxx.genie.ui.settings.DevoxxGenieStateService;
+import com.intellij.openapi.application.Application;
+import com.intellij.openapi.application.ApplicationManager;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Regression tests for lazy credential loading (keychain prompt at IDE startup).
+ * Determining which providers are available must never read secrets from the
+ * credential store; keys may only be read when actually used (prompt execution).
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class LLMProviderServiceTest {
+
+    @Mock
+    private Application application;
+
+    @Mock
+    private CredentialService credentialService;
+
+    @Mock
+    private LLMModelRegistryService modelRegistryService;
+
+    private MockedStatic<ApplicationManager> applicationManagerMockedStatic;
+    private MockedStatic<DevoxxGenieStateService> stateServiceMockedStatic;
+
+    private DevoxxGenieStateService stateService;
+    private LLMProviderService providerService;
+
+    @BeforeEach
+    void setUp() {
+        stateService = new DevoxxGenieStateService();
+
+        applicationManagerMockedStatic = Mockito.mockStatic(ApplicationManager.class);
+        applicationManagerMockedStatic.when(ApplicationManager::getApplication).thenReturn(application);
+        lenient().when(application.getService(DevoxxGenieStateService.class)).thenReturn(stateService);
+        lenient().when(application.getService(CredentialService.class)).thenReturn(credentialService);
+        lenient().when(application.getService(LLMModelRegistryService.class)).thenReturn(modelRegistryService);
+
+        stateServiceMockedStatic = Mockito.mockStatic(DevoxxGenieStateService.class);
+        stateServiceMockedStatic.when(DevoxxGenieStateService::getInstance).thenReturn(stateService);
+
+        lenient().when(credentialService.getCredential(any())).thenReturn("");
+        lenient().when(modelRegistryService.getModels()).thenReturn(List.of(
+                LanguageModel.builder().provider(ModelProvider.Anthropic).modelName("claude-sonnet-4-6").apiKeyUsed(true).build(),
+                LanguageModel.builder().provider(ModelProvider.OpenAI).modelName("gpt-5").apiKeyUsed(true).build()
+        ));
+
+        providerService = new LLMProviderService();
+    }
+
+    @AfterEach
+    void tearDown() {
+        stateServiceMockedStatic.close();
+        applicationManagerMockedStatic.close();
+    }
+
+    @Test
+    void getAvailableModelProvidersShouldNeverReadCredentialStore() {
+        stateService.setAnthropicEnabled(true);
+
+        providerService.getAvailableModelProviders();
+
+        verify(credentialService, never()).getCredential(any());
+    }
+
+    @Test
+    void enabledCloudProviderIsAvailableWithoutStoredKey() {
+        stateService.setAnthropicEnabled(true);
+
+        List<ModelProvider> providers = providerService.getAvailableModelProviders();
+
+        assertThat(providers).contains(ModelProvider.Anthropic);
+    }
+
+    @Test
+    void disabledCloudProviderIsNotAvailableEvenWithStoredKey() {
+        stateService.setOpenAIEnabled(false);
+        lenient().when(credentialService.getCredential(CredentialKey.OPEN_AI_KEY)).thenReturn("sk-test");
+
+        List<ModelProvider> providers = providerService.getAvailableModelProviders();
+
+        assertThat(providers).doesNotContain(ModelProvider.OpenAI);
+    }
+
+    @Test
+    void getApiKeyReadsCredentialStoreLazilyAtUseTime() {
+        when(credentialService.getCredential(CredentialKey.ANTHROPIC_KEY)).thenReturn("sk-ant-test");
+
+        assertThat(providerService.getApiKey(ModelProvider.Anthropic)).isEqualTo("sk-ant-test");
+        verify(credentialService).getCredential(CredentialKey.ANTHROPIC_KEY);
+    }
+}


### PR DESCRIPTION
## Summary
- Fixes the macOS keychain password dialog appearing on every IDE startup since API keys moved to the secret vault (PasswordSafe)
- Root cause: populating the LLM provider combo box called `PasswordSafe.get()` for every cloud provider key on project open (`LlmProviderPanel` → `getAvailableModelProviders()` → key-presence filter)
- Provider availability is now derived solely from the non-secret per-provider enabled flags already persisted in the settings XML; API keys are only read lazily via `getApiKey()` when a prompt is actually executed
- Behavior change: a provider that is enabled in Settings but has no stored key now appears in the combo box and fails at prompt time, instead of being silently hidden

## Test plan
- [x] New `LLMProviderServiceTest` asserts `getAvailableModelProviders()` never calls `CredentialService.getCredential()` (failed before the fix, passes after)
- [x] Tests cover: enabled provider available without stored key, disabled provider hidden even with stored key, `getApiKey()` still reads the credential store lazily
- [x] Full test suite green (`./gradlew test`)
- [x] Manually verified: no keychain prompt at IDE startup; key is read (and macOS prompts at most once per IDE) only when a prompt is submitted

🤖 Generated with [Claude Code](https://claude.com/claude-code)