### PR TITLE
build(deps): bump software.amazon.awssdk:bom 2.46.6 → 2.46.7

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -264,7 +264,7 @@ dependencies {
     
     val lg4j_version = "1.16.1"
     val lg4j_beta_version = "1.16.1-beta26"
-    val awsSdkVersion = "2.46.6"
+    val awsSdkVersion = "2.46.7"
     val retrofitVersion = "3.0.0"
     val sqliteVersion = "3.53.2.0"
     val dockerJavaVersion = "3.7.1"


### PR DESCRIPTION
Patch-level AWS SDK BOM bump, cherry-picked from the grouped Dependabot PR #1098.

The grouped PR #1098 bundled 8 updates; the other 7 (Kotlin 2.2.20→2.4.0, IntelliJ platform 2.13.1→2.16.0, multiplatform-markdown-renderer 0.38.1→0.41.0, gitignore-reader 1.14.1→2.0.0, plus the Kotlin lombok/compose plugins) are intentionally **excluded**. They break the minimum-supported-IDE (2025.3) bundled-stdlib constraint documented in `build.gradle.kts` and fail CI with an inconsistent JVM-target error. Those should wait until the minimum supported IDE is deliberately raised.

This PR isolates the only safe member of the group.

## Verification
- `./gradlew compileJava` succeeds locally (JDK 21).

🤖 Generated with [Claude Code](https://claude.com/claude-code)