### PR TITLE
Add Algolia Experiences documentation search to Docusaurus

### DIFF
--- a/docusaurus/docusaurus.config.js
+++ b/docusaurus/docusaurus.config.js
@@ -47,7 +47,20 @@ const config = {
     locales: ['en'],
   },
 
-  plugins: [],
+  plugins: [
+    // Algolia Experiences documentation search.
+    // Injects the Algolia Experiences library which renders into the
+    // #autocomplete container provided by src/theme/SearchBar.
+    [
+      './src/plugins/algolia-experiences',
+      {
+        appId: 'YFQ8A065SY',
+        apiKey: '6ae04ce6197d1e96bad9c0c99d56ddac',
+        experienceId: 'YFQ8A065SY',
+        env: 'prod',
+      },
+    ],
+  ],
 
   presets: [
     [

--- a/docusaurus/src/css/custom.css
+++ b/docusaurus/src/css/custom.css
@@ -59,3 +59,18 @@
   margin-bottom: 1rem;
   color: var(--ifm-color-primary);
 }
+
+/* Algolia Experiences search container in the navbar */
+#autocomplete.algolia-experiences-autocomplete {
+  display: flex;
+  align-items: center;
+  min-width: 200px;
+  margin: 0 0.5rem;
+}
+
+@media (max-width: 996px) {
+  #autocomplete.algolia-experiences-autocomplete {
+    min-width: auto;
+    width: 100%;
+  }
+}

--- a/docusaurus/src/plugins/algolia-experiences/index.js
+++ b/docusaurus/src/plugins/algolia-experiences/index.js
@@ -1,0 +1,38 @@
+// Algolia Experiences search plugin for Docusaurus.
+// Loads the Algolia Experiences library at the end of <body>, which
+// attaches the search UI to the #autocomplete container rendered by
+// the swizzled navbar SearchBar component (src/theme/SearchBar).
+//
+// See: https://www.algolia.com/doc/
+
+const DEFAULTS = {
+  appId: 'YFQ8A065SY',
+  apiKey: '6ae04ce6197d1e96bad9c0c99d56ddac',
+  experienceId: 'YFQ8A065SY',
+  env: 'prod',
+};
+
+module.exports = function algoliaExperiencesPlugin(context, options) {
+  const {appId, apiKey, experienceId, env} = {...DEFAULTS, ...options};
+
+  const src =
+    'https://cdn.jsdelivr.net/npm/@algolia/experiences/dist/experiences.js' +
+    `?appId=${appId}&apiKey=${apiKey}&experienceId=${experienceId}&env=${env}`;
+
+  return {
+    name: 'algolia-experiences',
+
+    injectHtmlTags() {
+      return {
+        postBodyTags: [
+          {
+            tagName: 'script',
+            attributes: {
+              src,
+            },
+          },
+        ],
+      };
+    },
+  };
+};

--- a/docusaurus/src/theme/SearchBar/index.js
+++ b/docusaurus/src/theme/SearchBar/index.js
@@ -1,0 +1,8 @@
+import React from 'react';
+
+// Overrides the default Docusaurus navbar SearchBar.
+// Renders the #autocomplete container that the Algolia Experiences
+// library (loaded via the algolia-experiences plugin) attaches to.
+export default function SearchBar() {
+  return <div id="autocomplete" className="algolia-experiences-autocomplete" />;
+}


### PR DESCRIPTION
- Swizzle navbar SearchBar to render the #autocomplete container
- Add algolia-experiences plugin injecting the library at end of <body>
- Style the navbar search container

https://claude.ai/code/session_01KhZjHgeTUqV3CtEFzDeC1D