### PR TITLE
fix(settings): TASK-238 open settings dialog without blocking the EDT

### DIFF
--- a/backlog/completed/task-238 - Fix-PyCharm-EDT-exception-when-opening-DevoxxGenie-settings.md
+++ b/backlog/completed/task-238 - Fix-PyCharm-EDT-exception-when-opening-DevoxxGenie-settings.md
@@ -1,0 +1,46 @@
+---
+id: TASK-238
+title: Fix PyCharm EDT exception when opening DevoxxGenie settings
+status: Done
+assignee: []
+created_date: '2026-06-10 20:23'
+updated_date: '2026-06-10 21:20'
+labels:
+  - bug
+  - pycharm
+  - settings
+  - edt
+dependencies: []
+references:
+  - src/main/java/com/devoxx/genie/ui/util/SettingsDialogUtil.java
+  - src/main/java/com/devoxx/genie/ui/window/DevoxxGenieToolWindowFactory.java
+modified_files:
+  - src/main/java/com/devoxx/genie/ui/util/SettingsDialogUtil.java
+  - src/main/java/com/devoxx/genie/ui/settings/agent/AgentSettingsComponent.java
+  - src/test/java/com/devoxx/genie/ApiCompatibilityTest.java
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Opening DevoxxGenie settings from the tool window in PyCharm can throw `java.lang.IllegalStateException: This method is forbidden on EDT because it does not pump the event queue`. The observed stack starts from `DevoxxGenieToolWindowFactory$OpenSettingsAction.actionPerformed`, calls `SettingsDialogUtil.showSettingsDialog`, then IntelliJ builds settings configurables and PyCharm's Flask console options call `PythonPackageManager.Companion.forSdk(...)` via `FlaskUtilsKt.isFlaskInstalled(...)`, which is forbidden on the EDT. Investigate how the plugin opens settings and adjust the flow so opening DevoxxGenie settings does not synchronously trigger forbidden PyCharm package-manager work on the event dispatch thread.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Opening DevoxxGenie settings from the tool window in PyCharm no longer throws the EDT `IllegalStateException`.
+- [x] #2 The settings action still opens the intended DevoxxGenie settings page in IntelliJ-based IDEs where Python/PyCharm configurables are present and where they are absent.
+- [x] #3 The fix avoids blocking or long-running work on the EDT and uses an IntelliJ Platform-supported threading/progress approach where needed.
+- [x] #4 A regression test or documented manual verification covers the PyCharm settings-opening path.
+<!-- AC:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Root cause (verified against IntelliJ 2025.3.3 bytecode): every synchronous `ShowSettingsUtil.showSettingsDialog(...)` overload (display-name, class, or predicate based) collects ALL configurable groups on the calling thread. In PyCharm, building the group tree runs `FlaskConsoleOptionsProvider.isApplicableTo()` → `PythonPackageManager.forSdk()` → `runBlockingCancellable`, which asserts a background thread and throws on the EDT. Intermittent because the Python package manager is cached per SDK after the first call.
+
+Fix mirrors the platform's own ShowSettingsAction: `SettingsDialogUtil` now collects configurable groups via `ShowSettingsUtilImpl.getConfigurableGroups()` on a pooled thread, resolves the target configurable with `ConfigurableVisitor`, then shows the dialog on the EDT via the non-deprecated, non-internal `ShowSettingsUtilImpl.showSettings()`. Added a display-name variant and a disposed-project guard. Routed the "Open Web search settings" / "Open RAG settings" hyperlinks in `AgentSettingsComponent` (same EDT bug) through the utility. Regression coverage: `ApiCompatibilityTest.settingsDialogIsNeverOpenedSynchronouslyOnTheEdt` scans src/main and fails if any code calls `ShowSettingsUtil.getInstance().showSettingsDialog` directly (TDD: red before fix, green after). Full suite: 2955 tests, only pre-existing unrelated `ReadFileToolExecutorTest` failure (fails on clean tree too).
+
+PR: https://github.com/devoxx/DevoxxGenieIDEAPlugin/pull/1108
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/src/main/java/com/devoxx/genie/ui/settings/agent/AgentSettingsComponent.java
+++ b/src/main/java/com/devoxx/genie/ui/settings/agent/AgentSettingsComponent.java
@@ -12,7 +12,7 @@ import com.devoxx.genie.ui.renderer.ModelInfoRenderer;
 import com.devoxx.genie.ui.settings.AbstractSettingsComponent;
 import com.devoxx.genie.ui.settings.DevoxxGenieStateService;
 import com.devoxx.genie.ui.util.DevoxxGenieFontsUtil;
-import com.intellij.openapi.options.ShowSettingsUtil;
+import com.devoxx.genie.ui.util.SettingsDialogUtil;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.project.ProjectManager;
 import com.intellij.openapi.ui.ComboBox;
@@ -797,7 +797,7 @@ public class AgentSettingsComponent extends AbstractSettingsComponent {
         link.addHyperlinkListener(e -> {
             Project[] projects = ProjectManager.getInstance().getOpenProjects();
             Project p = projects.length > 0 ? projects[0] : null;
-            ShowSettingsUtil.getInstance().showSettingsDialog(p, "Web search");
+            SettingsDialogUtil.showSettingsDialog(p, "Web search");
         });
         panel.add(link);
         return panel;
@@ -836,7 +836,7 @@ public class AgentSettingsComponent extends AbstractSettingsComponent {
         link.addHyperlinkListener(e -> {
             Project[] projects = ProjectManager.getInstance().getOpenProjects();
             Project p = projects.length > 0 ? projects[0] : null;
-            ShowSettingsUtil.getInstance().showSettingsDialog(p, "RAG");
+            SettingsDialogUtil.showSettingsDialog(p, "RAG");
         });
         panel.add(link);
         return panel;

--- a/src/main/java/com/devoxx/genie/ui/util/SettingsDialogUtil.java
+++ b/src/main/java/com/devoxx/genie/ui/util/SettingsDialogUtil.java
@@ -1,7 +1,18 @@
 package com.devoxx.genie.ui.util;
 
-import com.intellij.openapi.options.ShowSettingsUtil;
+import com.devoxx.genie.ui.settings.llm.LLMProvidersConfigurable;
+import com.intellij.ide.actions.ShowSettingsUtilImpl;
+import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.options.Configurable;
+import com.intellij.openapi.options.ConfigurableGroup;
+import com.intellij.openapi.options.ex.ConfigurableVisitor;
 import com.intellij.openapi.project.Project;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.Function;
 
 public class SettingsDialogUtil {
 
@@ -9,7 +20,29 @@ public class SettingsDialogUtil {
         /* This utility class should not be instantiated */
     }
 
-    public static void showSettingsDialog(Project project) {
-        ShowSettingsUtil.getInstance().showSettingsDialog(project, "DevoxxGenie");
+    public static void showSettingsDialog(@Nullable Project project) {
+        showSettingsDialog(project, groups -> ConfigurableVisitor.findByType(LLMProvidersConfigurable.class, groups));
+    }
+
+    public static void showSettingsDialog(@Nullable Project project, @NotNull String displayName) {
+        showSettingsDialog(project, groups ->
+                ConfigurableVisitor.find(configurable -> displayName.equals(configurable.getDisplayName()), groups));
+    }
+
+    private static void showSettingsDialog(@Nullable Project project,
+                                           @NotNull Function<List<ConfigurableGroup>, Configurable> selector) {
+        ApplicationManager.getApplication().executeOnPooledThread(() -> {
+            // Collecting the configurable groups runs third-party configurables; in PyCharm the
+            // Flask console configurable calls runBlockingCancellable, which is forbidden on the
+            // EDT. Collect on a pooled thread, then show the dialog on the EDT with the result.
+            List<ConfigurableGroup> groups = Arrays.asList(ShowSettingsUtilImpl.getConfigurableGroups(project, true));
+            Configurable toSelect = selector.apply(groups);
+            ApplicationManager.getApplication().invokeLater(() -> {
+                if (project != null && project.isDisposed()) {
+                    return;
+                }
+                ShowSettingsUtilImpl.showSettings(project, groups, toSelect);
+            });
+        });
     }
 }

--- a/src/test/java/com/devoxx/genie/ApiCompatibilityTest.java
+++ b/src/test/java/com/devoxx/genie/ApiCompatibilityTest.java
@@ -34,6 +34,35 @@ class ApiCompatibilityTest {
         assertThat(violations).isEmpty();
     }
 
+    @Test
+    void settingsDialogIsNeverOpenedSynchronouslyOnTheEdt() throws IOException {
+        // ShowSettingsUtil.getInstance().showSettingsDialog(...) collects ALL configurable
+        // groups on the calling thread. On the EDT this crashes in PyCharm: the Flask console
+        // configurable calls runBlockingCancellable during group collection, which asserts a
+        // background thread (IllegalStateException "This method is forbidden on EDT").
+        // All settings opening must go through SettingsDialogUtil, which collects the groups
+        // on a pooled thread before showing the dialog on the EDT.
+        List<String> violations;
+        try (var paths = Files.walk(Path.of("src/main"))) {
+            violations = paths
+                    .filter(Files::isRegularFile)
+                    .filter(ApiCompatibilityTest::isSourceFile)
+                    .filter(path -> fileContains(path, "ShowSettingsUtil.getInstance().showSettingsDialog"))
+                    .map(Path::toString)
+                    .toList();
+        }
+
+        assertThat(violations).isEmpty();
+    }
+
+    private static boolean fileContains(Path path, String needle) {
+        try {
+            return Files.readString(path).contains(needle);
+        } catch (IOException e) {
+            throw new IllegalStateException("Failed to read " + path, e);
+        }
+    }
+
     private static boolean isSourceFile(Path path) {
         String fileName = path.getFileName().toString();
         return fileName.endsWith(".java") || fileName.endsWith(".kt");


### PR DESCRIPTION
## Summary
- Fixes the intermittent PyCharm crash `IllegalStateException: This method is forbidden on EDT` when opening DevoxxGenie settings: all synchronous `ShowSettingsUtil.showSettingsDialog(...)` overloads collect every configurable group on the calling thread, and PyCharm's Flask console configurable calls `runBlockingCancellable` during that collection.
- `SettingsDialogUtil` now mirrors the platform's own ShowSettingsAction: collects configurable groups on a pooled thread (`ShowSettingsUtilImpl.getConfigurableGroups`), resolves the target page with `ConfigurableVisitor`, then shows the dialog on the EDT via `ShowSettingsUtilImpl.showSettings`. The "Open Web search settings" / "Open RAG settings" links in `AgentSettingsComponent` had the same bug and now route through the utility.
- Adds `ApiCompatibilityTest.settingsDialogIsNeverOpenedSynchronouslyOnTheEdt`, which fails if any production code calls `ShowSettingsUtil.getInstance().showSettingsDialog` directly (red before the fix, green after).

## Test plan
- [x] New regression test fails on the old code and passes on the fix
- [x] Full test suite: 2955 tests, only the pre-existing unrelated `ReadFileToolExecutorTest` failure (also fails on a clean tree)
- [ ] Manual: open DevoxxGenie settings from the tool window gear in PyCharm (first open after IDE start) — no EDT exception, LLM Providers page preselected
- [ ] Manual: "Open Web search settings" / "Open RAG settings" links in Agent settings open the correct pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)