### PR TITLE
task-236: Long-running feedback & history polish

### DIFF
--- a/src/main/java/com/devoxx/genie/service/conversations/PendingConversationDeletionManager.java
+++ b/src/main/java/com/devoxx/genie/service/conversations/PendingConversationDeletionManager.java
@@ -1,0 +1,140 @@
+package com.devoxx.genie.service.conversations;
+
+import com.devoxx.genie.model.conversation.Conversation;
+import com.intellij.openapi.project.Project;
+import com.intellij.util.concurrency.AppExecutorUtil;
+import lombok.extern.slf4j.Slf4j;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.function.BiConsumer;
+
+/**
+ * Undo-deferred conversation deletion (task-236). Deleting a conversation from the history
+ * popup does <em>not</em> remove the SQLite row immediately. Instead the conversation id is
+ * parked in a pending-deletion set and the actual {@link ConversationStorageService} delete
+ * is committed only after an undo grace period. Within that window {@link #undo(String)}
+ * cancels the scheduled commit and the conversation reappears untouched.
+ *
+ * <p>This pending-set pattern deliberately avoids delete-then-re-insert on undo: re-inserting
+ * would have to recreate the conversation row plus all chat_messages rows in the right order
+ * and could collide with the foreign-key relationship between the two tables.
+ *
+ * <p>Thread-safety: all state lives in a {@link ConcurrentHashMap}; commit and undo race
+ * safely because both use atomic {@code remove(id)} as the single point of arbitration.
+ */
+@Slf4j
+public class PendingConversationDeletionManager {
+
+    /** How long a deletion stays undoable before the SQLite row is actually removed. */
+    public static final long DEFAULT_UNDO_GRACE_MS = 5_000;
+
+    private static final class Holder {
+        private static final PendingConversationDeletionManager INSTANCE =
+                new PendingConversationDeletionManager(
+                        (project, conversation) ->
+                                ConversationStorageService.getInstance().removeConversation(project, conversation),
+                        AppExecutorUtil.getAppScheduledExecutorService(),
+                        DEFAULT_UNDO_GRACE_MS);
+    }
+
+    public static @NotNull PendingConversationDeletionManager getInstance() {
+        return Holder.INSTANCE;
+    }
+
+    private record PendingDeletion(@NotNull Conversation conversation,
+                                   @NotNull ScheduledFuture<?> commitFuture) {
+    }
+
+    private final BiConsumer<Project, Conversation> deletionCommitter;
+    private final ScheduledExecutorService scheduler;
+    private final long undoGraceMs;
+    private final Map<String, PendingDeletion> pending = new ConcurrentHashMap<>();
+
+    /**
+     * Visible for tests: inject a mock committer, a controllable scheduler, and a short
+     * grace period. Production code uses {@link #getInstance()}.
+     */
+    PendingConversationDeletionManager(@NotNull BiConsumer<Project, Conversation> deletionCommitter,
+                                       @NotNull ScheduledExecutorService scheduler,
+                                       long undoGraceMs) {
+        this.deletionCommitter = deletionCommitter;
+        this.scheduler = scheduler;
+        this.undoGraceMs = undoGraceMs;
+    }
+
+    /** Schedules {@code conversation} for deletion after the undo grace period. */
+    public void scheduleDeletion(@NotNull Project project, @NotNull Conversation conversation) {
+        scheduleDeletion(project, conversation, () -> { });
+    }
+
+    /**
+     * Schedules {@code conversation} for deletion after the undo grace period.
+     * Scheduling the same conversation again while a deletion is already pending is a no-op
+     * (the first timer keeps running), so a double Delete-press cannot double-commit.
+     *
+     * @param onCommitted invoked (on the scheduler thread) once the deletion has actually
+     *                    been committed — even when the storage delete itself failed — so
+     *                    callers can expire the undo notification and refresh their view
+     */
+    public void scheduleDeletion(@NotNull Project project,
+                                 @NotNull Conversation conversation,
+                                 @NotNull Runnable onCommitted) {
+        String id = conversation.getId();
+        pending.computeIfAbsent(id, key -> {
+            ScheduledFuture<?> future = scheduler.schedule(
+                    () -> commit(project, key, onCommitted), undoGraceMs, TimeUnit.MILLISECONDS);
+            log.debug("Scheduled deletion of conversation {} in {} ms", key, undoGraceMs);
+            return new PendingDeletion(conversation, future);
+        });
+    }
+
+    /**
+     * Cancels a pending deletion. Returns {@code true} when the conversation was still
+     * pending and is now restored; {@code false} when it was unknown or already committed.
+     */
+    public boolean undo(@NotNull String conversationId) {
+        PendingDeletion deletion = pending.remove(conversationId);
+        if (deletion == null) {
+            return false;
+        }
+        deletion.commitFuture().cancel(false);
+        log.debug("Undid pending deletion of conversation {}", conversationId);
+        return true;
+    }
+
+    /** True while {@code conversationId} is parked awaiting commit (i.e. still undoable). */
+    public boolean isPendingDeletion(@NotNull String conversationId) {
+        return pending.containsKey(conversationId);
+    }
+
+    /** Snapshot of all conversation ids currently pending deletion — used to filter views. */
+    public @NotNull Set<String> pendingIds() {
+        return Set.copyOf(pending.keySet());
+    }
+
+    private void commit(@NotNull Project project, @NotNull String conversationId, @NotNull Runnable onCommitted) {
+        PendingDeletion deletion = pending.remove(conversationId);
+        if (deletion == null) {
+            // Undone (or already committed) between timer fire and now — nothing to do.
+            return;
+        }
+        try {
+            deletionCommitter.accept(project, deletion.conversation());
+            log.debug("Committed deletion of conversation {}", conversationId);
+        } catch (Exception e) {
+            log.warn("Failed to commit deletion of conversation {}: {}", conversationId, e.getMessage());
+        } finally {
+            try {
+                onCommitted.run();
+            } catch (Exception e) {
+                log.warn("onCommitted callback failed for conversation {}: {}", conversationId, e.getMessage());
+            }
+        }
+    }
+}

--- a/src/main/java/com/devoxx/genie/service/projectscanner/ProjectScannerService.java
+++ b/src/main/java/com/devoxx/genie/service/projectscanner/ProjectScannerService.java
@@ -186,6 +186,13 @@ public class ProjectScannerService {
         for (int i = 0; i < total; i++) {
             VirtualFile file = files.get(i);
             if (indicator != null) {
+                // Intentional new exit path (task-236): checkCanceled() throws
+                // ProcessCanceledException, also from inside the surrounding ReadAction
+                // (read actions are cancellation-aware). An indicator only exists when the
+                // scan runs under a progress-managed context (Task.Backgroundable /
+                // ProgressManager.runProcess), and that framework always handles PCE —
+                // non-RAG callers (token calc, project-context scans) run without an
+                // indicator and are unaffected.
                 indicator.checkCanceled();
                 indicator.setFraction((i + 1) / (double) total);
                 indicator.setText2(file.getName());

--- a/src/main/java/com/devoxx/genie/service/projectscanner/ProjectScannerService.java
+++ b/src/main/java/com/devoxx/genie/service/projectscanner/ProjectScannerService.java
@@ -3,6 +3,8 @@ package com.devoxx.genie.service.projectscanner;
 import com.devoxx.genie.model.ScanContentResult;
 import com.intellij.openapi.application.ApplicationManager;
 import com.devoxx.genie.util.ReadAccess;
+import com.intellij.openapi.progress.ProgressIndicator;
+import com.intellij.openapi.progress.ProgressManager;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.roots.ProjectFileIndex;
 import com.intellij.openapi.vfs.VirtualFile;
@@ -14,7 +16,6 @@ import org.jetbrains.annotations.NotNull;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 @Slf4j
 @Setter
@@ -172,8 +173,33 @@ public class ProjectScannerService {
 
     // Changed from private to public for better testability
     public @NotNull String extractAllFileContents(@NotNull List<VirtualFile> files) {
-        return files.stream()
-                .map(contentExtractor::extractFileContent)
-                .collect(Collectors.joining());
+        // The file count is known up front, so surface determinate progress when this scan
+        // runs under a progress context (task-236). Outside one, the indicator is null and
+        // behavior is unchanged.
+        ProgressIndicator indicator = currentProgressIndicator();
+        int total = files.size();
+        if (indicator != null && total > 0) {
+            indicator.setIndeterminate(false);
+        }
+
+        StringBuilder contents = new StringBuilder();
+        for (int i = 0; i < total; i++) {
+            VirtualFile file = files.get(i);
+            if (indicator != null) {
+                indicator.checkCanceled();
+                indicator.setFraction((i + 1) / (double) total);
+                indicator.setText2(file.getName());
+            }
+            contents.append(contentExtractor.extractFileContent(file));
+        }
+        return contents.toString();
+    }
+
+    /** Null-safe lookup of the current progress indicator (null in unit tests / outside tasks). */
+    private static ProgressIndicator currentProgressIndicator() {
+        if (ApplicationManager.getApplication() == null) {
+            return null;
+        }
+        return ProgressManager.getInstance().getProgressIndicator();
     }
 }

--- a/src/main/java/com/devoxx/genie/service/rag/ProjectIndexerService.java
+++ b/src/main/java/com/devoxx/genie/service/rag/ProjectIndexerService.java
@@ -7,6 +7,7 @@ import com.devoxx.genie.service.rag.manifest.IndexManifest;
 import com.devoxx.genie.service.rag.manifest.IndexManifestService;
 import com.devoxx.genie.service.rag.manifest.InMemoryIndexManifest;
 import com.devoxx.genie.ui.settings.DevoxxGenieStateService;
+import com.intellij.ide.util.DelegatingProgressIndicator;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.components.Service;
 import com.intellij.openapi.progress.ProgressIndicator;
@@ -58,6 +59,12 @@ public final class ProjectIndexerService {
      *  Ollama serializes embed requests by default and the embedding model also competes
      *  for CPU, so going above 4 typically regresses throughput. */
     static final int INDEXING_PARALLELISM = 2;
+
+    /**
+     * Fraction of the shared progress bar consumed by the scan phase; the embedding phase
+     * fills the rest. One indicator, one monotonic 0→100% sweep across both phases.
+     */
+    static final double SCAN_PHASE_END = 0.5;
 
     private final ChromaEmbeddingService chromaEmbeddingService;
     private final ProjectScannerService projectScannerService;
@@ -153,12 +160,14 @@ public final class ProjectIndexerService {
 
         // When running under a progress context (e.g. Task.Backgroundable from the RAG
         // settings panel), surface determinate progress in the IDE progress UI as well.
+        // The run is split into two phases sharing one indicator: scan fills 0.0→0.5,
+        // embedding fills 0.5→1.0 — a single monotonic sweep instead of two 0→100% passes.
         ProgressIndicator indicator = ApplicationManager.getApplication() == null
                 ? null
                 : ProgressManager.getInstance().getProgressIndicator();
         if (indicator != null) {
             indicator.setIndeterminate(true);
-            indicator.setText("Scanning project files...");
+            indicator.setText("Scanning project files (1/2)...");
         }
 
         if (SwingUtilities.isEventDispatchThread()) {
@@ -190,7 +199,14 @@ public final class ProjectIndexerService {
             return;
         }
 
-        ScanContentResult scanResult = projectScannerService.scanProject(project, baseDir, Integer.MAX_VALUE, false);
+        // Phase 1 (scan): run under a scaled sub-indicator so the determinate progress the
+        // scanner reports (ProjectScannerService.extractAllFileContents) lands in the 0.0→0.5
+        // half of the shared bar instead of sweeping it 0→100% on its own.
+        ScanContentResult scanResult = indicator == null
+                ? projectScannerService.scanProject(project, baseDir, Integer.MAX_VALUE, false)
+                : ProgressManager.getInstance().runProcess(
+                        () -> projectScannerService.scanProject(project, baseDir, Integer.MAX_VALUE, false),
+                        new PhaseScalingIndicator(indicator, 0.0, SCAN_PHASE_END, "Scanning (1/2): "));
         List<Path> filesToProcess = new ArrayList<>(scanResult.getFiles());
 
         // RAG-specific directory exclusion (task-220). Layered on top of the project-scanner
@@ -237,9 +253,10 @@ public final class ProjectIndexerService {
         int totalFiles = filesToProcess.size();
 
         if (indicator != null) {
+            // Phase 2 (embed): continue from where the scan phase left the bar.
             indicator.setIndeterminate(false);
-            indicator.setFraction(0);
-            indicator.setText("Indexing project files for RAG");
+            indicator.setFraction(SCAN_PHASE_END);
+            indicator.setText("Indexing project files for RAG (2/2)");
             indicator.setText2("");
         }
 
@@ -254,6 +271,7 @@ public final class ProjectIndexerService {
                     return t;
                 });
         java.util.concurrent.atomic.AtomicInteger processedCount = new java.util.concurrent.atomic.AtomicInteger();
+        java.util.concurrent.atomic.AtomicInteger maxReported = new java.util.concurrent.atomic.AtomicInteger();
         try {
             java.util.List<java.util.concurrent.Future<?>> futures = new java.util.ArrayList<>(totalFiles);
             for (Path path : filesToProcess) {
@@ -269,10 +287,12 @@ public final class ProjectIndexerService {
                     int done = processedCount.incrementAndGet();
                     int progress = (int) (((double) done / totalFiles) * 100);
                     String fileName = path.getFileName().toString();
-                    if (indicator != null && !indicator.isCanceled()) {
-                        // ProgressIndicator API is thread-safe; no EDT hop needed.
-                        indicator.setFraction(done / (double) totalFiles);
-                        indicator.setText2(String.format("%d of %d: %s", done, totalFiles, fileName));
+                    if (indicator != null && !indicator.isCanceled()
+                            && maxReported.accumulateAndGet(done, Math::max) == done) {
+                        // ProgressIndicator API is thread-safe; no EDT hop needed. The max-guard
+                        // keeps parallel workers from briefly rolling the bar/text backwards.
+                        indicator.setFraction(SCAN_PHASE_END + (done / (double) totalFiles) * (1.0 - SCAN_PHASE_END));
+                        indicator.setText2(String.format("Indexing (2/2): %d of %d: %s", done, totalFiles, fileName));
                     }
                     SwingUtilities.invokeLater(() -> {
                         progressBar.setVisible(true);
@@ -541,6 +561,43 @@ public final class ProjectIndexerService {
         } catch (IOException e) {
             log.warn("Error processing file: {}", path);
             return 0;
+        }
+    }
+
+    /**
+     * Maps a sub-phase's 0.0→1.0 progress into a [from, to] slice of the parent indicator
+     * and prefixes its detail text with the phase label. Cancellation, text and all other
+     * calls delegate straight through, so cancelling the parent task still cancels the phase.
+     */
+    private static final class PhaseScalingIndicator extends DelegatingProgressIndicator {
+        private final double from;
+        private final double to;
+        private final String text2Prefix;
+
+        private PhaseScalingIndicator(@NotNull ProgressIndicator delegate,
+                                      double from,
+                                      double to,
+                                      @NotNull String text2Prefix) {
+            super(delegate);
+            this.from = from;
+            this.to = to;
+            this.text2Prefix = text2Prefix;
+        }
+
+        @Override
+        public void setFraction(double fraction) {
+            super.setFraction(from + fraction * (to - from));
+        }
+
+        @Override
+        public double getFraction() {
+            double parent = super.getFraction();
+            return to == from ? parent : (parent - from) / (to - from);
+        }
+
+        @Override
+        public void setText2(String text) {
+            super.setText2(text == null ? null : text2Prefix + text);
         }
     }
 }

--- a/src/main/java/com/devoxx/genie/service/rag/ProjectIndexerService.java
+++ b/src/main/java/com/devoxx/genie/service/rag/ProjectIndexerService.java
@@ -9,6 +9,8 @@ import com.devoxx.genie.service.rag.manifest.InMemoryIndexManifest;
 import com.devoxx.genie.ui.settings.DevoxxGenieStateService;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.components.Service;
+import com.intellij.openapi.progress.ProgressIndicator;
+import com.intellij.openapi.progress.ProgressManager;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.vfs.LocalFileSystem;
 import com.intellij.openapi.vfs.VirtualFile;
@@ -149,6 +151,16 @@ public final class ProjectIndexerService {
                            JLabel progressLabel) {
         resetCancellationFlag();
 
+        // When running under a progress context (e.g. Task.Backgroundable from the RAG
+        // settings panel), surface determinate progress in the IDE progress UI as well.
+        ProgressIndicator indicator = ApplicationManager.getApplication() == null
+                ? null
+                : ProgressManager.getInstance().getProgressIndicator();
+        if (indicator != null) {
+            indicator.setIndeterminate(true);
+            indicator.setText("Scanning project files...");
+        }
+
         if (SwingUtilities.isEventDispatchThread()) {
             progressBar.setValue(0);
             progressBar.setVisible(true);
@@ -224,6 +236,13 @@ public final class ProjectIndexerService {
 
         int totalFiles = filesToProcess.size();
 
+        if (indicator != null) {
+            indicator.setIndeterminate(false);
+            indicator.setFraction(0);
+            indicator.setText("Indexing project files for RAG");
+            indicator.setText2("");
+        }
+
         // Bounded parallel pool: a handful of file-processing threads share access to the
         // batched embedAll / Chroma writes. We still cap progress + cancellation checks at the
         // file boundary, since per-file work is the meaningful unit.
@@ -239,11 +258,22 @@ public final class ProjectIndexerService {
             java.util.List<java.util.concurrent.Future<?>> futures = new java.util.ArrayList<>(totalFiles);
             for (Path path : filesToProcess) {
                 futures.add(pool.submit(() -> {
+                    // Bridge IDE progress-indicator cancellation into the indexer's own flag so
+                    // pressing Cancel on the background task stops the loop just like the
+                    // settings panel's Stop button does.
+                    if (indicator != null && indicator.isCanceled()) {
+                        cancelIndexing.set(true);
+                    }
                     if (isIndexingCancelled()) return;
                     indexFile(path, forceReindex);
                     int done = processedCount.incrementAndGet();
                     int progress = (int) (((double) done / totalFiles) * 100);
                     String fileName = path.getFileName().toString();
+                    if (indicator != null && !indicator.isCanceled()) {
+                        // ProgressIndicator API is thread-safe; no EDT hop needed.
+                        indicator.setFraction(done / (double) totalFiles);
+                        indicator.setText2(String.format("%d of %d: %s", done, totalFiles, fileName));
+                    }
                     SwingUtilities.invokeLater(() -> {
                         progressBar.setVisible(true);
                         progressLabel.setVisible(true);
@@ -253,6 +283,9 @@ public final class ProjectIndexerService {
                 }));
             }
             for (java.util.concurrent.Future<?> f : futures) {
+                if (indicator != null && indicator.isCanceled()) {
+                    cancelIndexing.set(true);
+                }
                 if (isIndexingCancelled()) break;
                 try {
                     f.get();

--- a/src/main/java/com/devoxx/genie/ui/panel/conversationhistory/ConversationHistoryPanel.java
+++ b/src/main/java/com/devoxx/genie/ui/panel/conversationhistory/ConversationHistoryPanel.java
@@ -2,11 +2,18 @@ package com.devoxx.genie.ui.panel.conversationhistory;
 
 import com.devoxx.genie.model.conversation.Conversation;
 import com.devoxx.genie.service.conversations.ConversationStorageService;
+import com.devoxx.genie.service.conversations.PendingConversationDeletionManager;
 import com.devoxx.genie.service.prompt.memory.ChatMemoryManager;
 import com.devoxx.genie.ui.listener.ConversationSelectionListener;
 import com.devoxx.genie.ui.topic.AppTopics;
 import com.devoxx.genie.ui.util.NotificationUtil;
 import com.intellij.icons.AllIcons;
+import com.intellij.notification.Notification;
+import com.intellij.notification.NotificationAction;
+import com.intellij.notification.NotificationGroupManager;
+import com.intellij.notification.NotificationType;
+import com.intellij.notification.Notifications;
+import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.ui.Messages;
 import com.intellij.openapi.ui.popup.JBPopup;
@@ -21,13 +28,17 @@ import org.jetbrains.annotations.Nullable;
 import javax.swing.*;
 import javax.swing.table.*;
 import java.awt.*;
+import java.awt.event.ActionEvent;
+import java.awt.event.KeyEvent;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 import java.util.function.Function;
+import java.util.function.IntSupplier;
 
 import static com.devoxx.genie.ui.component.button.ButtonFactory.createActionButton;
 import static com.devoxx.genie.ui.util.DevoxxGenieIconsUtil.TrashIcon;
@@ -35,10 +46,14 @@ import static com.devoxx.genie.ui.util.DevoxxGenieIconsUtil.TrashIcon;
 public class ConversationHistoryPanel extends JPanel implements ConversationSelectionListener {
     private final transient ConversationStorageService storageService;
     private final ConversationTableModel tableModel;
+    private final JBTable table;
     private final transient Project project;
     private final String tabId;
     private transient JBPopup activePopup;
     private transient ConversationSelectionListener directSelectionListener;
+
+    /** Row currently under the mouse pointer, or -1; drives the hover highlight. */
+    private int hoveredRow = -1;
 
     public ConversationHistoryPanel(Project project) {
         this(project, null);
@@ -54,7 +69,7 @@ public class ConversationHistoryPanel extends JPanel implements ConversationSele
 
         // Create table model
         tableModel = new ConversationTableModel();
-        JTable table = new JBTable(tableModel);
+        table = new JBTable(tableModel);
 
         // Configure table properties
         table.setShowGrid(false);
@@ -81,26 +96,52 @@ public class ConversationHistoryPanel extends JPanel implements ConversationSele
                 int row = table.rowAtPoint(e.getPoint());
                 int column = table.columnAtPoint(e.getPoint());
                 if (row >= 0 && column != 0) {
-                    // Get the conversation from the model
-                    Conversation conversation = tableModel.getConversationAt(row);
-                    // Update chat memory
-                    updateChatMemory(conversation);
-                    // Notify listener
-                    onConversationSelected(conversation);
-                    // Dismiss the popup so the restored conversation is visible
-                    if (activePopup != null && !activePopup.isDisposed()) {
-                        activePopup.cancel();
-                    }
+                    openConversationAt(row);
+                }
+            }
+
+            @Override
+            public void mouseExited(MouseEvent e) {
+                setHoveredRow(-1);
+            }
+        });
+
+        // Track the row under the mouse so renderers can paint a hover highlight
+        table.addMouseMotionListener(new MouseAdapter() {
+            @Override
+            public void mouseMoved(MouseEvent e) {
+                setHoveredRow(table.rowAtPoint(e.getPoint()));
+            }
+        });
+
+        // Keyboard support: Enter opens the selected conversation, Delete removes it (undoable)
+        table.getInputMap(JComponent.WHEN_ANCESTOR_OF_FOCUSED_COMPONENT)
+                .put(KeyStroke.getKeyStroke(KeyEvent.VK_ENTER, 0), "openConversation");
+        table.getActionMap().put("openConversation", new AbstractAction() {
+            @Override
+            public void actionPerformed(ActionEvent e) {
+                openConversationAt(table.getSelectedRow());
+            }
+        });
+        table.getInputMap(JComponent.WHEN_ANCESTOR_OF_FOCUSED_COMPONENT)
+                .put(KeyStroke.getKeyStroke(KeyEvent.VK_DELETE, 0), "deleteConversation");
+        table.getActionMap().put("deleteConversation", new AbstractAction() {
+            @Override
+            public void actionPerformed(ActionEvent e) {
+                int row = table.getSelectedRow();
+                if (row >= 0 && row < tableModel.getRowCount()) {
+                    deleteWithUndo(tableModel.getConversationAt(row));
                 }
             }
         });
 
         // Configure columns
         TableColumnModel columnModel = table.getColumnModel();
+        IntSupplier hoveredRowSupplier = () -> hoveredRow;
 
         // Title column
         TableColumn titleColumn = columnModel.getColumn(1);
-        titleColumn.setCellRenderer(new TitleRenderer());
+        titleColumn.setCellRenderer(new TitleRenderer(hoveredRowSupplier));
 
         // Set a very large preferred width to encourage expansion
         titleColumn.setPreferredWidth(Integer.MAX_VALUE);
@@ -113,7 +154,7 @@ public class ConversationHistoryPanel extends JPanel implements ConversationSele
         TableColumn deleteColumn = columnModel.getColumn(0);
         deleteColumn.setMinWidth(40);
         deleteColumn.setMaxWidth(40);
-        deleteColumn.setCellRenderer(new ButtonRenderer(AllIcons.Actions.GC));
+        deleteColumn.setCellRenderer(new ButtonRenderer(AllIcons.Actions.GC, hoveredRowSupplier));
 
         JButton deleteButton = new JButton(AllIcons.Actions.GC);
         deleteButton.setBorder(BorderFactory.createEmptyBorder());
@@ -121,7 +162,7 @@ public class ConversationHistoryPanel extends JPanel implements ConversationSele
         deleteButton.setMaximumSize(new Dimension(40, 40));
 
         ButtonEditor buttonEditor = new ButtonEditor(deleteButton, conversation -> {
-            removeConversation(conversation);
+            deleteWithUndo(conversation);
             return true;
         });
 
@@ -131,7 +172,7 @@ public class ConversationHistoryPanel extends JPanel implements ConversationSele
         TableColumn timeColumn = columnModel.getColumn(2);
         timeColumn.setMinWidth(100);
         timeColumn.setMaxWidth(100);
-        timeColumn.setCellRenderer(new TimeRenderer());
+        timeColumn.setCellRenderer(new TimeRenderer(hoveredRowSupplier));
 
         // Add table to scroll pane
         JBScrollPane scrollPane = new JBScrollPane(table);
@@ -159,9 +200,36 @@ public class ConversationHistoryPanel extends JPanel implements ConversationSele
 
     public void loadConversations() {
         List<Conversation> conversations = storageService.getConversations(project);
+        // Conversations parked for (undoable) deletion are hidden but not yet removed
+        // from storage — see PendingConversationDeletionManager.
+        Set<String> pendingDeletion = PendingConversationDeletionManager.getInstance().pendingIds();
+        if (!pendingDeletion.isEmpty()) {
+            conversations.removeIf(c -> pendingDeletion.contains(c.getId()));
+        }
         conversations.sort((c1, c2) -> c2.getTimestamp().compareTo(c1.getTimestamp()));
+        hoveredRow = -1;
         tableModel.setConversations(conversations);
         tableModel.fireTableDataChanged();
+    }
+
+    private void setHoveredRow(int row) {
+        if (row != hoveredRow) {
+            hoveredRow = row;
+            table.repaint();
+        }
+    }
+
+    /** Opens the conversation at {@code row}: restores chat memory, notifies, closes the popup. */
+    private void openConversationAt(int row) {
+        if (row < 0 || row >= tableModel.getRowCount()) {
+            return;
+        }
+        Conversation conversation = tableModel.getConversationAt(row);
+        updateChatMemory(conversation);
+        onConversationSelected(conversation);
+        if (activePopup != null && !activePopup.isDisposed()) {
+            activePopup.cancel();
+        }
     }
 
     @Override
@@ -264,8 +332,11 @@ public class ConversationHistoryPanel extends JPanel implements ConversationSele
 
     // Custom renderers
     private static class ButtonRenderer extends JButton implements TableCellRenderer {
-        public ButtonRenderer(Icon icon) {
+        private final transient IntSupplier hoveredRowSupplier;
+
+        public ButtonRenderer(Icon icon, IntSupplier hoveredRowSupplier) {
             super(icon);
+            this.hoveredRowSupplier = hoveredRowSupplier;
             setPreferredSize(new Dimension(40, 40));
             setMaximumSize(new Dimension(40, 40));
         }
@@ -274,13 +345,35 @@ public class ConversationHistoryPanel extends JPanel implements ConversationSele
         public Component getTableCellRendererComponent(JTable table, Object value,
                                                        boolean isSelected, boolean hasFocus,
                                                        int row, int column) {
+            applyHoverBackground(this, table, isSelected, row, hoveredRowSupplier.getAsInt());
             return this;
+        }
+    }
+
+    /** Shared hover/selection background logic for all renderers in this table. */
+    private static void applyHoverBackground(@NotNull JComponent component,
+                                             @NotNull JTable table,
+                                             boolean isSelected,
+                                             int row,
+                                             int hoveredRow) {
+        component.setOpaque(true);
+        if (isSelected) {
+            component.setBackground(table.getSelectionBackground());
+        } else if (row == hoveredRow) {
+            component.setBackground(JBUI.CurrentTheme.Table.Hover.background(true));
+        } else {
+            component.setBackground(table.getBackground());
         }
     }
 
     private static class TitleRenderer extends DefaultTableCellRenderer {
         private static final int MAX_TITLE_LENGTH = 50;
-        
+        private final transient IntSupplier hoveredRowSupplier;
+
+        public TitleRenderer(IntSupplier hoveredRowSupplier) {
+            this.hoveredRowSupplier = hoveredRowSupplier;
+        }
+
         @Override
         public Component getTableCellRendererComponent(JTable table, Object value,
                                                        boolean isSelected, boolean hasFocus,
@@ -302,6 +395,8 @@ public class ConversationHistoryPanel extends JPanel implements ConversationSele
             // Store the full text as tooltip
             setToolTipText(fullText);
 
+            applyHoverBackground(this, table, isSelected, row, hoveredRowSupplier.getAsInt());
+
             return this;
         }
 
@@ -320,7 +415,10 @@ public class ConversationHistoryPanel extends JPanel implements ConversationSele
     }
 
     private static class TimeRenderer extends DefaultTableCellRenderer {
-        public TimeRenderer() {
+        private final transient IntSupplier hoveredRowSupplier;
+
+        public TimeRenderer(IntSupplier hoveredRowSupplier) {
+            this.hoveredRowSupplier = hoveredRowSupplier;
             setForeground(JBColor.GRAY);
         }
 
@@ -330,6 +428,7 @@ public class ConversationHistoryPanel extends JPanel implements ConversationSele
                                                        int row, int column) {
             super.getTableCellRendererComponent(table, value, isSelected, hasFocus, row, column);
             setBorder(JBUI.Borders.empty(0, 8));
+            applyHoverBackground(this, table, isSelected, row, hoveredRowSupplier.getAsInt());
             return this;
         }
     }
@@ -387,14 +486,32 @@ public class ConversationHistoryPanel extends JPanel implements ConversationSele
         }
     }
 
-    private void removeConversation(Conversation conversation) {
-        try {
-            storageService.removeConversation(project, conversation);
-            loadConversations();
-            NotificationUtil.sendNotification(project, "Conversation removed");
-        } catch (Exception e) {
-            NotificationUtil.sendNotification(project, "Failed to remove conversation: " + e.getMessage());
+    /**
+     * Undoable deletion (task-236): the row disappears immediately, but the SQLite delete is
+     * deferred for a grace period during which an "Undo" notification action restores it.
+     */
+    private void deleteWithUndo(@NotNull Conversation conversation) {
+        PendingConversationDeletionManager deletionManager = PendingConversationDeletionManager.getInstance();
+        if (deletionManager.isPendingDeletion(conversation.getId())) {
+            return;
         }
+
+        Notification notification = NotificationGroupManager.getInstance()
+                .getNotificationGroup("com.devoxx.genie.notifications")
+                .createNotification("Conversation deleted", NotificationType.INFORMATION);
+        notification.addAction(NotificationAction.createSimpleExpiring("Undo", () -> {
+            if (deletionManager.undo(conversation.getId())) {
+                loadConversations();
+            }
+        }));
+
+        deletionManager.scheduleDeletion(project, conversation, () ->
+                // Commit runs on a scheduler thread; expiring the balloon must happen on the EDT.
+                ApplicationManager.getApplication().invokeLater(notification::expire));
+
+        // Hide the row right away — loadConversations() filters ids pending deletion.
+        loadConversations();
+        Notifications.Bus.notify(notification, project);
     }
 
     private void removeAllConversations() {

--- a/src/main/java/com/devoxx/genie/ui/settings/rag/RAGSettingsComponent.java
+++ b/src/main/java/com/devoxx/genie/ui/settings/rag/RAGSettingsComponent.java
@@ -14,6 +14,10 @@ import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.fileChooser.FileChooser;
 import com.intellij.openapi.fileChooser.FileChooserDescriptor;
 import com.intellij.openapi.fileChooser.FileChooserDescriptorFactory;
+import com.intellij.openapi.progress.ProcessCanceledException;
+import com.intellij.openapi.progress.ProgressIndicator;
+import com.intellij.openapi.progress.ProgressManager;
+import com.intellij.openapi.progress.Task;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.vfs.LocalFileSystem;
 import com.intellij.openapi.vfs.VirtualFile;
@@ -344,51 +348,62 @@ public class RAGSettingsComponent extends AbstractSettingsComponent {
         // Make sure progress components are visible before starting the indexing process
         setStartButtons(false);
         
-        // Run the indexing process in a background thread to avoid blocking the UI
-        ApplicationManager.getApplication().executeOnPooledThread(() -> {
-            try {
-                // Run the indexing process
-                ProjectIndexerService.getInstance().indexFiles(project, true, progressBar, progressLabel);
-                
-                // Update UI after indexing is complete
-                SwingUtilities.invokeLater(() -> {
-                    // Reset indexing flag
-                    isIndexing = false;
-                    
-                    // First reset the buttons
-                    setStartButtons(true);
-                    
-                    // Clear the table before reloading
-                    tableModel.setRowCount(0);
-                    tableModel.fireTableDataChanged();
-                    
-                    // Add a small delay to ensure ChromaDB has time to update its state
-                    Timer timer = new Timer(500, e -> {
-                        // Reload collections
-                        loadCollections();
-                        
-                        // Force table repaint
-                        collectionsTable.revalidate();
-                        collectionsTable.repaint();
-                        
-                        // Show a notification that indexing is complete
-                        if (ProjectIndexerService.getInstance().isIndexingCancelled()) {
-                            NotificationUtil.sendNotification(project, "Project indexing was cancelled");
-                        } else {
-                            NotificationUtil.sendNotification(project, "Project indexing completed successfully");
-                        }
-                    });
-                    timer.setRepeats(false);
-                    timer.start();
+        // Run the indexing process as a cancellable background task so the IDE shows
+        // determinate progress (n/total files, current file name) via the ProgressIndicator
+        // that ProjectIndexerService.indexFiles() picks up from the progress context.
+        ProgressManager.getInstance().run(new Task.Backgroundable(project, "Indexing project for RAG", true) {
+            private Exception failure;
+
+            @Override
+            public void run(@NotNull ProgressIndicator indicator) {
+                try {
+                    ProjectIndexerService.getInstance().indexFiles(project, true, progressBar, progressLabel);
+                } catch (ProcessCanceledException pce) {
+                    throw pce;
+                } catch (Exception e) {
+                    failure = e;
+                }
+            }
+
+            @Override
+            public void onCancel() {
+                // Cancellation via the IDE progress UI must stop the indexer loop too.
+                ProjectIndexerService.getInstance().cancelIndexing();
+            }
+
+            @Override
+            public void onFinished() {
+                // Runs on the EDT for both completion and cancellation.
+                isIndexing = false;
+                setStartButtons(true);
+
+                if (failure != null) {
+                    NotificationUtil.sendNotification(project, "Error indexing project: " + failure.getMessage());
+                    return;
+                }
+
+                // Clear the table before reloading
+                tableModel.setRowCount(0);
+                tableModel.fireTableDataChanged();
+
+                // Add a small delay to ensure ChromaDB has time to update its state
+                Timer timer = new Timer(500, e -> {
+                    // Reload collections
+                    loadCollections();
+
+                    // Force table repaint
+                    collectionsTable.revalidate();
+                    collectionsTable.repaint();
+
+                    // Show a notification that indexing is complete
+                    if (ProjectIndexerService.getInstance().isIndexingCancelled()) {
+                        NotificationUtil.sendNotification(project, "Project indexing was cancelled");
+                    } else {
+                        NotificationUtil.sendNotification(project, "Project indexing completed successfully");
+                    }
                 });
-            } catch (Exception e) {
-                SwingUtilities.invokeLater(() -> {
-                    // Reset indexing flag
-                    isIndexing = false;
-                    
-                    NotificationUtil.sendNotification(project, "Error indexing project: " + e.getMessage());
-                    setStartButtons(true);
-                });
+                timer.setRepeats(false);
+                timer.start();
             }
         });
     }

--- a/src/main/kotlin/com/devoxx/genie/ui/compose/components/ActivitySection.kt
+++ b/src/main/kotlin/com/devoxx/genie/ui/compose/components/ActivitySection.kt
@@ -22,9 +22,14 @@ import com.devoxx.genie.ui.compose.model.ActivityEntryUiModel
 import com.devoxx.genie.ui.compose.model.ActivityStatus
 import com.devoxx.genie.ui.compose.theme.DevoxxBlue
 import com.devoxx.genie.ui.compose.theme.DevoxxGenieThemeAccessor
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
 
 private val SuccessGreen = Color(0xFF43A047)
 private val ErrorRed = Color(0xFFE53935)
+
+/** A row must be RUNNING for at least this long before the elapsed suffix appears. */
+private const val ELAPSED_SUFFIX_THRESHOLD_MS = 2_000L
 
 @Composable
 fun ActivitySection(
@@ -42,6 +47,23 @@ fun ActivitySection(
     var expanded by remember { mutableStateOf(!completed) }
     val colors = DevoxxGenieThemeAccessor.colors
     val typography = DevoxxGenieThemeAccessor.typography
+
+    // One shared 1s ticker per visible Activity section (not per row). It only runs while
+    // at least one visible row is RUNNING and the rows are actually on screen — otherwise
+    // the LaunchedEffect restarts with tick=false and exits immediately, so a finished or
+    // collapsed timeline causes no idle CPU churn.
+    val anyRunning = visibleEntries.any { entry ->
+        entry.status == ActivityStatus.RUNNING || entry.children.any { it.status == ActivityStatus.RUNNING }
+    }
+    val tick = anyRunning && expanded && visible
+    var nowMs by remember { mutableStateOf(System.currentTimeMillis()) }
+    LaunchedEffect(tick) {
+        if (!tick) return@LaunchedEffect
+        while (isActive) {
+            nowMs = System.currentTimeMillis()
+            delay(1_000L)
+        }
+    }
 
     Column(modifier = modifier.fillMaxWidth().padding(vertical = 2.dp)) {
         // Header
@@ -93,11 +115,12 @@ fun ActivitySection(
                 verticalArrangement = Arrangement.spacedBy(4.dp),
             ) {
                 visibleEntries.forEachIndexed { index, entry ->
-                    ActivityEntryRow(entry, rowKey = "$index/${entry.toolName}/${entry.callNumber}")
+                    ActivityEntryRow(entry, rowKey = "$index/${entry.toolName}/${entry.callNumber}", nowMs = nowMs)
                     entry.children.forEach { child ->
                         ActivityEntryRow(
                             child,
                             rowKey = "$index/${entry.callNumber}/${child.toolName}",
+                            nowMs = nowMs,
                             modifier = Modifier.padding(start = 16.dp),
                         )
                     }
@@ -111,6 +134,7 @@ fun ActivitySection(
 private fun ActivityEntryRow(
     entry: ActivityEntryUiModel,
     rowKey: String,
+    nowMs: Long,
     modifier: Modifier = Modifier,
 ) {
     val colors = DevoxxGenieThemeAccessor.colors
@@ -155,6 +179,13 @@ private fun ActivityEntryRow(
                 Spacer(Modifier.width(4.dp))
                 BasicText(
                     text = "(${entry.callNumber}/${entry.maxCalls})",
+                    style = typography.caption.copy(color = colors.textSecondary),
+                )
+            }
+            elapsedSuffix(entry, nowMs)?.let { suffix ->
+                Spacer(Modifier.width(4.dp))
+                BasicText(
+                    text = suffix,
                     style = typography.caption.copy(color = colors.textSecondary),
                 )
             }
@@ -256,6 +287,18 @@ internal fun RunningSpinner(modifier: Modifier = Modifier) {
             .alpha(pulseAlpha)
             .background(DevoxxBlue, CircleShape),
     )
+}
+
+/**
+ * Live elapsed-time suffix for a long-running tool row, derived from the shared section
+ * ticker rather than mutating the entry every second. Returns null until the row has been
+ * RUNNING for more than [ELAPSED_SUFFIX_THRESHOLD_MS] so quick tools don't flicker.
+ */
+internal fun elapsedSuffix(entry: ActivityEntryUiModel, nowMs: Long): String? {
+    if (entry.status != ActivityStatus.RUNNING || entry.startedAt <= 0) return null
+    val elapsedMs = nowMs - entry.startedAt
+    if (elapsedMs < ELAPSED_SUFFIX_THRESHOLD_MS) return null
+    return "running\u2026 ${elapsedMs / 1_000}s"
 }
 
 /**

--- a/src/main/kotlin/com/devoxx/genie/ui/compose/model/MessageUiModel.kt
+++ b/src/main/kotlin/com/devoxx/genie/ui/compose/model/MessageUiModel.kt
@@ -54,6 +54,11 @@ data class ActivityEntryUiModel(
     val maxCalls: Int = 0,
     val status: ActivityStatus = ActivityStatus.INFO,
     /**
+     * Wall-clock millis when the tool request was observed; 0 for entries without a
+     * lifecycle. Drives the live "running… Ns" suffix on long-running RUNNING rows.
+     */
+    val startedAt: Long = 0,
+    /**
      * True for tool-call activity (requests, MCP messages) — rendering of these rows is
      * gated by [MessageUiModel.showToolActivity]. Agent reasoning entries are false and
      * always rendered.

--- a/src/main/kotlin/com/devoxx/genie/ui/compose/viewmodel/ConversationViewModel.kt
+++ b/src/main/kotlin/com/devoxx/genie/ui/compose/viewmodel/ConversationViewModel.kt
@@ -327,6 +327,7 @@ class ConversationViewModel(
             callNumber = message.callNumber,
             maxCalls = message.maxCalls,
             status = ActivityStatus.RUNNING,
+            startedAt = System.currentTimeMillis(),
             isToolActivity = true,
             subAgentId = message.subAgentId,
         )
@@ -499,8 +500,38 @@ class ConversationViewModel(
     fun hideLoadingIndicator(messageId: String) {
         // Complete, error and stop all end up here — clearing the streaming flag in the
         // same place keeps one lifecycle for both the loading dots and the streaming caret.
+        // Rows still open at this point (e.g. a tool whose response was lost, or a stopped
+        // run) are resolved to INFO so neither the spinner nor the elapsed-time ticker can
+        // outlive the run.
         updateMessage(messageId) { msg ->
-            msg.copy(isLoadingIndicatorVisible = false, isStreaming = false)
+            msg.copy(
+                isLoadingIndicatorVisible = false,
+                isStreaming = false,
+                activityEntries = finalizeOpenEntries(msg.activityEntries),
+            )
+        }
+    }
+
+    /** Resolves any still-open (RUNNING/PENDING_APPROVAL) rows — including children — to INFO. */
+    private fun finalizeOpenEntries(
+        entries: List<ActivityEntryUiModel>,
+    ): List<ActivityEntryUiModel> {
+        if (entries.none { it.isOpen() || it.children.any { child -> child.isOpen() } }) return entries
+        return entries.map { entry ->
+            val children = if (entry.children.any { it.isOpen() }) {
+                entry.children.map { child ->
+                    if (child.isOpen()) child.copy(status = ActivityStatus.INFO) else child
+                }
+            } else {
+                entry.children
+            }
+            if (entry.isOpen()) {
+                entry.copy(status = ActivityStatus.INFO, children = children)
+            } else if (children !== entry.children) {
+                entry.copy(children = children)
+            } else {
+                entry
+            }
         }
     }
 
@@ -534,6 +565,7 @@ class ConversationViewModel(
                     loopLimitMaxCalls = maxCalls,
                     isLoadingIndicatorVisible = false,
                     isStreaming = false,
+                    activityEntries = finalizeOpenEntries(msg.activityEntries),
                 )
             }
         }

--- a/src/test/java/com/devoxx/genie/service/conversations/PendingConversationDeletionManagerTest.java
+++ b/src/test/java/com/devoxx/genie/service/conversations/PendingConversationDeletionManagerTest.java
@@ -1,0 +1,145 @@
+package com.devoxx.genie.service.conversations;
+
+import com.devoxx.genie.model.conversation.Conversation;
+import com.intellij.openapi.project.Project;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Tests for the undo-deferred deletion logic (task-236, AC#7):
+ * delete &rarr; undo restores; delete &rarr; timeout actually removes via
+ * {@link ConversationStorageService}.
+ */
+class PendingConversationDeletionManagerTest {
+
+    private static final long GRACE_MS = 100;
+
+    private ScheduledExecutorService scheduler;
+    private ConversationStorageService storageService;
+    private Project project;
+    private PendingConversationDeletionManager manager;
+
+    @BeforeEach
+    void setUp() {
+        scheduler = new ScheduledThreadPoolExecutor(1);
+        storageService = mock(ConversationStorageService.class);
+        project = mock(Project.class);
+        manager = new PendingConversationDeletionManager(
+                storageService::removeConversation, scheduler, GRACE_MS);
+    }
+
+    @AfterEach
+    void tearDown() {
+        scheduler.shutdownNow();
+    }
+
+    private static Conversation conversation(String id) {
+        Conversation conversation = new Conversation();
+        conversation.setId(id);
+        conversation.setTitle("Conversation " + id);
+        return conversation;
+    }
+
+    @Test
+    void deleteThenUndoRestoresConversationAndNeverTouchesStorage() throws Exception {
+        Conversation conversation = conversation("c-1");
+
+        manager.scheduleDeletion(project, conversation);
+        assertThat(manager.isPendingDeletion("c-1")).isTrue();
+
+        boolean undone = manager.undo("c-1");
+
+        assertThat(undone).isTrue();
+        assertThat(manager.isPendingDeletion("c-1")).isFalse();
+
+        // Wait well past the grace period: the cancelled deletion must never fire.
+        Thread.sleep(GRACE_MS * 4);
+        verify(storageService, never()).removeConversation(project, conversation);
+    }
+
+    @Test
+    void deleteThenTimeoutActuallyRemovesFromStorage() throws Exception {
+        Conversation conversation = conversation("c-2");
+        CountDownLatch committed = new CountDownLatch(1);
+
+        manager.scheduleDeletion(project, conversation, committed::countDown);
+
+        assertThat(committed.await(5, TimeUnit.SECONDS))
+                .as("deletion should be committed after the undo grace period")
+                .isTrue();
+        verify(storageService, times(1)).removeConversation(project, conversation);
+        assertThat(manager.isPendingDeletion("c-2")).isFalse();
+    }
+
+    @Test
+    void undoAfterCommitReturnsFalseAndDoesNotResurrect() throws Exception {
+        Conversation conversation = conversation("c-3");
+        CountDownLatch committed = new CountDownLatch(1);
+
+        manager.scheduleDeletion(project, conversation, committed::countDown);
+        assertThat(committed.await(5, TimeUnit.SECONDS)).isTrue();
+
+        assertThat(manager.undo("c-3")).isFalse();
+        verify(storageService, times(1)).removeConversation(project, conversation);
+    }
+
+    @Test
+    void undoOfUnknownConversationReturnsFalse() {
+        assertThat(manager.undo("does-not-exist")).isFalse();
+    }
+
+    @Test
+    void pendingIdsReflectsScheduledDeletionsUntilCommitOrUndo() {
+        manager.scheduleDeletion(project, conversation("c-4"));
+        manager.scheduleDeletion(project, conversation("c-5"));
+
+        assertThat(manager.pendingIds()).containsExactlyInAnyOrder("c-4", "c-5");
+
+        manager.undo("c-4");
+        assertThat(manager.pendingIds()).containsExactly("c-5");
+    }
+
+    @Test
+    void reschedulingSameConversationCommitsOnlyOnce() throws Exception {
+        Conversation conversation = conversation("c-6");
+        CountDownLatch committed = new CountDownLatch(1);
+
+        manager.scheduleDeletion(project, conversation, committed::countDown);
+        // Delete pressed twice (e.g. double Delete-key press) before the grace expires.
+        manager.scheduleDeletion(project, conversation, committed::countDown);
+
+        assertThat(committed.await(5, TimeUnit.SECONDS)).isTrue();
+        // Give a potential straggling second commit a chance to (incorrectly) fire.
+        Thread.sleep(GRACE_MS * 4);
+        verify(storageService, times(1)).removeConversation(project, conversation);
+    }
+
+    @Test
+    void committerFailureStillClearsPendingState() throws Exception {
+        Conversation conversation = conversation("c-7");
+        CountDownLatch committed = new CountDownLatch(1);
+        PendingConversationDeletionManager failingManager = new PendingConversationDeletionManager(
+                (p, c) -> {
+                    throw new RuntimeException("boom");
+                },
+                scheduler,
+                GRACE_MS);
+
+        failingManager.scheduleDeletion(project, conversation, committed::countDown);
+
+        assertThat(committed.await(5, TimeUnit.SECONDS)).isTrue();
+        assertThat(failingManager.isPendingDeletion("c-7")).isFalse();
+    }
+}

--- a/src/test/kotlin/com/devoxx/genie/ui/compose/components/ActivitySectionElapsedTest.kt
+++ b/src/test/kotlin/com/devoxx/genie/ui/compose/components/ActivitySectionElapsedTest.kt
@@ -1,0 +1,55 @@
+package com.devoxx.genie.ui.compose.components
+
+import com.devoxx.genie.ui.compose.model.ActivityEntryUiModel
+import com.devoxx.genie.ui.compose.model.ActivityStatus
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+/**
+ * Tests for the derived elapsed-time suffix shown on long-running activity rows (task-236).
+ */
+class ActivitySectionElapsedTest {
+
+    private fun runningEntry(startedAt: Long) = ActivityEntryUiModel(
+        source = "AGENT",
+        content = "",
+        toolName = "run_command",
+        status = ActivityStatus.RUNNING,
+        startedAt = startedAt,
+        isToolActivity = true,
+    )
+
+    @Test
+    fun `no suffix while a running tool is under the two second threshold`() {
+        val now = 100_000L
+        assertThat(elapsedSuffix(runningEntry(startedAt = now - 1_500), now)).isNull()
+    }
+
+    @Test
+    fun `suffix appears once a tool has been running for more than two seconds`() {
+        val now = 100_000L
+        assertThat(elapsedSuffix(runningEntry(startedAt = now - 12_000), now))
+            .isEqualTo("running\u2026 12s")
+    }
+
+    @Test
+    fun `no suffix for resolved or lifecycle-less entries`() {
+        val now = 100_000L
+        val success = runningEntry(startedAt = now - 12_000).copy(status = ActivityStatus.SUCCESS)
+        val errored = runningEntry(startedAt = now - 12_000).copy(status = ActivityStatus.ERROR)
+        val info = runningEntry(startedAt = now - 12_000).copy(status = ActivityStatus.INFO)
+        assertThat(elapsedSuffix(success, now)).isNull()
+        assertThat(elapsedSuffix(errored, now)).isNull()
+        assertThat(elapsedSuffix(info, now)).isNull()
+    }
+
+    @Test
+    fun `no suffix for entries without a start timestamp`() {
+        val entry = ActivityEntryUiModel(
+            source = "AGENT",
+            content = "reasoning",
+            status = ActivityStatus.RUNNING,
+        )
+        assertThat(elapsedSuffix(entry, 100_000L)).isNull()
+    }
+}

--- a/src/test/kotlin/com/devoxx/genie/ui/compose/viewmodel/ConversationViewModelTest.kt
+++ b/src/test/kotlin/com/devoxx/genie/ui/compose/viewmodel/ConversationViewModelTest.kt
@@ -426,6 +426,44 @@ class ConversationViewModelTest {
     }
 
     @Test
+    fun `tool request records a start timestamp for the elapsed-time ticker`() {
+        val viewModel = ConversationViewModel(showToolActivityInChat = { true })
+        viewModel.addUserPromptMessage(ChatMessageContext.builder().id("msg-1").userPrompt("hi").build())
+
+        val before = System.currentTimeMillis()
+        viewModel.onActivityMessage(toolRequest("run_command", """{"command":"gradle test"}"""))
+
+        val entry = activeMessageEntries(viewModel).single()
+        assertThat(entry.status).isEqualTo(ActivityStatus.RUNNING)
+        assertThat(entry.startedAt).isBetween(before, System.currentTimeMillis())
+    }
+
+    @Test
+    fun `hide loading indicator resolves dangling RUNNING rows so the ticker stops`() {
+        val viewModel = ConversationViewModel(showToolActivityInChat = { true })
+        viewModel.addUserPromptMessage(ChatMessageContext.builder().id("msg-1").userPrompt("hi").build())
+
+        // Tool whose response never arrives (e.g. run stopped mid-call)
+        viewModel.onActivityMessage(toolRequest("run_command", """{"command":"gradle test"}"""))
+        assertThat(activeMessageEntries(viewModel).single().status).isEqualTo(ActivityStatus.RUNNING)
+
+        viewModel.hideLoadingIndicator("msg-1")
+
+        assertThat(activeMessageEntries(viewModel).single().status).isEqualTo(ActivityStatus.INFO)
+    }
+
+    @Test
+    fun `stop terminal state resolves dangling RUNNING rows so the ticker stops`() {
+        val viewModel = ConversationViewModel(showToolActivityInChat = { true })
+        viewModel.addUserPromptMessage(ChatMessageContext.builder().id("msg-1").userPrompt("hi").build())
+
+        viewModel.onActivityMessage(toolRequest("run_command", """{"command":"gradle test"}"""))
+        viewModel.setTerminalState("msg-1", TerminalState.STOPPED)
+
+        assertThat(activeMessageEntries(viewModel).single().status).isEqualTo(ActivityStatus.INFO)
+    }
+
+    @Test
     fun `tool error resolves the open row to ERROR`() {
         val viewModel = ConversationViewModel(showToolActivityInChat = { true })
         viewModel.addUserPromptMessage(ChatMessageContext.builder().id("msg-1").userPrompt("hi").build())


### PR DESCRIPTION
Implements backlog task-236. Rebased on task-233 (#1109).

- **Activity timeline elapsed ticker**: `ActivityEntryUiModel` gains `startedAt`, recorded when the TOOL_REQUEST row opens. Rows RUNNING >2s show a live `running… Ns` suffix driven by one shared 1s `LaunchedEffect` ticker per visible Activity section; ticker exits when no row is RUNNING or the section is collapsed/hidden. Dangling RUNNING rows are resolved to INFO at end of run so neither spinner nor ticker can outlive it.
- **Determinate RAG indexing**: indexing now runs under a cancellable `Task.Backgroundable`; `ProjectIndexerService` reports `setFraction(done/total)` + `setText2(fileName)` per file, and progress-UI cancel bridges into the existing cancellation flag. Project scanner (`extractAllFileContents`) reports determinate per-file progress when running under a progress context.
- **History popup UX**: hover row highlight, Enter opens, Delete key deletes. Deletion is undo-deferred via a pending-deletion set (`PendingConversationDeletionManager`) — SQLite delete commits only after a 5s grace period; an Undo notification action restores. No delete+re-insert.

Testing: new unit tests for undo-deferred deletion (undo restores, timeout removes via `ConversationStorageService`, double-delete/race safety), `startedAt`/finalization view-model transitions, and elapsed-suffix logic. Full suite green (2990+ tests).
