### PR TITLE
fix: skip Java-only PSI agent tools when Java plugin is absent (#1100)

### DIFF
--- a/src/main/java/com/devoxx/genie/service/agent/tool/BuiltInToolProvider.java
+++ b/src/main/java/com/devoxx/genie/service/agent/tool/BuiltInToolProvider.java
@@ -337,6 +337,15 @@ public class BuiltInToolProvider implements ToolProvider {
                 new FindImplementationsToolExecutor(project)
         );
 
+        // The remaining tools are Java-only: their executor classes reference Java-plugin PSI
+        // types (PsiMethod, PsiModifierListOwner, …) in method signatures, so merely linking
+        // them throws NoClassDefFoundError in IDEs without the Java plugin (PyCharm, WebStorm,
+        // GoLand, …) — see issue #1100. The isJavaAvailable() checks inside their execute()
+        // methods cannot help because the class never loads. Skip registration entirely.
+        if (!PsiToolUtils.isJavaAvailable()) {
+            return;
+        }
+
         // find_callees — outgoing calls from a method (inverse of find_references)
         tools.put(
                 ToolSpecification.builder()

--- a/src/test/java/com/devoxx/genie/service/agent/tool/BuiltInToolProviderTest.java
+++ b/src/test/java/com/devoxx/genie/service/agent/tool/BuiltInToolProviderTest.java
@@ -1,6 +1,7 @@
 package com.devoxx.genie.service.agent.tool;
 
 import com.devoxx.genie.service.agent.tool.psi.PsiToolCatalog;
+import com.devoxx.genie.service.agent.tool.psi.PsiToolUtils;
 import com.devoxx.genie.ui.settings.DevoxxGenieStateService;
 import com.intellij.openapi.project.Project;
 import dev.langchain4j.agent.tool.ToolSpecification;
@@ -268,6 +269,32 @@ class BuiltInToolProviderTest {
         assertThat(toolNames).contains(
                 "find_symbols", "document_symbols", "find_references", "find_definition",
                 "find_implementations", "find_callees", "trace_call_chains", "calculate_complexity");
+    }
+
+    /**
+     * Regression test for issue #1100: on non-Java IDEs (PyCharm, WebStorm, GoLand…) the
+     * classes of the four Java-only PSI executors cannot even be linked — their method
+     * signatures reference Java-plugin PSI types such as {@code PsiModifierListOwner},
+     * so constructing them throws {@link NoClassDefFoundError} and kills agent mode
+     * entirely. When Java PSI is unavailable, only the five platform-level PSI tools
+     * may be registered; the Java-only executors must never be instantiated.
+     */
+    @Test
+    void provideTools_psiToolsEnabledButJavaPsiUnavailable_registersOnlyPlatformPsiTools() {
+        when(stateService.getPsiToolsEnabled()).thenReturn(true);
+
+        try (MockedStatic<PsiToolUtils> psiToolUtilsMock = mockStatic(PsiToolUtils.class)) {
+            psiToolUtilsMock.when(PsiToolUtils::isJavaAvailable).thenReturn(false);
+            BuiltInToolProvider provider = createProvider();
+
+            Set<String> toolNames = getToolNames(provider.provideTools(request));
+
+            assertThat(toolNames).contains(
+                    "find_symbols", "document_symbols", "find_references",
+                    "find_definition", "find_implementations");
+            assertThat(toolNames).doesNotContain(
+                    "find_callees", "trace_call_chains", "calculate_complexity", "find_dead_code");
+        }
     }
 
     // --- All features enabled ---


### PR DESCRIPTION
## Summary

Fixes #1100 — agent mode crashed on non-Java IDEs (PyCharm, WebStorm, GoLand, …) with:

```
java.lang.NoClassDefFoundError: com/intellij/psi/PsiModifierListOwner
    at com.devoxx.genie.service.agent.tool.BuiltInToolProvider.registerPsiTools(BuiltInToolProvider.java:416)
```

Ask mode worked fine; only agent mode crashed.

## Root cause

`com.intellij.modules.java` is an **optional** plugin dependency, so its PSI classes
(`PsiMethod`, `PsiModifierListOwner`, …) are absent on the classpath in non-Java IDEs.
Four of the nine PSI agent-tool executors reference those Java-plugin PSI types directly
in their method signatures:

- `FindCalleesToolExecutor`
- `TraceCallChainsToolExecutor`
- `CalculateComplexityToolExecutor`
- `FindDeadCodeToolExecutor` (the `PsiModifierListOwner` in the stack trace)

`registerPsiTools` constructs every executor unconditionally, and `psiToolsEnabled`
defaults to `true`, so simply linking these classes threw `NoClassDefFoundError` and took
down the whole prompt. The existing `PsiToolUtils.isJavaAvailable()` guard inside each
`execute()` method never got a chance to run — the class failed to load before any method
could execute.

## Fix

`registerPsiTools` now checks `PsiToolUtils.isJavaAvailable()` and returns early after the
five platform-level PSI tools when the Java plugin is absent. Non-Java IDEs keep the
language-agnostic tools (`find_symbols`, `document_symbols`, `find_references`,
`find_definition`, `find_implementations`) and the four Java-only executors are never
instantiated, so agent mode works again.

## Testing

Added a regression test `provideTools_psiToolsEnabledButJavaPsiUnavailable_registersOnlyPlatformPsiTools`
that mocks `isJavaAvailable()` → `false` and asserts the four Java-only tools are not
registered while the five platform tools still are. Written test-first (watched it fail,
then pass). Full `BuiltInToolProviderTest` is green (23/23).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
