### PR TITLE
fix: stop DevoxxGenie LLM settings panel from overflowing the dialog …

### DIFF
--- a/src/main/java/com/devoxx/genie/ui/settings/AbstractSettingsComponent.java
+++ b/src/main/java/com/devoxx/genie/ui/settings/AbstractSettingsComponent.java
@@ -76,9 +76,12 @@ public class AbstractSettingsComponent implements SettingsComponent {
     protected void addSettingRow(@NotNull JPanel panel, @NotNull GridBagConstraints gbc, String label, JComponent component) {
         gbc.gridwidth = 1;
         gbc.gridx = 0;
+        gbc.weightx = 0;
         panel.add(new JLabel(label), gbc);
         gbc.gridx = 1;
+        gbc.weightx = 1.0; // let the input column absorb the available width instead of overflowing the dialog
         panel.add(component, gbc);
+        gbc.weightx = 0;
         gbc.gridy++;
     }
 

--- a/src/main/java/com/devoxx/genie/ui/settings/llm/LLMProvidersComponent.java
+++ b/src/main/java/com/devoxx/genie/ui/settings/llm/LLMProvidersComponent.java
@@ -4,8 +4,8 @@ import com.devoxx.genie.model.enumarations.AwsBedrockAuthMode;
 import com.devoxx.genie.service.PropertiesService;
 import com.devoxx.genie.ui.settings.AbstractSettingsComponent;
 import com.intellij.ide.ui.UINumericRange;
+import com.intellij.openapi.ui.panel.ComponentPanelBuilder;
 import com.intellij.ui.JBIntSpinner;
-import com.intellij.ui.JBColor;
 import com.intellij.util.ui.JBUI;
 import lombok.Getter;
 import org.jetbrains.annotations.NotNull;
@@ -17,6 +17,19 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class LLMProvidersComponent extends AbstractSettingsComponent {
+
+    /**
+     * Preferred width of text/password fields, expressed in columns. Keeps a long stored
+     * value from dictating the field's preferred width; the field still grows to fill the
+     * available horizontal space.
+     */
+    private static final int TEXT_FIELD_COLUMNS = 20;
+
+    /**
+     * Max line length (in characters) before a hint label wraps. Keeps long hints from
+     * widening the input column — and thus the whole settings dialog — beyond the view.
+     */
+    private static final int HINT_WRAP_COLUMNS = 60;
 
     @Getter
     private final JTextField projectVersion = new JTextField(PropertiesService.getInstance().getVersion());
@@ -231,6 +244,8 @@ public class LLMProvidersComponent extends AbstractSettingsComponent {
         addSection(panel, gbc, "Plugin version");
         addSettingRow(panel, gbc, "v" + projectVersion.getText(), createTextWithLinkButton(new JLabel("View on GitHub"), "https://github.com/devoxx/DevoxxGenieIDEAPlugin"));
 
+        boundTextFieldWidths(panel);
+
         return panel;
     }
 
@@ -335,14 +350,17 @@ public class LLMProvidersComponent extends AbstractSettingsComponent {
     ) {
         gbc.gridwidth = 1;
         gbc.gridx = 0;
+        gbc.weightx = 0;
         gbc.insets = JBUI.insets(5, 20, 5, 5); // Indent by 20 pixels on the left
         JLabel jLabel = new JLabel(label);
         panel.add(jLabel, gbc);
         componentsGroup.add(jLabel);
 
         gbc.gridx = 1;
+        gbc.weightx = 1.0;
         panel.add(component, gbc);
         componentsGroup.add(component);
+        gbc.weightx = 0;
         gbc.gridy++;
 
         gbc.insets = JBUI.insets(5);
@@ -400,16 +418,38 @@ public class LLMProvidersComponent extends AbstractSettingsComponent {
             @NotNull GridBagConstraints gbc,
             String text
     ) {
-        JLabel hintLabel = new JLabel(text);
-        hintLabel.setFont(hintLabel.getFont().deriveFont(hintLabel.getFont().getSize() - 2f));
-        hintLabel.setForeground(JBColor.GRAY);
+        // Use a word-wrapping comment component so long hints reflow to multiple lines
+        // instead of stretching the input column (and the whole dialog) past its edge.
+        JComponent hintLabel = ComponentPanelBuilder.createCommentComponent(text, true, HINT_WRAP_COLUMNS, true);
 
         JPanel providerPanel = new JPanel(new BorderLayout(5, 0));
         providerPanel.add(hintLabel, BorderLayout.CENTER);
 
         gbc.gridwidth = 1;
         gbc.gridx = 1;
+        gbc.weightx = 1.0;
         panel.add(providerPanel, gbc);
+        gbc.weightx = 0;
         gbc.gridy++;
+    }
+
+    /**
+     * Bound the preferred width of every text/password field so a long stored value
+     * (e.g. a 150-char API key) cannot blow up the settings form width and push the
+     * input borders off the edge of the dialog. The fields still expand to fill the
+     * available width via {@code fill=HORIZONTAL} + {@code weightx}; this only caps
+     * their <em>preferred</em> width. Spinners are left untouched.
+     */
+    private void boundTextFieldWidths(@NotNull Container container) {
+        for (Component child : container.getComponents()) {
+            if (child instanceof JSpinner) {
+                continue; // spinners manage their own editor size
+            }
+            if (child instanceof JTextField textField) {
+                textField.setColumns(TEXT_FIELD_COLUMNS);
+            } else if (child instanceof Container nested) {
+                boundTextFieldWidths(nested);
+            }
+        }
     }
 }


### PR DESCRIPTION
…width

The "Tools > DevoxxGenie" settings panel rendered far wider than the visible dialog, clipping the right edge of the input field borders. Root cause: the API-key JPasswordField/JTextField components are created with the stored value as content and no column count, so each sized its preferred width to the full string. A long key (e.g. a ~150-char OpenAI sk-proj-... key) gave one field a ~1170px preferred width, forcing the GridBag column, the form, and the whole auto-sized dialog past the screen edge.

- boundTextFieldWidths(): cap every text/password field to a fixed column count so a long stored value can't dictate the form width; fields still fill the available width via fill=HORIZONTAL + weightx.
- addSettingRow / addNestedSettingsRow: give the input column weightx=1 (label column weightx=0) so inputs absorb width instead of overflowing.
- Hints now use a word-wrapping comment component (ComponentPanelBuilder) capped at 60 chars, so long hints reflow to multiple lines rather than widening the column.

Verified live in IntelliJ 2025.3.3: the form's minimum width drops from ~728px to ~625px and the input borders stay within the panel.

# Pull Request

## 📚 Documentation

Before submitting, please review our [Contributing Guide](https://genie.devoxx.com/docs/contributing).

## Description

<!-- Provide a clear description of your changes -->

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test addition/improvement

## Related Issue

<!-- Link to the issue this PR addresses -->
Fixes #
Closes #
Related to #

## Changes Made

<!-- List the specific changes made in this PR -->
-
-
-

## Testing

**How has this been tested?**

- [ ] Unit tests
- [ ] Integration tests
- [ ] Manual testing in IntelliJ IDEA
- [ ] Tested with local LLM (Ollama/LMStudio/GPT4All)
- [ ] Tested with cloud LLM (OpenAI/Anthropic/Gemini)
- [ ] Tested with MCP servers
- [ ] Tested with RAG enabled

**Test Configuration:**
- IntelliJ IDEA version:
- JDK version:
- OS:

## Documentation

- [ ] I have updated the documentation at [genie.devoxx.com](https://genie.devoxx.com) if needed
- [ ] I have updated CLAUDE.md if architecture/patterns changed
- [ ] I have added/updated code comments for complex logic
- [ ] I have updated the README.md if needed

## Checklist

- [ ] My code follows the existing code style
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Screenshots/Videos (if applicable)

<!-- Add screenshots or videos demonstrating the changes, especially for UI changes -->

## Additional Notes

<!-- Any additional information that reviewers should know -->

## Breaking Changes

<!-- If this PR introduces breaking changes, describe them here and update the version accordingly -->

---

By submitting this pull request, I confirm that my contribution is made under the terms of the project's license.
