### PR TITLE
Chat output font zoom via CMD/Ctrl +/- shortcuts

### DIFF
--- a/backlog/tasks/task-237 - Chat-output-font-zoom-via-CMD-Ctrl-keyboard-shortcuts.md
+++ b/backlog/tasks/task-237 - Chat-output-font-zoom-via-CMD-Ctrl-keyboard-shortcuts.md
@@ -1,0 +1,65 @@
+---
+id: TASK-237
+title: Chat output font zoom via CMD/Ctrl +/- keyboard shortcuts
+status: In Progress
+assignee: []
+created_date: '2026-06-12 14:21'
+updated_date: '2026-06-12 14:31'
+labels:
+  - enhancement
+  - ui
+dependencies: []
+modified_files:
+  - src/main/java/com/devoxx/genie/ui/util/ChatFontSizeService.java
+  - src/main/java/com/devoxx/genie/action/AbstractChatFontSizeAction.java
+  - src/main/java/com/devoxx/genie/action/IncreaseChatFontSizeAction.java
+  - src/main/java/com/devoxx/genie/action/DecreaseChatFontSizeAction.java
+  - src/main/resources/META-INF/plugin.xml
+  - src/test/java/com/devoxx/genie/ui/util/ChatFontSizeServiceTest.java
+  - docusaurus/static/api/tips.json
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Add keyboard shortcuts to increase/decrease the chat output panel font size, like editor zoom.
+
+- CMD +/- on macOS, Ctrl +/- on Windows/Linux.
+- Scales both prose (customFontSize) and code (customCodeFontSize) together.
+- Persists across IDE restarts (DevoxxGenieStateService is @State-persisted).
+- Reuses existing appearance refresh plumbing: mutate state -> publish APPEARANCE_SETTINGS_TOPIC -> ConversationPanel recomposes the Compose chat view.
+- Scoped to the DevoxxGenie tool window (action disabled when tool window not active, so the shortcut passes through to the editor elsewhere).
+
+Trackpad pinch / Cmd+scroll deferred to a follow-up (needs JBR/Compose gesture spike).
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 CMD+ / CMD- (Mac) and Ctrl+ / Ctrl- (Win/Linux) increase/decrease chat output font size
+- [x] #2 Both prose and code font sizes scale together, clamped to 8-24
+- [x] #3 Font size persists across IDE restarts
+- [x] #4 Shortcut only active when DevoxxGenie tool window is focused
+- [x] #5 Unit test covers the clamp/next-size logic
+- [x] #6 Project builds with JDK 21
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented via IDE AnActions + shortcuts (not Swing/Compose key handling) because the chat is Compose for Desktop and IDE actions take precedence regardless of Compose focus consumption.
+
+- ChatFontSizeService.changeBy(delta): mutates DevoxxGenieStateService customFontSize + customCodeFontSize (clamped 8-24), sets useCustomFontSize/useCustomCodeFontSize=true, publishes APPEARANCE_SETTINGS_TOPIC. Persistence is free via @State.
+- AbstractChatFontSizeAction.update() enables the action only when the DevoxxGenie tool window isActive(), so CMD/Ctrl +/- pass through to the editor elsewhere.
+- plugin.xml: Increase = control/meta EQUALS + ADD; Decrease = control/meta MINUS + SUBTRACT (Mac OS X 10.5+ keymap for meta).
+
+Verified: JDK 21 compileJava OK, 5/5 unit tests pass, buildPlugin SUCCESSFUL (plugin.xml valid). AC #4 (focus scoping) needs manual runIde confirmation.
+<!-- SECTION:NOTES:END -->
+
+## Comments
+
+<!-- COMMENTS:BEGIN -->
+created: 2026-06-12 14:31
+---
+Manually verified working in runIde (user confirmed). Added a related tip to docusaurus/static/api/tips.json.
+---
+<!-- COMMENTS:END -->

--- a/docusaurus/static/api/tips.json
+++ b/docusaurus/static/api/tips.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "lastUpdated": "2026-06-10",
+  "lastUpdated": "2026-06-12",
   "tips": [
     { "text": "Type @ to add a file to the context.", "weight": 2 },
     { "text": "Generate a DEVOXXGENIE.md with /init for project-aware answers.", "weight": 3 },
@@ -19,6 +19,7 @@
     { "text": "Watch the live token count and cost estimate as you build a prompt.", "weight": 1 },
     { "text": "Tune chat memory size in Settings to control how much history the LLM sees.", "weight": 1 },
     { "text": "Set your own submit and newline shortcuts in Settings.", "weight": 1 },
+    { "text": "Zoom the chat font with Cmd/Ctrl +/- — the size sticks across restarts.", "weight": 1 },
     { "text": "Enable Inline Completion for AI code suggestions as you type.", "weight": 1 },
     { "text": "Enable Security Scanning — Gitleaks, OpenGrep and Trivy run as agent tools.", "weight": 1 },
     { "text": "Define tasks in Backlog.md and let the Agent implement them from the Spec Browser.", "weight": 1 },

--- a/src/main/java/com/devoxx/genie/action/AbstractChatFontSizeAction.java
+++ b/src/main/java/com/devoxx/genie/action/AbstractChatFontSizeAction.java
@@ -1,0 +1,36 @@
+package com.devoxx.genie.action;
+
+import com.devoxx.genie.ui.util.WindowPluginUtil;
+import com.intellij.openapi.actionSystem.ActionUpdateThread;
+import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.intellij.openapi.project.DumbAwareAction;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.wm.ToolWindow;
+import com.intellij.openapi.wm.ToolWindowManager;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Base class for chat-output font-size shortcuts.
+ * <p>
+ * The action is only enabled while the DevoxxGenie tool window is active, so the CMD/Ctrl +/-
+ * shortcut passes through to the editor (or wherever focus is) when the chat is not in use.
+ */
+public abstract class AbstractChatFontSizeAction extends DumbAwareAction {
+
+    @Override
+    public void update(@NotNull AnActionEvent e) {
+        Project project = e.getProject();
+        boolean enabled = false;
+        if (project != null) {
+            ToolWindow toolWindow =
+                ToolWindowManager.getInstance(project).getToolWindow(WindowPluginUtil.TOOL_WINDOW_ID);
+            enabled = toolWindow != null && toolWindow.isActive();
+        }
+        e.getPresentation().setEnabled(enabled);
+    }
+
+    @Override
+    public @NotNull ActionUpdateThread getActionUpdateThread() {
+        return ActionUpdateThread.EDT;
+    }
+}

--- a/src/main/java/com/devoxx/genie/action/DecreaseChatFontSizeAction.java
+++ b/src/main/java/com/devoxx/genie/action/DecreaseChatFontSizeAction.java
@@ -1,0 +1,16 @@
+package com.devoxx.genie.action;
+
+import com.devoxx.genie.ui.util.ChatFontSizeService;
+import com.intellij.openapi.actionSystem.AnActionEvent;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Decreases the chat output font size (prose and code) by one step.
+ */
+public class DecreaseChatFontSizeAction extends AbstractChatFontSizeAction {
+
+    @Override
+    public void actionPerformed(@NotNull AnActionEvent e) {
+        ChatFontSizeService.decrease();
+    }
+}

--- a/src/main/java/com/devoxx/genie/action/IncreaseChatFontSizeAction.java
+++ b/src/main/java/com/devoxx/genie/action/IncreaseChatFontSizeAction.java
@@ -1,0 +1,16 @@
+package com.devoxx.genie.action;
+
+import com.devoxx.genie.ui.util.ChatFontSizeService;
+import com.intellij.openapi.actionSystem.AnActionEvent;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Increases the chat output font size (prose and code) by one step.
+ */
+public class IncreaseChatFontSizeAction extends AbstractChatFontSizeAction {
+
+    @Override
+    public void actionPerformed(@NotNull AnActionEvent e) {
+        ChatFontSizeService.increase();
+    }
+}

--- a/src/main/java/com/devoxx/genie/ui/util/ChatFontSizeService.java
+++ b/src/main/java/com/devoxx/genie/ui/util/ChatFontSizeService.java
@@ -1,0 +1,77 @@
+package com.devoxx.genie.ui.util;
+
+import com.devoxx.genie.ui.settings.DevoxxGenieStateService;
+import com.intellij.openapi.application.ApplicationManager;
+
+import static com.devoxx.genie.ui.topic.AppTopics.APPEARANCE_SETTINGS_TOPIC;
+
+/**
+ * Adjusts the chat output font size (prose and code together) and persists it.
+ * <p>
+ * The new size is stored in {@link DevoxxGenieStateService} (which is {@code @State}-persisted,
+ * so it survives IDE restarts) and an {@code APPEARANCE_SETTINGS_TOPIC} event is published so the
+ * Compose-based conversation view recomposes with the new sizes.
+ */
+public final class ChatFontSizeService {
+
+    public static final int MIN_FONT_SIZE = 8;
+    public static final int MAX_FONT_SIZE = 24;
+
+    /** Defaults must mirror the fallbacks used by the Compose ConversationViewModel. */
+    private static final int DEFAULT_TEXT_FONT_SIZE = 13;
+    private static final int DEFAULT_CODE_FONT_SIZE = 12;
+
+    private ChatFontSizeService() {
+    }
+
+    /** Clamp a font size to the supported range. */
+    public static int clamp(int size) {
+        return Math.max(MIN_FONT_SIZE, Math.min(MAX_FONT_SIZE, size));
+    }
+
+    /** Apply a delta to a font size, keeping the result within the supported range. */
+    public static int nextSize(int currentSize, int delta) {
+        return clamp(currentSize + delta);
+    }
+
+    /** Increase the chat font size by one step. */
+    public static void increase() {
+        changeBy(+1);
+    }
+
+    /** Decrease the chat font size by one step. */
+    public static void decrease() {
+        changeBy(-1);
+    }
+
+    /**
+     * Change both the prose and code chat font sizes by {@code delta}, persist the result, and
+     * notify open conversation panels to refresh.
+     */
+    public static void changeBy(int delta) {
+        DevoxxGenieStateService state = DevoxxGenieStateService.getInstance();
+
+        int newTextSize = nextSize(effectiveTextSize(state), delta);
+        int newCodeSize = nextSize(effectiveCodeSize(state), delta);
+
+        // Enable the custom sizes so the values are actually applied by the view model.
+        state.setUseCustomFontSize(true);
+        state.setUseCustomCodeFontSize(true);
+        state.setCustomFontSize(newTextSize);
+        state.setCustomCodeFontSize(newCodeSize);
+
+        ApplicationManager.getApplication().getMessageBus()
+                .syncPublisher(APPEARANCE_SETTINGS_TOPIC)
+                .appearanceSettingsChanged();
+    }
+
+    private static int effectiveTextSize(DevoxxGenieStateService state) {
+        return Boolean.TRUE.equals(state.getUseCustomFontSize())
+                ? state.getCustomFontSize() : DEFAULT_TEXT_FONT_SIZE;
+    }
+
+    private static int effectiveCodeSize(DevoxxGenieStateService state) {
+        return Boolean.TRUE.equals(state.getUseCustomCodeFontSize())
+                ? state.getCustomCodeFontSize() : DEFAULT_CODE_FONT_SIZE;
+    }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -842,5 +842,25 @@
             <add-to-group group-id="ProjectViewPopupMenu" anchor="after" relative-to-action="CopyDirectoryToClipboard"/>
         </action>
 
+        <action id="DevoxxGenie.IncreaseChatFontSize"
+                class="com.devoxx.genie.action.IncreaseChatFontSizeAction"
+                text="Increase Chat Font Size"
+                description="Increase the DevoxxGenie chat output font size">
+            <keyboard-shortcut keymap="$default" first-keystroke="control EQUALS"/>
+            <keyboard-shortcut keymap="$default" first-keystroke="control ADD"/>
+            <keyboard-shortcut keymap="Mac OS X 10.5+" first-keystroke="meta EQUALS"/>
+            <keyboard-shortcut keymap="Mac OS X 10.5+" first-keystroke="meta ADD"/>
+        </action>
+
+        <action id="DevoxxGenie.DecreaseChatFontSize"
+                class="com.devoxx.genie.action.DecreaseChatFontSizeAction"
+                text="Decrease Chat Font Size"
+                description="Decrease the DevoxxGenie chat output font size">
+            <keyboard-shortcut keymap="$default" first-keystroke="control MINUS"/>
+            <keyboard-shortcut keymap="$default" first-keystroke="control SUBTRACT"/>
+            <keyboard-shortcut keymap="Mac OS X 10.5+" first-keystroke="meta MINUS"/>
+            <keyboard-shortcut keymap="Mac OS X 10.5+" first-keystroke="meta SUBTRACT"/>
+        </action>
+
     </actions>
 </idea-plugin>

--- a/src/test/java/com/devoxx/genie/ui/util/ChatFontSizeServiceTest.java
+++ b/src/test/java/com/devoxx/genie/ui/util/ChatFontSizeServiceTest.java
@@ -1,0 +1,43 @@
+package com.devoxx.genie.ui.util;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ChatFontSizeServiceTest {
+
+    @Test
+    void clamp_keepsValuesWithinBounds() {
+        assertThat(ChatFontSizeService.clamp(14)).isEqualTo(14);
+        assertThat(ChatFontSizeService.clamp(ChatFontSizeService.MIN_FONT_SIZE)).isEqualTo(ChatFontSizeService.MIN_FONT_SIZE);
+        assertThat(ChatFontSizeService.clamp(ChatFontSizeService.MAX_FONT_SIZE)).isEqualTo(ChatFontSizeService.MAX_FONT_SIZE);
+    }
+
+    @Test
+    void clamp_clipsBelowMinimum() {
+        assertThat(ChatFontSizeService.clamp(ChatFontSizeService.MIN_FONT_SIZE - 1))
+                .isEqualTo(ChatFontSizeService.MIN_FONT_SIZE);
+        assertThat(ChatFontSizeService.clamp(-100)).isEqualTo(ChatFontSizeService.MIN_FONT_SIZE);
+    }
+
+    @Test
+    void clamp_clipsAboveMaximum() {
+        assertThat(ChatFontSizeService.clamp(ChatFontSizeService.MAX_FONT_SIZE + 1))
+                .isEqualTo(ChatFontSizeService.MAX_FONT_SIZE);
+        assertThat(ChatFontSizeService.clamp(1000)).isEqualTo(ChatFontSizeService.MAX_FONT_SIZE);
+    }
+
+    @Test
+    void nextSize_incrementsAndDecrementsWithinBounds() {
+        assertThat(ChatFontSizeService.nextSize(14, +1)).isEqualTo(15);
+        assertThat(ChatFontSizeService.nextSize(14, -1)).isEqualTo(13);
+    }
+
+    @Test
+    void nextSize_doesNotExceedBounds() {
+        assertThat(ChatFontSizeService.nextSize(ChatFontSizeService.MAX_FONT_SIZE, +1))
+                .isEqualTo(ChatFontSizeService.MAX_FONT_SIZE);
+        assertThat(ChatFontSizeService.nextSize(ChatFontSizeService.MIN_FONT_SIZE, -1))
+                .isEqualTo(ChatFontSizeService.MIN_FONT_SIZE);
+    }
+}


### PR DESCRIPTION
## Summary

Adds keyboard shortcuts to zoom the **chat output panel** font, like editor zoom — addresses TASK-237.

- **Cmd +/-** on macOS, **Ctrl +/-** on Windows/Linux (both main-keyboard `=`/`-` and numpad `+`/`-`).
- Scales **both prose and code** font sizes together, clamped to 8–24.
- **Persists across IDE restarts** — the size is stored in `DevoxxGenieStateService`, which is `@State`-persisted.

## How it works

The chat output is Compose for Desktop, so there's no CSS/JS to hook — but the appearance refresh plumbing already existed. The shortcut just drives it:

```
AnAction → ChatFontSizeService.changeBy(±1)
         → mutate DevoxxGenieStateService (customFontSize + customCodeFontSize, clamped 8–24)
         → publish APPEARANCE_SETTINGS_TOPIC
         → ConversationPanel recomposes the Compose view
```

The actions are **scoped to the DevoxxGenie tool window** (`AbstractChatFontSizeAction.update()` enables them only when the tool window `isActive()`), so Cmd/Ctrl +/- pass through to the editor everywhere else.

## Changes

- `ui/util/ChatFontSizeService.java` — mutate/clamp/publish logic
- `action/AbstractChatFontSizeAction.java` + `IncreaseChatFontSizeAction` / `DecreaseChatFontSizeAction`
- `META-INF/plugin.xml` — action + keymap registration
- `ui/util/ChatFontSizeServiceTest.java` — unit tests for clamp/next-size
- `docusaurus/static/api/tips.json` — related tip

## Testing

- JDK 21 `compileJava` ✅
- 5/5 unit tests pass ✅
- `buildPlugin` ✅ (plugin.xml valid)
- Manually verified in `runIde` ✅

## Follow-up (not in this PR)

Trackpad pinch / Cmd+scroll zoom was deferred — it needs a JBR/Compose gesture-API spike to confirm the gesture reaches the Compose panel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)