### PR TITLE
refactor: SonarQube code-quality fixes (S1192 and related)

### DIFF
--- a/backlog/tasks/task-239 - Fix-kotlinS3776-in-ActivitySectionkt-at-line-134.md
+++ b/backlog/tasks/task-239 - Fix-kotlinS3776-in-ActivitySectionkt-at-line-134.md
@@ -1,0 +1,40 @@
+---
+id: task-239
+title: "Fix kotlin:S3776 in ActivitySection.kt at line 134"
+status: To Do
+priority: high
+assignee: []
+created_date: '2026-06-15 12:18'
+labels:
+  - sonarqube
+  - kotlin
+dependencies: []
+references: []
+documentation: []
+ordinal: 1000
+---
+
+# Fix `kotlin:S3776`: Refactor this method to reduce its Cognitive Complexity from 26 to the 15 allowed.
+
+## Description
+
+SonarQube for IDE detected a code quality issue.
+
+- **Rule:** `kotlin:S3776`
+- **File:** `bin/main/com/devoxx/genie/ui/compose/components/ActivitySection.kt`
+- **Line:** 134
+- **Severity:** High impact on Maintainability
+- **Issue:** Refactor this method to reduce its Cognitive Complexity from 26 to the 15 allowed.
+
+## Task
+
+Fix the SonarQube issue `kotlin:S3776` at line 134 in `bin/main/com/devoxx/genie/ui/compose/components/ActivitySection.kt`.
+
+## Acceptance Criteria
+
+- [ ] Issue `kotlin:S3776` at `ActivitySection.kt:134` is resolved
+- [ ] No new SonarQube issues introduced by the fix
+- [ ] Verify that all relevant tests still pass (DO NOT run the full test suite)
+- [ ] If the modified code lacks tests, add new ones to cover the changes
+
+

--- a/src/main/java/com/devoxx/genie/chatmodel/ChatModelProvider.java
+++ b/src/main/java/com/devoxx/genie/chatmodel/ChatModelProvider.java
@@ -93,7 +93,9 @@ public class ChatModelProvider {
             case CustomOpenAI:
                 customChatModel.setBaseUrl(stateService.getCustomOpenAIUrl());
                 break;
-            // Add other local providers as needed
+            default:
+                // No base URL override needed for cloud providers
+                break;
         }
     }
 

--- a/src/main/java/com/devoxx/genie/chatmodel/cloud/bedrock/BedrockAuthResolver.java
+++ b/src/main/java/com/devoxx/genie/chatmodel/cloud/bedrock/BedrockAuthResolver.java
@@ -21,69 +21,74 @@ public class BedrockAuthResolver {
 
     public @NotNull BedrockRuntimeClientBuilder configure(@NotNull BedrockRuntimeClientBuilder builder) {
         return configureAuth(builder.region(getRegion()));
-    }
+     }
 
     public @NotNull BedrockRuntimeAsyncClientBuilder configure(@NotNull BedrockRuntimeAsyncClientBuilder builder) {
         return configureAuth(builder.region(getRegion()));
-    }
+     }
 
     public @NotNull BedrockClientBuilder configure(@NotNull BedrockClientBuilder builder) {
         return configureAuth(builder.region(getRegion()));
-    }
+     }
 
     public @NotNull Region getRegion() {
         return Region.of(DevoxxGenieStateService.getInstance().getAwsRegion());
-    }
+     }
 
+    /**
+      * Returns the effective AWS Bedrock auth mode. The underlying
+      * {@code DevoxxGenieStateService.getAwsBedrockAuthMode()} is annotated @NotNull
+      * and will never return null (it falls back to a default mode), so no
+      * additional null check is needed here.
+      */
     public @NotNull AwsBedrockAuthMode getAuthMode() {
-        AwsBedrockAuthMode authMode = DevoxxGenieStateService.getInstance().getAwsBedrockAuthMode();
-        return authMode != null ? authMode : AwsBedrockAuthMode.defaultMode();
-    }
+        return DevoxxGenieStateService.getInstance().getAwsBedrockAuthMode();
+     }
 
     public @NotNull AwsCredentialsProvider getCredentialsProvider() {
         return switch (getAuthMode()) {
             case ACCESS_KEY -> StaticCredentialsProvider.create(AwsBasicCredentials.create(
                     DevoxxGenieStateService.getInstance().getAwsAccessKeyId(),
                     DevoxxGenieStateService.getInstance().getAwsSecretKey()
-            ));
+             ));
             case PROFILE -> ProfileCredentialsProvider.create(DevoxxGenieStateService.getInstance().getAwsProfileName());
             case BEARER_TOKEN -> throw new IllegalStateException("Bearer token auth does not use AWS credentials.");
-        };
-    }
+         };
+     }
 
     public @NotNull IdentityProvider<TokenIdentity> getTokenProvider() {
         String bearerToken = DevoxxGenieStateService.getInstance().getAwsBearerToken();
         return new IdentityProvider<>() {
-            @Override
+             @Override
             public Class<TokenIdentity> identityType() {
                 return TokenIdentity.class;
-            }
+             }
 
-            @Override
+             @Override
             public CompletableFuture<TokenIdentity> resolveIdentity(ResolveIdentityRequest request) {
                 return CompletableFuture.completedFuture(TokenIdentity.create(bearerToken));
-            }
-        };
-    }
+             }
+         };
+     }
 
     private @NotNull BedrockRuntimeClientBuilder configureAuth(@NotNull BedrockRuntimeClientBuilder builder) {
         return switch (getAuthMode()) {
             case ACCESS_KEY, PROFILE -> builder.credentialsProvider(getCredentialsProvider());
             case BEARER_TOKEN -> builder.tokenProvider(getTokenProvider());
-        };
-    }
+         };
+     }
 
     private @NotNull BedrockRuntimeAsyncClientBuilder configureAuth(@NotNull BedrockRuntimeAsyncClientBuilder builder) {
         return switch (getAuthMode()) {
             case ACCESS_KEY, PROFILE -> builder.credentialsProvider(getCredentialsProvider());
             case BEARER_TOKEN -> builder.tokenProvider(getTokenProvider());
-        };
-    }
+         };
+     }
 
     private @NotNull BedrockClientBuilder configureAuth(@NotNull BedrockClientBuilder builder) {
         return switch (getAuthMode()) {
             case ACCESS_KEY, PROFILE -> builder.credentialsProvider(getCredentialsProvider());
             case BEARER_TOKEN -> builder.tokenProvider(getTokenProvider());
-        };
-    }
+         };
+     }
 }

--- a/src/main/java/com/devoxx/genie/chatmodel/local/exo/ExoModelService.java
+++ b/src/main/java/com/devoxx/genie/chatmodel/local/exo/ExoModelService.java
@@ -3,7 +3,6 @@ package com.devoxx.genie.chatmodel.local.exo;
 import com.devoxx.genie.chatmodel.local.LocalLLMProvider;
 import com.devoxx.genie.model.exo.ExoModelDTO;
 import com.devoxx.genie.model.exo.ExoModelEntryDTO;
-import com.devoxx.genie.service.exception.UnsuccessfulRequestException;
 import com.devoxx.genie.ui.settings.DevoxxGenieStateService;
 import com.devoxx.genie.util.HttpClientProvider;
 import com.google.gson.Gson;
@@ -28,6 +27,11 @@ public class ExoModelService implements LocalLLMProvider {
 
     private static final Gson gson = new Gson();
     private static final MediaType JSON_TYPE = MediaType.parse("application/json");
+    private static final String INSTANCES_KEY = "instances";
+    private static final String RUNNERS_KEY = "runners";
+    public static final String MODEL_CARD = "modelCard";
+    public static final String INSTANCE = "instance";
+    public static final String INSTANCE_ID = "instanceId";
 
     /**
      * Returns the Exo API base URL (without /v1/ suffix).
@@ -57,22 +61,30 @@ public class ExoModelService implements LocalLLMProvider {
     @Override
     public ExoModelEntryDTO[] getModels() throws IOException {
         String baseUrl = getExoApiBaseUrl();
-
-        // Get downloaded model IDs from /state (DownloadCompleted entries)
         Set<String> downloadedModelIds = getDownloadedModelIds(baseUrl);
 
         if (downloadedModelIds.isEmpty()) {
             throw new IOException("No downloaded models found. Use the Exo dashboard to download models first.");
         }
 
-        // Fetch full model metadata from /models and filter to only downloaded ones
+        List<ExoModelEntryDTO> result = fetchDownloadedModelsFromApi(baseUrl, downloadedModelIds);
+        if (result.isEmpty()) {
+            result = createFallbackModelEntries(downloadedModelIds);
+        }
+
+        return result.toArray(new ExoModelEntryDTO[0]);
+    }
+
+    /**
+     * Fetches full model metadata from /models and returns only those present in downloadedModelIds.
+     */
+    private List<ExoModelEntryDTO> fetchDownloadedModelsFromApi(String baseUrl,
+                                                                Set<String> downloadedModelIds) throws IOException {
         List<ExoModelEntryDTO> result = new ArrayList<>();
-        String url = baseUrl + "models";
-        Request request = new Request.Builder().url(url).build();
+        Request request = new Request.Builder().url(baseUrl + "models").build();
         try (Response response = HttpClientProvider.getClient().newCall(request).execute()) {
-            if (response.isSuccessful() && response.body() != null) {
-                String json = response.body().string();
-                ExoModelDTO dto = gson.fromJson(json, ExoModelDTO.class);
+            if (response.isSuccessful()) {
+                ExoModelDTO dto = gson.fromJson(response.body().string(), ExoModelDTO.class);
                 if (dto.getData() != null) {
                     for (ExoModelEntryDTO model : dto.getData()) {
                         if (downloadedModelIds.contains(model.getId())) {
@@ -82,19 +94,22 @@ public class ExoModelService implements LocalLLMProvider {
                 }
             }
         }
+        return result;
+    }
 
-        // If /models didn't match, create entries from state info
-        if (result.isEmpty()) {
-            for (String modelId : downloadedModelIds) {
-                ExoModelEntryDTO dto = new ExoModelEntryDTO();
-                dto.setId(modelId);
-                dto.setName(modelId.contains("/") ? modelId.substring(modelId.indexOf('/') + 1) : modelId);
-                dto.setContextLength(0);
-                result.add(dto);
-            }
+    /**
+     * Creates minimal model entries from state info when /models returns no matching results.
+     */
+    private List<ExoModelEntryDTO> createFallbackModelEntries(Set<String> downloadedModelIds) {
+        List<ExoModelEntryDTO> result = new ArrayList<>();
+        for (String modelId : downloadedModelIds) {
+            ExoModelEntryDTO dto = new ExoModelEntryDTO();
+            dto.setId(modelId);
+            dto.setName(modelId.contains("/") ? modelId.substring(modelId.indexOf('/') + 1) : modelId);
+            dto.setContextLength(0);
+            result.add(dto);
         }
-
-        return result.toArray(new ExoModelEntryDTO[0]);
+        return result;
     }
 
     /**
@@ -128,11 +143,12 @@ public class ExoModelService implements LocalLLMProvider {
             if (shardMetadata == null) return null;
             for (var entry : shardMetadata.entrySet()) {
                 JsonObject shard = entry.getValue().getAsJsonObject();
-                if (shard.has("modelCard")) {
-                    return shard.getAsJsonObject("modelCard").get("modelId").getAsString();
+                if (shard.has(MODEL_CARD)) {
+                    return shard.getAsJsonObject(MODEL_CARD).get("modelId").getAsString();
                 }
             }
         } catch (Exception ignored) {
+            // Ignore exception
         }
         return null;
     }
@@ -145,10 +161,10 @@ public class ExoModelService implements LocalLLMProvider {
         try {
             String baseUrl = getExoApiBaseUrl();
             JsonObject state = fetchState(baseUrl);
-            JsonObject instances = state.getAsJsonObject("instances");
+            JsonObject instances = state.getAsJsonObject(INSTANCES_KEY);
             if (instances == null || instances.entrySet().isEmpty()) return false;
 
-            JsonObject runners = state.getAsJsonObject("runners");
+            JsonObject runners = state.getAsJsonObject(RUNNERS_KEY);
             for (var entry : instances.entrySet()) {
                 String instModelId = extractModelIdFromInstance(entry.getValue());
                 if (modelId.equals(instModelId)) {
@@ -157,6 +173,7 @@ public class ExoModelService implements LocalLLMProvider {
                 }
             }
         } catch (Exception ignored) {
+            // Exo API may be unavailable or return unexpected JSON; treat as not ready
         }
         return false;
     }
@@ -167,70 +184,10 @@ public class ExoModelService implements LocalLLMProvider {
      */
     public void ensureInstance(String modelId) throws IOException {
         String baseUrl = getExoApiBaseUrl();
-
-        // Check if an instance already exists for this model
-        JsonObject state = fetchState(baseUrl);
-        JsonObject instances = state.getAsJsonObject("instances");
-        if (instances != null) {
-            for (var entry : instances.entrySet()) {
-                String instanceModelId = extractModelIdFromInstance(entry.getValue());
-                if (modelId.equals(instanceModelId)) {
-                    // Instance exists — check if its runners are ready
-                    String instanceId = extractInstanceId(entry.getValue());
-                    JsonObject runners = state.getAsJsonObject("runners");
-                    if (instanceId != null && areInstanceRunnersReady(instances, runners, instanceId)) {
-                        return; // Instance exists and is ready
-                    }
-                    // Instance exists but runners not ready — wait for them
-                    waitForInstanceReady(baseUrl, modelId, 120);
-                    return;
-                }
-            }
+        if (!checkExistingInstance(baseUrl, modelId)) {
+            createInstance(baseUrl, fetchChosenPreview(baseUrl, modelId));
+            waitForInstanceReady(baseUrl, modelId);
         }
-
-        // Preview placements
-        String previewUrl = baseUrl + "instance/previews?model_id=" + modelId;
-        Request previewRequest = new Request.Builder().url(previewUrl).build();
-        String previewBody;
-        try (Response previewResponse = HttpClientProvider.getClient().newCall(previewRequest).execute()) {
-            if (!previewResponse.isSuccessful() || previewResponse.body() == null) {
-                throw new IOException("Failed to preview placements for model: " + modelId);
-            }
-            previewBody = previewResponse.body().string();
-        }
-
-        // Find first valid placement
-        JsonObject previewObj = gson.fromJson(previewBody, JsonObject.class);
-        JsonArray previews = previewObj.getAsJsonArray("previews");
-        JsonElement chosenPreview = null;
-
-        for (JsonElement p : previews) {
-            JsonObject preview = p.getAsJsonObject();
-            if (preview.get("error").isJsonNull() && preview.get("instance") != null && !preview.get("instance").isJsonNull()) {
-                chosenPreview = p;
-                break;
-            }
-        }
-
-        if (chosenPreview == null) {
-            throw new IOException("No valid placement found for model: " + modelId +
-                    ". Ensure enough devices are connected in the Exo cluster.");
-        }
-
-        // Create instance
-        String instanceUrl = baseUrl + "instance";
-        RequestBody body = RequestBody.create(chosenPreview.toString(), JSON_TYPE);
-        Request instanceRequest = new Request.Builder().url(instanceUrl).post(body).build();
-
-        try (Response instanceResponse = HttpClientProvider.getClient().newCall(instanceRequest).execute()) {
-            if (!instanceResponse.isSuccessful()) {
-                String errorBody = instanceResponse.body() != null ? instanceResponse.body().string() : "unknown";
-                throw new IOException("Failed to create Exo instance: " + errorBody);
-            }
-        }
-
-        // Wait for the instance runners to be ready
-        waitForInstanceReady(baseUrl, modelId, 120);
     }
 
     /**
@@ -242,127 +199,170 @@ public class ExoModelService implements LocalLLMProvider {
         indicator.setText("Checking for existing instance...");
         indicator.setFraction(0.1);
 
-        // Check if an instance already exists for this model
-        JsonObject state = fetchState(baseUrl);
-        JsonObject instances = state.getAsJsonObject("instances");
-        if (instances != null) {
-            for (var entry : instances.entrySet()) {
-                String instanceModelId = extractModelIdFromInstance(entry.getValue());
-                if (modelId.equals(instanceModelId)) {
-                    String instanceId = extractInstanceId(entry.getValue());
-                    JsonObject runners = state.getAsJsonObject("runners");
-                    if (instanceId != null && areInstanceRunnersReady(instances, runners, instanceId)) {
-                        indicator.setText("Instance already running");
-                        indicator.setFraction(1.0);
-                        return;
-                    }
-                    indicator.setText("Waiting for runners to warm up...");
-                    indicator.setFraction(0.5);
-                    waitForInstanceReadyWithProgress(baseUrl, modelId, 120, indicator);
-                    return;
-                }
-            }
-        }
+        if (checkExistingInstanceWithProgress(baseUrl, modelId, indicator)) return;
 
         indicator.setText("Previewing placements across cluster...");
         indicator.setFraction(0.2);
         if (indicator.isCanceled()) return;
 
-        // Preview placements
-        String previewUrl = baseUrl + "instance/previews?model_id=" + modelId;
-        Request previewRequest = new Request.Builder().url(previewUrl).build();
-        String previewBody;
-        try (Response previewResponse = HttpClientProvider.getClient().newCall(previewRequest).execute()) {
-            if (!previewResponse.isSuccessful() || previewResponse.body() == null) {
-                throw new IOException("Failed to preview placements for model: " + modelId);
-            }
-            previewBody = previewResponse.body().string();
-        }
-
-        JsonObject previewObj = gson.fromJson(previewBody, JsonObject.class);
-        JsonArray previews = previewObj.getAsJsonArray("previews");
-        JsonElement chosenPreview = null;
-        for (JsonElement p : previews) {
-            JsonObject preview = p.getAsJsonObject();
-            if (preview.get("error").isJsonNull() && preview.get("instance") != null && !preview.get("instance").isJsonNull()) {
-                chosenPreview = p;
-                break;
-            }
-        }
-
-        if (chosenPreview == null) {
-            throw new IOException("No valid placement found for model: " + modelId +
-                    ". Ensure enough devices are connected in the Exo cluster.");
-        }
+        JsonElement chosenPreview = fetchChosenPreview(baseUrl, modelId);
 
         indicator.setText("Creating instance...");
         indicator.setFraction(0.3);
         if (indicator.isCanceled()) return;
 
-        // Create instance
-        String instanceUrl = baseUrl + "instance";
-        RequestBody body = RequestBody.create(chosenPreview.toString(), JSON_TYPE);
-        Request instanceRequest = new Request.Builder().url(instanceUrl).post(body).build();
-
-        try (Response instanceResponse = HttpClientProvider.getClient().newCall(instanceRequest).execute()) {
-            if (!instanceResponse.isSuccessful()) {
-                String errorBody = instanceResponse.body() != null ? instanceResponse.body().string() : "unknown";
-                throw new IOException("Failed to create Exo instance: " + errorBody);
-            }
-        }
+        createInstance(baseUrl, chosenPreview);
 
         indicator.setText("Loading model across cluster...");
         indicator.setFraction(0.4);
 
-        waitForInstanceReadyWithProgress(baseUrl, modelId, 120, indicator);
+        waitForInstanceReadyWithProgress(baseUrl, modelId, indicator);
+    }
+
+    /**
+     * Checks if an instance already exists for the given model, and waits for it if not yet ready.
+     * Returns true if the instance was found (either ready or waited for), false if no instance exists.
+     */
+    private boolean checkExistingInstance(String baseUrl, String modelId) throws IOException {
+        JsonObject state = fetchState(baseUrl);
+        JsonObject instances = state.getAsJsonObject(INSTANCES_KEY);
+        if (instances == null) return false;
+
+        for (var entry : instances.entrySet()) {
+            if (modelId.equals(extractModelIdFromInstance(entry.getValue()))) {
+                String instanceId = extractInstanceId(entry.getValue());
+                JsonObject runners = state.getAsJsonObject(RUNNERS_KEY);
+                if (instanceId == null || !areInstanceRunnersReady(instances, runners, instanceId)) {
+                    waitForInstanceReady(baseUrl, modelId);
+                }
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Checks if an instance already exists for the given model, reporting progress.
+     * Returns true if handled (instance found and ready or waited for), false if no instance exists.
+     */
+    private boolean checkExistingInstanceWithProgress(String baseUrl, String modelId,
+                                                      ProgressIndicator indicator) throws IOException {
+        JsonObject state = fetchState(baseUrl);
+        JsonObject instances = state.getAsJsonObject(INSTANCES_KEY);
+        if (instances == null) return false;
+
+        for (var entry : instances.entrySet()) {
+            if (modelId.equals(extractModelIdFromInstance(entry.getValue()))) {
+                String instanceId = extractInstanceId(entry.getValue());
+                JsonObject runners = state.getAsJsonObject(RUNNERS_KEY);
+                if (instanceId != null && areInstanceRunnersReady(instances, runners, instanceId)) {
+                    indicator.setText("Instance already running");
+                    indicator.setFraction(1.0);
+                } else {
+                    indicator.setText("Waiting for runners to warm up...");
+                    indicator.setFraction(0.5);
+                    waitForInstanceReadyWithProgress(baseUrl, modelId, indicator);
+                }
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Fetches cluster placement previews and returns the first valid one, or throws if none found.
+     */
+    private JsonElement fetchChosenPreview(String baseUrl, String modelId) throws IOException {
+        String previewUrl = baseUrl + "instance/previews?model_id=" + modelId;
+        Request previewRequest = new Request.Builder().url(previewUrl).build();
+        String previewBody;
+        try (Response previewResponse = HttpClientProvider.getClient().newCall(previewRequest).execute()) {
+            if (!previewResponse.isSuccessful()) {
+                throw new IOException("Failed to preview placements for model: " + modelId);
+            }
+            previewBody = previewResponse.body().string();
+        }
+
+        JsonArray previews = gson.fromJson(previewBody, JsonObject.class).getAsJsonArray("previews");
+        for (JsonElement p : previews) {
+            JsonObject preview = p.getAsJsonObject();
+            if (preview.get("error").isJsonNull() && preview.get(INSTANCE) != null && !preview.get(INSTANCE).isJsonNull()) {
+                return p;
+            }
+        }
+        throw new IOException("No valid placement found for model: " + modelId +
+                ". Ensure enough devices are connected in the Exo cluster.");
+    }
+
+    /**
+     * Posts the chosen preview to the instance endpoint to create a new Exo instance.
+     */
+    private void createInstance(String baseUrl, JsonElement chosenPreview) throws IOException {
+        Request instanceRequest = new Request.Builder()
+                .url(baseUrl + INSTANCE)
+                .post(RequestBody.create(chosenPreview.toString(), JSON_TYPE))
+                .build();
+        try (Response instanceResponse = HttpClientProvider.getClient().newCall(instanceRequest).execute()) {
+            if (!instanceResponse.isSuccessful()) {
+                throw new IOException("Failed to create Exo instance: " + instanceResponse.body().string());
+            }
+        }
     }
 
     private void waitForInstanceReadyWithProgress(String baseUrl, String modelId,
-                                                   int timeoutSeconds, ProgressIndicator indicator) throws IOException {
-        long deadline = System.currentTimeMillis() + (timeoutSeconds * 1000L);
+                                                  ProgressIndicator indicator) throws IOException {
+        long deadline = System.currentTimeMillis() + (120 * 1000L);
         long startTime = System.currentTimeMillis();
 
         while (System.currentTimeMillis() < deadline) {
             if (indicator.isCanceled()) return;
 
             JsonObject state = fetchState(baseUrl);
-            JsonObject instances = state.getAsJsonObject("instances");
-            JsonObject runners = state.getAsJsonObject("runners");
-
-            if (instances != null) {
-                for (var entry : instances.entrySet()) {
-                    String instModelId = extractModelIdFromInstance(entry.getValue());
-                    if (modelId.equals(instModelId)) {
-                        String instanceId = extractInstanceId(entry.getValue());
-                        if (instanceId != null && areInstanceRunnersReady(instances, runners, instanceId)) {
-                            indicator.setText("Exo instance ready");
-                            indicator.setFraction(1.0);
-                            return;
-                        }
-                    }
-                }
+            if (isModelInstanceReady(state, modelId)) {
+                indicator.setText("Exo instance ready");
+                indicator.setFraction(1.0);
+                return;
             }
 
-            // Update progress (0.4 to 0.95 over the timeout period)
-            double elapsed = (System.currentTimeMillis() - startTime) / (double) (timeoutSeconds * 1000L);
+            double elapsed = (System.currentTimeMillis() - startTime) / (double) (120 * 1000L);
             indicator.setFraction(0.4 + elapsed * 0.55);
             indicator.setText("Warming up model runners...");
 
-            try {
-                Thread.sleep(2000);
-            } catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
-                throw new IOException("Interrupted while waiting for Exo runners", e);
-            }
+            sleepOrThrow();
         }
         throw new IOException("Timed out waiting for Exo runners to become ready");
+    }
+
+    private boolean isModelInstanceReady(JsonObject state, String modelId) {
+        JsonObject instances = state.getAsJsonObject(INSTANCES_KEY);
+        JsonObject runners = state.getAsJsonObject(RUNNERS_KEY);
+        if (instances == null) return false;
+
+        for (var entry : instances.entrySet()) {
+            if (modelId.equals(extractModelIdFromInstance(entry.getValue()))) {
+                String instanceId = extractInstanceId(entry.getValue());
+                if (instanceId != null && areInstanceRunnersReady(instances, runners, instanceId)) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    private void sleepOrThrow() throws IOException {
+        try {
+            Thread.sleep(2000);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IOException("Interrupted while waiting for Exo runners", e);
+        }
     }
 
     private JsonObject fetchState(String baseUrl) throws IOException {
         String stateUrl = baseUrl + "state";
         Request request = new Request.Builder().url(stateUrl).build();
         try (Response response = HttpClientProvider.getClient().newCall(request).execute()) {
-            if (!response.isSuccessful() || response.body() == null) {
+            if (!response.isSuccessful()) {
                 throw new IOException("Failed to fetch Exo state");
             }
             return gson.fromJson(response.body().string(), JsonObject.class);
@@ -389,8 +389,8 @@ public class ExoModelService implements LocalLLMProvider {
             JsonObject inst = instanceValue.getAsJsonObject();
             for (var entry : inst.entrySet()) {
                 JsonObject inner = entry.getValue().getAsJsonObject();
-                if (inner.has("instanceId")) {
-                    return inner.get("instanceId").getAsString();
+                if (inner.has(INSTANCE_ID)) {
+                    return inner.get(INSTANCE_ID).getAsString();
                 }
             }
         } catch (Exception ignored) {
@@ -405,70 +405,71 @@ public class ExoModelService implements LocalLLMProvider {
     private boolean areInstanceRunnersReady(JsonObject instances, JsonObject runners, String instanceId) {
         if (runners == null || instances == null) return false;
 
-        // Find runner IDs belonging to this instance
-        Set<String> instanceRunnerIds = new HashSet<>();
-        for (var entry : instances.entrySet()) {
-            String iid = extractInstanceId(entry.getValue());
-            if (instanceId.equals(iid)) {
-                try {
-                    JsonObject inst = entry.getValue().getAsJsonObject();
-                    for (var inner : inst.entrySet()) {
-                        JsonObject shardAssignments = inner.getValue().getAsJsonObject().getAsJsonObject("shardAssignments");
-                        if (shardAssignments != null) {
-                            JsonObject nodeToRunner = shardAssignments.getAsJsonObject("nodeToRunner");
-                            if (nodeToRunner != null) {
-                                for (var nr : nodeToRunner.entrySet()) {
-                                    instanceRunnerIds.add(nr.getValue().getAsString());
-                                }
-                            }
-                        }
-                    }
-                } catch (Exception ignored) {
-                }
-                break;
-            }
-        }
-
+        Set<String> instanceRunnerIds = collectInstanceRunnerIds(instances, instanceId);
         if (instanceRunnerIds.isEmpty()) return false;
 
-        // Check only those runners
-        return instanceRunnerIds.stream().allMatch(runnerId -> {
-            JsonElement runner = runners.get(runnerId);
-            if (runner == null) return false;
-            JsonObject r = runner.getAsJsonObject();
-            return r.has("RunnerReady") || r.has("RunnerRunning");
-        });
+        return instanceRunnerIds.stream().allMatch(runnerId -> isRunnerReady(runners, runnerId));
+    }
+
+    /**
+     * Collects runner IDs from the nodeToRunner mapping for the given instanceId.
+     */
+    private Set<String> collectInstanceRunnerIds(JsonObject instances, String instanceId) {
+        Set<String> runnerIds = new HashSet<>();
+        for (var entry : instances.entrySet()) {
+            if (!instanceId.equals(extractInstanceId(entry.getValue()))) continue;
+            try {
+                JsonObject inst = entry.getValue().getAsJsonObject();
+                for (var inner : inst.entrySet()) {
+                    collectRunnerIdsFromShard(inner.getValue(), runnerIds);
+                }
+            } catch (Exception ignored) {
+                // Ignore exception
+            }
+            break;
+        }
+        return runnerIds;
+    }
+
+    /**
+     * Adds runner IDs from a shard's nodeToRunner mapping into the provided set.
+     */
+    private void collectRunnerIdsFromShard(JsonElement shardElement, Set<String> runnerIds) {
+        try {
+            JsonObject shardAssignments = shardElement.getAsJsonObject().getAsJsonObject("shardAssignments");
+            if (shardAssignments == null) return;
+            JsonObject nodeToRunner = shardAssignments.getAsJsonObject("nodeToRunner");
+            if (nodeToRunner == null) return;
+            for (var nr : nodeToRunner.entrySet()) {
+                runnerIds.add(nr.getValue().getAsString());
+            }
+        } catch (Exception ignored) {
+            // Ignore exception
+        }
+    }
+
+    /**
+     * Returns true if the runner with the given ID is in a ready or running state.
+     */
+    private boolean isRunnerReady(JsonObject runners, String runnerId) {
+        JsonElement runner = runners.get(runnerId);
+        if (runner == null) return false;
+        JsonObject r = runner.getAsJsonObject();
+        return r.has("RunnerReady") || r.has("RunnerRunning");
     }
 
     /**
      * Waits for the instance running the given model to have all its runners ready.
      */
-    private void waitForInstanceReady(String baseUrl, String modelId, int timeoutSeconds) throws IOException {
-        long deadline = System.currentTimeMillis() + (timeoutSeconds * 1000L);
+    private void waitForInstanceReady(String baseUrl, String modelId) throws IOException {
+        long deadline = System.currentTimeMillis() + (120 * 1000L);
 
         while (System.currentTimeMillis() < deadline) {
             JsonObject state = fetchState(baseUrl);
-            JsonObject instances = state.getAsJsonObject("instances");
-            JsonObject runners = state.getAsJsonObject("runners");
-
-            if (instances != null) {
-                for (var entry : instances.entrySet()) {
-                    String instModelId = extractModelIdFromInstance(entry.getValue());
-                    if (modelId.equals(instModelId)) {
-                        String instanceId = extractInstanceId(entry.getValue());
-                        if (instanceId != null && areInstanceRunnersReady(instances, runners, instanceId)) {
-                            return;
-                        }
-                    }
-                }
+            if (isModelInstanceReady(state, modelId)) {
+                return;
             }
-
-            try {
-                Thread.sleep(2000);
-            } catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
-                throw new IOException("Interrupted while waiting for Exo runners", e);
-            }
+            sleepOrThrow();
         }
         throw new IOException("Timed out waiting for Exo runners to become ready");
     }

--- a/src/main/java/com/devoxx/genie/completion/LMStudioFimProvider.java
+++ b/src/main/java/com/devoxx/genie/completion/LMStudioFimProvider.java
@@ -11,6 +11,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.time.Duration;
+import java.util.Objects;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static com.devoxx.genie.util.HttpUtil.ensureEndsWithSlash;
@@ -68,14 +69,10 @@ public class LMStudioFimProvider implements FimProvider {
                 return null;
             }
 
-            ResponseBody responseBody = response.body();
-            if (responseBody == null) {
-                return null;
-            }
+            ResponseBody responseBody = Objects.requireNonNull(response.body());
 
             JsonObject jsonResponse = GSON.fromJson(responseBody.string(), JsonObject.class);
 
-            // OpenAI completions format: { "choices": [{ "text": "..." }] }
             JsonArray choices = jsonResponse.getAsJsonArray("choices");
             if (choices == null || choices.isEmpty()) {
                 return null;

--- a/src/main/java/com/devoxx/genie/completion/OllamaFimProvider.java
+++ b/src/main/java/com/devoxx/genie/completion/OllamaFimProvider.java
@@ -10,6 +10,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.time.Duration;
+import java.util.Objects;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static com.devoxx.genie.util.HttpUtil.ensureEndsWithSlash;
@@ -77,10 +78,7 @@ public class OllamaFimProvider implements FimProvider {
                 return null;
             }
 
-            ResponseBody responseBody = response.body();
-            if (responseBody == null) {
-                return null;
-            }
+            ResponseBody responseBody = Objects.requireNonNull(response.body(), "Response body is null");
 
             JsonObject jsonResponse = GSON.fromJson(responseBody.string(), JsonObject.class);
             String completionText = jsonResponse.has("response")

--- a/src/main/java/com/devoxx/genie/controller/ActionButtonsPanelController.java
+++ b/src/main/java/com/devoxx/genie/controller/ActionButtonsPanelController.java
@@ -19,6 +19,7 @@ import com.devoxx.genie.util.ChatMessageContextUtil;
 import com.intellij.openapi.progress.ProgressIndicator;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.ui.ComboBox;
+import lombok.Setter;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -37,6 +38,7 @@ public class ActionButtonsPanelController implements PromptExecutionListener {
     private final ProjectContextController projectContextController;
     private final TokenCalculationController tokenCalculationController;
     private final String tabId;
+    @Setter
     private DevoxxGenieToolWindowContent toolWindowContent;
 
     public ActionButtonsPanelController(Project project,
@@ -104,10 +106,6 @@ public class ActionButtonsPanelController implements PromptExecutionListener {
         }
 
         return result;
-    }
-
-    public void setToolWindowContent(DevoxxGenieToolWindowContent toolWindowContent) {
-        this.toolWindowContent = toolWindowContent;
     }
 
     /**

--- a/src/main/java/com/devoxx/genie/model/LanguageModel.java
+++ b/src/main/java/com/devoxx/genie/model/LanguageModel.java
@@ -9,6 +9,7 @@ import lombok.NoArgsConstructor;
 
 import org.jetbrains.annotations.NotNull;
 
+import java.io.Serializable;
 import java.util.Comparator;
 
 @Data
@@ -49,7 +50,12 @@ public class LanguageModel implements Comparable<LanguageModel> {
         return "";
     }
 
-    private static class ModelVersionComparator implements Comparator<String> {
+    private static class ModelVersionComparator implements Comparator<String>, Serializable {
+        // Special version names for Anthropic models (Opus > Sonnet > Haiku)
+        private static final String SPECIAL_OPUS = "Opus";
+        private static final String SPECIAL_SONNET = "Sonnet";
+        private static final String SPECIAL_HAIKU = "Haiku";
+
         @Override
         public int compare(String v1, String v2) {
             String[] parts1 = v1.split(" ");
@@ -73,15 +79,15 @@ public class LanguageModel implements Comparable<LanguageModel> {
         }
 
         private boolean isSpecialVersion(@NotNull String version) {
-            return version.equals("Sonnet") || version.equals("Haiku") || version.equals("Opus");
+            return version.equals(SPECIAL_SONNET) || version.equals(SPECIAL_HAIKU) || version.equals(SPECIAL_OPUS);
         }
 
         private int compareSpecialVersions(@NotNull String v1, String v2) {
             if (v1.equals(v2)) return 0;
-            if (v1.equals("Opus")) return 1;
-            if (v2.equals("Opus")) return -1;
-            if (v1.equals("Sonnet")) return 1;
-            if (v2.equals("Sonnet")) return -1;
+            if (v1.equals(SPECIAL_OPUS)) return 1;
+            if (v2.equals(SPECIAL_OPUS)) return -1;
+            if (v1.equals(SPECIAL_SONNET)) return 1;
+            if (v2.equals(SPECIAL_SONNET)) return -1;
             return v1.compareTo(v2);
         }
 

--- a/src/main/java/com/devoxx/genie/service/blog/BlogFeedService.java
+++ b/src/main/java/com/devoxx/genie/service/blog/BlogFeedService.java
@@ -53,14 +53,10 @@ public final class BlogFeedService {
     private static final String CACHE_TIMESTAMP_KEY = "devoxxgenie.blog.cache.ts";
     private static final long CACHE_TTL_MILLIS = 6L * 60 * 60 * 1000; // 6 hours
 
-    private static final BlogFeedService INSTANCE = new BlogFeedService();
-
     private final Gson gson = new Gson();
 
-    private BlogFeedService() {}
-
     public static BlogFeedService getInstance() {
-        return INSTANCE;
+        return ApplicationManager.getApplication().getService(BlogFeedService.class);
     }
 
     /** Synchronously load the bundled blog post list from the plugin classpath. */
@@ -154,7 +150,6 @@ public final class BlogFeedService {
                 return null;
             }
             ResponseBody body = response.body();
-            if (body == null) return null;
             return parseRss(body.bytes());
         } catch (Exception e) {
             log.debug("Blog RSS fetch failed", e);

--- a/src/main/java/com/devoxx/genie/service/rag/RAGEventPublisher.java
+++ b/src/main/java/com/devoxx/genie/service/rag/RAGEventPublisher.java
@@ -74,7 +74,6 @@ public final class RAGEventPublisher {
             // Guard for tests where ApplicationManager isn't initialised.
             if (ApplicationManager.getApplication() == null) return;
             MessageBus bus = ApplicationManager.getApplication().getMessageBus();
-            if (bus == null) return;
             bus.syncPublisher(AppTopics.RAG_LOG_MSG).onRAGLoggingMessage(message);
         } catch (Exception e) {
             log.debug("Could not publish RAG event to message bus: {}", e.getMessage());

--- a/src/main/java/com/devoxx/genie/service/rag/watcher/RAGFileWatcher.java
+++ b/src/main/java/com/devoxx/genie/service/rag/watcher/RAGFileWatcher.java
@@ -5,7 +5,6 @@ import com.devoxx.genie.service.rag.manifest.IndexManifest;
 import com.devoxx.genie.service.rag.manifest.IndexManifestService;
 import com.devoxx.genie.ui.settings.DevoxxGenieStateService;
 import com.intellij.openapi.Disposable;
-import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.components.Service;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.Disposer;

--- a/src/main/java/com/devoxx/genie/ui/settings/mcp/dialog/MCPServerDialog.java
+++ b/src/main/java/com/devoxx/genie/ui/settings/mcp/dialog/MCPServerDialog.java
@@ -34,7 +34,7 @@ public class MCPServerDialog extends DialogWrapper {
     private final JComboBox<MCPServer.TransportType> transportTypeCombo = new JComboBox<>(MCPServer.TransportType.values());
     private final JButton testConnectionButton = new JButton("Test Connection & Fetch Tools");
     
-    private final Map<MCPServer.TransportType, TransportPanel> transportPanels = new HashMap<>();
+    private final Map<MCPServer.TransportType, TransportPanel> transportPanels = new EnumMap<>(MCPServer.TransportType.class);
     private final JPanel cardPanel = new JPanel(new CardLayout());
     
     private final MCPServer existingServer;
@@ -575,10 +575,10 @@ public class MCPServerDialog extends DialogWrapper {
         }
 
         private void setValueFieldText(String text) {
-            if (valueField instanceof JPasswordField) {
-                ((JPasswordField) valueField).setText(text);
-            } else if (valueField instanceof JTextField) {
-                ((JTextField) valueField).setText(text);
+            if (valueField instanceof JPasswordField jPasswordField) {
+                jPasswordField.setText(text);
+            } else if (valueField instanceof JTextField jTextField) {
+                jTextField.setText(text);
             }
         }
 

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -762,6 +762,8 @@
             implementation="com.devoxx.genie.completion.DevoxxGenieInlineCompletionProvider"/>
         <!-- Event Automation service -->
         <applicationService serviceImplementation="com.devoxx.genie.service.automation.EventAutomationService"/>
+        <!-- Blog feed service -->
+        <applicationService serviceImplementation="com.devoxx.genie.service.blog.BlogFeedService"/>
         <!-- Event Automation listeners -->
         <checkinHandlerFactory implementation="com.devoxx.genie.service.automation.listeners.VcsCheckinHandlerFactory"/>
         <testStatusListener implementation="com.devoxx.genie.service.automation.listeners.TestExecutionListener"/>

--- a/src/test/java/com/devoxx/genie/service/agent/tool/psi/FindDefinitionToolExecutorPsiTest.java
+++ b/src/test/java/com/devoxx/genie/service/agent/tool/psi/FindDefinitionToolExecutorPsiTest.java
@@ -1,0 +1,134 @@
+package com.devoxx.genie.service.agent.tool.psi;
+
+import com.intellij.testFramework.fixtures.BasePlatformTestCase;
+import dev.langchain4j.agent.tool.ToolExecutionRequest;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Real-PSI regression tests for {@link FindDefinitionToolExecutor}, guarding the robustness fixes
+ * that let the tool cope with the imperfect (file, line, symbol) arguments LLMs typically supply:
+ * <ul>
+ *     <li>a slightly wrong package directory in the path (resolved by filename fallback), and</li>
+ *     <li>a symbol name with an imprecise / wrong line number (resolved by file-wide symbol search).</li>
+ * </ul>
+ */
+class FindDefinitionToolExecutorPsiTest extends BasePlatformTestCase {
+
+    private FindDefinitionToolExecutor executor;
+
+    @BeforeEach
+    public void setUp() throws Exception {
+        super.setUp();
+        executor = new FindDefinitionToolExecutor(getProject());
+    }
+
+    @AfterEach
+    public void tearDown() throws Exception {
+        super.tearDown();
+    }
+
+    private static ToolExecutionRequest request(String args) {
+        return ToolExecutionRequest.builder().name("find_definition").arguments(args).build();
+    }
+
+    // --- Resolving a usage to its definition (precise position) ---
+
+    @Test
+    public void resolvesUsageToDefinition() {
+        // 1: public class Sample {
+        // 2:     void caller() {
+        // 3:         target();
+        // 4:     }
+        // 5:     void target() {}
+        // 6: }
+        myFixture.addFileToProject("Sample.java",
+                "public class Sample {\n" +
+                "    void caller() {\n" +
+                "        target();\n" +
+                "    }\n" +
+                "    void target() {}\n" +
+                "}\n");
+
+        String result = executor.execute(
+                request("{\"file\": \"Sample.java\", \"line\": 3, \"symbol\": \"target\"}"), null);
+
+        assertThat(result).contains("Definition of 'target'");
+        assertThat(result).contains("Sample.java:5");
+    }
+
+    // --- FIX 1: symbol with a wrong/imprecise line still resolves (file-wide fallback) ---
+
+    @Test
+    public void resolvesSymbolWhenLineIsWrong() {
+        // The reported failure: symbol points at the class, but the line points elsewhere
+        // (a body line that does not mention the symbol at all).
+        myFixture.addFileToProject("ProjectContextController.java",
+                "public class ProjectContextController {\n" +     // line 1 - the declaration
+                "    private final Object project;\n" +
+                "    public ProjectContextController(Object project) {\n" +
+                "        this.project = project;\n" +              // line 4 - LLM points here
+                "    }\n" +
+                "}\n");
+
+        String result = executor.execute(
+                request("{\"file\": \"ProjectContextController.java\", \"line\": 4, " +
+                        "\"symbol\": \"ProjectContextController\"}"), null);
+
+        assertThat(result).contains("Definition of 'ProjectContextController'");
+        assertThat(result).contains("ProjectContextController.java:1");
+    }
+
+    @Test
+    public void resolvesMethodSymbolFromWrongLine() {
+        myFixture.addFileToProject("Calc.java",
+                "public class Calc {\n" +
+                "    int compute() { return 1; }\n" +   // line 2 - definition
+                "    int unrelated() { return 2; }\n" +  // line 3 - LLM points here
+                "}\n");
+
+        String result = executor.execute(
+                request("{\"file\": \"Calc.java\", \"line\": 3, \"symbol\": \"compute\"}"), null);
+
+        assertThat(result).contains("Definition of 'compute'");
+        assertThat(result).contains("Calc.java:2");
+    }
+
+    // --- FIX 2: wrong package directory in the path still resolves (filename fallback) ---
+
+    @Test
+    public void resolvesFileWithWrongPackageDirectory() {
+        myFixture.addFileToProject("src/main/java/com/example/controller/Widget.java",
+                "package com.example.controller;\n" +
+                "public class Widget {\n" +
+                "    void use() { build(); }\n" +
+                "    void build() {}\n" +
+                "}\n");
+
+        // The path says 'ui' but the file actually lives under 'controller'.
+        String result = executor.execute(
+                request("{\"file\": \"src/main/java/com/example/ui/Widget.java\", " +
+                        "\"line\": 3, \"symbol\": \"build\"}"), null);
+
+        assertThat(result).contains("Definition of 'build'");
+        assertThat(result).contains("Widget.java:4");
+    }
+
+    // --- A genuinely unknown symbol still reports a clear error ---
+
+    @Test
+    public void unknownSymbolReturnsError() {
+        myFixture.addFileToProject("Empty.java",
+                "public class Empty {\n" +
+                "    void m() {}\n" +
+                "}\n");
+
+        String result = executor.execute(
+                request("{\"file\": \"Empty.java\", \"line\": 2, \"symbol\": \"doesNotExist\"}"), null);
+
+        assertThat(result).contains("Error").contains("Could not resolve symbol");
+    }
+}

--- a/src/test/java/com/devoxx/genie/service/agent/tool/psi/PsiToolUtilsTest.java
+++ b/src/test/java/com/devoxx/genie/service/agent/tool/psi/PsiToolUtilsTest.java
@@ -1,0 +1,126 @@
+package com.devoxx.genie.service.agent.tool.psi;
+
+import com.intellij.openapi.vfs.VirtualFile;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+
+/**
+ * Unit tests for the pure path-resolution helpers in {@link PsiToolUtils}.
+ * <p>
+ * These guard the fallback that makes PSI tools tolerant of slightly wrong paths
+ * (e.g. the LLM guessing {@code .../ui/Foo.java} when the file is under
+ * {@code .../controller/Foo.java}). See {@link PsiToolUtils#resolvePsiFile}.
+ */
+class PsiToolUtilsTest {
+
+    // --- normalizeRelativePath ---
+
+    @Test
+    void normalizeRelativePath_trimsWhitespace() {
+        assertThat(PsiToolUtils.normalizeRelativePath("  src/Foo.java  ")).isEqualTo("src/Foo.java");
+    }
+
+    @Test
+    void normalizeRelativePath_convertsBackslashes() {
+        assertThat(PsiToolUtils.normalizeRelativePath("src\\main\\Foo.java")).isEqualTo("src/main/Foo.java");
+    }
+
+    @Test
+    void normalizeRelativePath_stripsLeadingDotSlash() {
+        assertThat(PsiToolUtils.normalizeRelativePath("./src/Foo.java")).isEqualTo("src/Foo.java");
+    }
+
+    @Test
+    void normalizeRelativePath_stripsLeadingSlash() {
+        assertThat(PsiToolUtils.normalizeRelativePath("/src/Foo.java")).isEqualTo("src/Foo.java");
+    }
+
+    @Test
+    void normalizeRelativePath_stripsMultipleLeadingSegments() {
+        assertThat(PsiToolUtils.normalizeRelativePath(".//src/Foo.java")).isEqualTo("src/Foo.java");
+    }
+
+    @Test
+    void normalizeRelativePath_leavesPlainPathUntouched() {
+        assertThat(PsiToolUtils.normalizeRelativePath("src/main/java/Foo.java"))
+                .isEqualTo("src/main/java/Foo.java");
+    }
+
+    // --- fileNameOf ---
+
+    @Test
+    void fileNameOf_returnsLastSegment() {
+        assertThat(PsiToolUtils.fileNameOf("src/main/java/com/devoxx/Foo.java")).isEqualTo("Foo.java");
+    }
+
+    @Test
+    void fileNameOf_returnsWholeStringWhenNoSlash() {
+        assertThat(PsiToolUtils.fileNameOf("Foo.java")).isEqualTo("Foo.java");
+    }
+
+    // --- pickBestPathMatch ---
+
+    @Test
+    void pickBestPathMatch_emptyCandidates_returnsNull() {
+        assertThat(PsiToolUtils.pickBestPathMatch(List.of(), "src/Foo.java")).isNull();
+    }
+
+    @Test
+    void pickBestPathMatch_singleCandidate_returnsIt() {
+        VirtualFile file = mockFile("/project/src/main/java/com/devoxx/genie/controller/Foo.java", false);
+        assertThat(PsiToolUtils.pickBestPathMatch(List.of(file), "anything/Foo.java")).isSameAs(file);
+    }
+
+    @Test
+    void pickBestPathMatch_picksLongestTrailingSegmentOverlap() {
+        // Two files share the name; the requested path's trailing segments match one of them more
+        // closely, so that candidate must win regardless of list order.
+        VirtualFile decoy = mockFile("/project/x/y/other/impl/Foo.java", false);
+        VirtualFile wanted = mockFile("/project/a/b/service/impl/Foo.java", false);
+
+        String requested = "service/impl/Foo.java";
+
+        assertThat(PsiToolUtils.pickBestPathMatch(List.of(decoy, wanted), requested)).isSameAs(wanted);
+        // Order must not matter.
+        assertThat(PsiToolUtils.pickBestPathMatch(List.of(wanted, decoy), requested)).isSameAs(wanted);
+    }
+
+    @Test
+    void pickBestPathMatch_wrongImmediateParent_stillResolvesToSameNamedFile() {
+        // Reproduces the reported bug shape: the LLM guessed the wrong package directory
+        // ("ui" instead of "controller"). When the differing directory is immediately before the
+        // file name, the trailing overlap is just the file name for every candidate, so we cannot
+        // tell them apart - but we must still return a same-named file rather than a hard error.
+        VirtualFile controller =
+                mockFile("/project/src/main/java/com/devoxx/genie/controller/ActionButtonsPanelController.java", false);
+
+        String requested = "src/main/java/com/devoxx/genie/ui/ActionButtonsPanelController.java";
+
+        assertThat(PsiToolUtils.pickBestPathMatch(List.of(controller), requested)).isSameAs(controller);
+    }
+
+    @Test
+    void pickBestPathMatch_skipsDirectories() {
+        VirtualFile dir = mockFile("/project/src/Foo.java", true);
+        VirtualFile realFile = mockFile("/project/other/Foo.java", false);
+        assertThat(PsiToolUtils.pickBestPathMatch(List.of(dir, realFile), "x/Foo.java")).isSameAs(realFile);
+    }
+
+    @Test
+    void pickBestPathMatch_allDirectories_returnsNull() {
+        VirtualFile dir = mockFile("/project/src/Foo.java", true);
+        assertThat(PsiToolUtils.pickBestPathMatch(List.of(dir), "x/Foo.java")).isNull();
+    }
+
+    private static VirtualFile mockFile(String path, boolean isDirectory) {
+        VirtualFile file = mock(VirtualFile.class);
+        lenient().when(file.getPath()).thenReturn(path);
+        lenient().when(file.isDirectory()).thenReturn(isDirectory);
+        return file;
+    }
+}

--- a/src/test/java/com/devoxx/genie/ui/settings/mcp/dialog/MCPServerDialogExistingServerSupportTest.java
+++ b/src/test/java/com/devoxx/genie/ui/settings/mcp/dialog/MCPServerDialogExistingServerSupportTest.java
@@ -1,0 +1,103 @@
+package com.devoxx.genie.ui.settings.mcp.dialog;
+
+import com.devoxx.genie.model.mcp.MCPServer;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class MCPServerDialogExistingServerSupportTest {
+
+    private MCPServerDialog.ExistingServerConfigurationSupport support;
+
+    @BeforeEach
+    void setUp() {
+        support = new MCPServerDialog.ExistingServerConfigurationSupport();
+    }
+
+    @Test
+    void headersForConnectionReturnsEmptyMapWhenServerIsNull() {
+        assertThat(support.headersForConnection(null)).isEmpty();
+    }
+
+    @Test
+    void headersForConnectionReturnsEmptyMapWhenServerHasNoHeaders() {
+        MCPServer server = MCPServer.builder().name("demo").build();
+
+        assertThat(support.headersForConnection(server)).isEmpty();
+    }
+
+    @Test
+    void headersForConnectionReturnsDefensiveCopy() {
+        Map<String, String> headers = new HashMap<>();
+        headers.put("Authorization", "Bearer token");
+        MCPServer server = MCPServer.builder()
+                .name("demo")
+                .headers(headers)
+                .build();
+
+        Map<String, String> result = support.headersForConnection(server);
+        result.put("X-Test", "value");
+
+        assertThat(result).containsEntry("Authorization", "Bearer token");
+        assertThat(server.getHeaders()).containsOnlyKeys("Authorization");
+        assertThat(server.getHeaders()).containsEntry("Authorization", "Bearer token");
+    }
+
+    @Test
+    void applyPreservedSettingsCopiesEnvAndHeadersOntoBuilder() {
+        MCPServer existingServer = MCPServer.builder()
+                .name("demo")
+                .env(new HashMap<>(Map.of("API_KEY", "secret")))
+                .headers(new HashMap<>(Map.of("Authorization", "Bearer token")))
+                .build();
+        MCPServer.MCPServerBuilder builder = MCPServer.builder().name("updated");
+
+        support.applyPreservedSettings(existingServer, builder);
+        MCPServer rebuilt = builder.build();
+
+        assertThat(rebuilt.getEnv()).containsOnlyKeys("API_KEY");
+        assertThat(rebuilt.getEnv()).containsEntry("API_KEY", "secret");
+        assertThat(rebuilt.getHeaders()).containsOnlyKeys("Authorization");
+        assertThat(rebuilt.getHeaders()).containsEntry("Authorization", "Bearer token");
+    }
+
+    @Test
+    void applyPreservedSettingsSkipsHeadersWhenExistingServerHasNone() {
+        MCPServer existingServer = MCPServer.builder()
+                .name("demo")
+                .env(new HashMap<>(Map.of("API_KEY", "secret")))
+                .build();
+        MCPServer.MCPServerBuilder builder = MCPServer.builder().name("updated");
+
+        support.applyPreservedSettings(existingServer, builder);
+        MCPServer rebuilt = builder.build();
+
+        assertThat(rebuilt.getEnv()).containsOnlyKeys("API_KEY");
+        assertThat(rebuilt.getEnv()).containsEntry("API_KEY", "secret");
+        assertThat(rebuilt.getHeaders()).isEmpty();
+    }
+
+    @Test
+    void applyPreservedHeadersDoesNotOverrideBuilderEnv() {
+        MCPServer existingServer = MCPServer.builder()
+                .name("demo")
+                .env(new HashMap<>(Map.of("API_KEY", "secret")))
+                .headers(new HashMap<>(Map.of("Authorization", "Bearer token")))
+                .build();
+        MCPServer.MCPServerBuilder builder = MCPServer.builder()
+                .name("updated")
+                .env(new HashMap<>(Map.of("FROM_UI", "value")));
+
+        support.applyPreservedHeaders(existingServer, builder);
+        MCPServer rebuilt = builder.build();
+
+        assertThat(rebuilt.getEnv()).containsOnlyKeys("FROM_UI");
+        assertThat(rebuilt.getEnv()).containsEntry("FROM_UI", "value");
+        assertThat(rebuilt.getHeaders()).containsOnlyKeys("Authorization");
+        assertThat(rebuilt.getHeaders()).containsEntry("Authorization", "Bearer token");
+    }
+}


### PR DESCRIPTION
## Summary
- Apply SonarQube fixes across LLM providers and services: extract duplicated string literals to constants (S1192), make `ModelVersionComparator` `Serializable`, add exhaustive `default` switch branches, use `EnumMap` + pattern-matching `instanceof`, and replace null-body checks with `Objects.requireNonNull`.
- Convert `BlogFeedService` to a registered IntelliJ application service.
- Add PSI tool and MCP dialog regression tests, plus a backlog note for the kotlin S3776 follow-up.

## Test plan
- [ ] `./gradlew clean buildPlugin` succeeds (verified locally with JDK 21)
- [ ] `./gradlew test` passes, including the new PSI and MCP dialog tests
- [ ] Anthropic model ordering (Opus > Sonnet > Haiku) still sorts correctly
- [ ] MCP "Test Connection" still works and preserves headers/env on edit

🤖 Generated with [Claude Code](https://claude.com/claude-code)