### PR TITLE
fix: DEVOXXGENIE.md generation hang + restore broken test suite

### DIFF
--- a/src/main/java/com/devoxx/genie/service/agent/tool/psi/FindDefinitionToolExecutor.java
+++ b/src/main/java/com/devoxx/genie/service/agent/tool/psi/FindDefinitionToolExecutor.java
@@ -8,6 +8,7 @@ import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiFile;
 import com.intellij.psi.PsiNameIdentifierOwner;
 import com.intellij.psi.PsiReference;
+import com.intellij.psi.util.PsiTreeUtil;
 import dev.langchain4j.agent.tool.ToolExecutionRequest;
 import dev.langchain4j.service.tool.ToolExecutor;
 import lombok.extern.slf4j.Slf4j;
@@ -58,7 +59,9 @@ public class FindDefinitionToolExecutor implements ToolExecutor {
 
         PsiFile psiFile = PsiToolUtils.resolvePsiFile(project, filePath);
         if (psiFile == null) {
-            return "Error: File not found or cannot be parsed: " + filePath;
+            return "Error: File not found or cannot be parsed: " + filePath
+                    + ". Verify the path (it is relative to the project root) - use 'search_files'"
+                    + " or 'find_symbols' to locate the correct file.";
         }
 
         // Try to find the element at the specific position
@@ -106,7 +109,31 @@ public class FindDefinitionToolExecutor implements ToolExecutor {
         PsiElement fromLine = resolveBySearchingLine(psiFile, line, symbol);
         if (fromLine != null) return fromLine;
 
-        return PsiToolUtils.findNamedElementOnLine(psiFile, line, symbol);
+        PsiElement namedOnLine = PsiToolUtils.findNamedElementOnLine(psiFile, line, symbol);
+        if (namedOnLine != null) return namedOnLine;
+
+        // Last resort: the supplied line may be imprecise (LLMs often guess it). When a symbol name
+        // is given, search the whole file for it - either a usage that resolves to its definition,
+        // or a declaration of that name living in this file.
+        return resolveBySymbolInFile(psiFile, symbol);
+    }
+
+    /**
+     * Strategy 4 (file-wide): when the line-scoped strategies fail but a symbol name is known,
+     * scan the entire file. First look for a usage of the symbol that resolves to a definition
+     * (possibly in another file); failing that, return a declaration of that name in this file.
+     */
+    @Nullable
+    private PsiElement resolveBySymbolInFile(@NotNull PsiFile psiFile, @Nullable String symbol) {
+        if (symbol == null || symbol.isBlank()) return null;
+
+        for (PsiElement leaf : PsiTreeUtil.collectElements(psiFile,
+                e -> e.getFirstChild() == null && symbol.equals(e.getText()))) {
+            PsiElement resolved = resolveElement(leaf);
+            if (resolved != null) return resolved;
+        }
+
+        return PsiToolUtils.findNamedElementInFile(psiFile, symbol);
     }
 
     /** Strategy 1: resolve the element at the exact column offset. */

--- a/src/main/java/com/devoxx/genie/service/agent/tool/psi/PsiToolUtils.java
+++ b/src/main/java/com/devoxx/genie/service/agent/tool/psi/PsiToolUtils.java
@@ -1,11 +1,15 @@
 package com.devoxx.genie.service.agent.tool.psi;
 
 import com.intellij.openapi.editor.Document;
+import com.intellij.openapi.project.DumbService;
+import com.intellij.openapi.project.IndexNotReadyException;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.project.ProjectUtil;
 import com.intellij.openapi.vfs.VfsUtil;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.psi.*;
+import com.intellij.psi.search.FilenameIndex;
+import com.intellij.psi.search.GlobalSearchScope;
 import com.intellij.psi.util.PsiTreeUtil;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -24,16 +28,124 @@ public final class PsiToolUtils {
 
     /**
      * Resolves a relative path to a PsiFile within the project.
+     * <p>
+     * First tries an exact lookup relative to the project root. When that fails - typically
+     * because the LLM guessed the wrong package directory (e.g. {@code .../ui/Foo.java} when the
+     * file actually lives under {@code .../controller/Foo.java}) - it falls back to a filename
+     * search across the project and picks the candidate whose path best matches the requested one.
      */
     @Nullable
     public static PsiFile resolvePsiFile(@NotNull Project project, @NotNull String relativePath) {
+        VirtualFile vf = resolveVirtualFile(project, relativePath);
+        if (vf == null) return null;
+        return PsiManager.getInstance(project).findFile(vf);
+    }
+
+    /**
+     * Resolves a relative path to a VirtualFile, with a filename-based fallback. See
+     * {@link #resolvePsiFile} for the resolution strategy.
+     */
+    @Nullable
+    public static VirtualFile resolveVirtualFile(@NotNull Project project, @NotNull String relativePath) {
         VirtualFile projectBase = ProjectUtil.guessProjectDir(project);
         if (projectBase == null) return null;
 
-        VirtualFile vf = projectBase.findFileByRelativePath(relativePath);
-        if (vf == null || vf.isDirectory()) return null;
+        String normalized = normalizeRelativePath(relativePath);
+        if (normalized.isEmpty()) return null;
 
-        return PsiManager.getInstance(project).findFile(vf);
+        // 1. Exact relative-path match (fast path).
+        VirtualFile vf = projectBase.findFileByRelativePath(normalized);
+        if (vf != null && !vf.isDirectory()) return vf;
+
+        // 2. Fallback: locate by filename and pick the closest path match.
+        return resolveByFileName(project, normalized);
+    }
+
+    @Nullable
+    private static VirtualFile resolveByFileName(@NotNull Project project, @NotNull String normalizedPath) {
+        String fileName = fileNameOf(normalizedPath);
+        if (fileName.isEmpty()) return null;
+
+        // FilenameIndex requires a built index; bail out gracefully during indexing.
+        if (DumbService.getInstance(project).isDumb()) return null;
+
+        try {
+            Collection<VirtualFile> matches =
+                    FilenameIndex.getVirtualFilesByName(fileName, GlobalSearchScope.projectScope(project));
+            return pickBestPathMatch(matches, normalizedPath);
+        } catch (IndexNotReadyException e) {
+            return null;
+        }
+    }
+
+    /**
+     * Normalizes a user-supplied path: trims whitespace, converts back-slashes, and strips
+     * leading {@code ./} and {@code /} segments so it is relative to the project root.
+     */
+    @NotNull
+    static String normalizeRelativePath(@NotNull String path) {
+        String normalized = path.trim().replace('\\', '/');
+        while (normalized.startsWith("./")) {
+            normalized = normalized.substring(2);
+        }
+        while (normalized.startsWith("/")) {
+            normalized = normalized.substring(1);
+        }
+        return normalized;
+    }
+
+    /** Returns the last path segment (the file name) of a normalized path. */
+    @NotNull
+    static String fileNameOf(@NotNull String normalizedPath) {
+        int slash = normalizedPath.lastIndexOf('/');
+        return slash < 0 ? normalizedPath : normalizedPath.substring(slash + 1);
+    }
+
+    /**
+     * From a set of files that all share the requested file name, picks the one whose path shares
+     * the longest trailing run of path segments with the requested path. This disambiguates when
+     * several files have the same name in different packages. Returns null when there are no
+     * candidates, and the single candidate when there is exactly one.
+     */
+    @Nullable
+    static VirtualFile pickBestPathMatch(@NotNull Collection<VirtualFile> candidates, @NotNull String requestedPath) {
+        if (candidates.isEmpty()) return null;
+
+        List<String> requestedSegments = splitSegments(requestedPath);
+
+        VirtualFile best = null;
+        int bestScore = -1;
+        for (VirtualFile candidate : candidates) {
+            if (candidate == null || candidate.isDirectory()) continue;
+            int score = trailingSegmentOverlap(requestedSegments, splitSegments(candidate.getPath()));
+            if (score > bestScore) {
+                bestScore = score;
+                best = candidate;
+            }
+        }
+        return best;
+    }
+
+    @NotNull
+    private static List<String> splitSegments(@NotNull String path) {
+        List<String> segments = new ArrayList<>();
+        for (String part : path.split("/")) {
+            if (!part.isBlank()) segments.add(part);
+        }
+        return segments;
+    }
+
+    /** Counts how many trailing path segments two paths have in common (file name counts as one). */
+    private static int trailingSegmentOverlap(@NotNull List<String> a, @NotNull List<String> b) {
+        int overlap = 0;
+        int i = a.size() - 1;
+        int j = b.size() - 1;
+        while (i >= 0 && j >= 0 && a.get(i).equals(b.get(j))) {
+            overlap++;
+            i--;
+            j--;
+        }
+        return overlap;
     }
 
     /**
@@ -78,15 +190,31 @@ public final class PsiToolUtils {
 
         if (onLine.isEmpty()) return null;
 
-        // If symbol name is provided, find the matching one
+        // If a symbol name is provided, only return an element that actually matches it. Returning
+        // an arbitrary unrelated declaration that merely happens to share the line would produce a
+        // wrong definition; instead return null so callers can fall back or report a clear error.
         if (symbolName != null && !symbolName.isBlank()) {
             for (PsiNameIdentifierOwner owner : onLine) {
                 if (symbolName.equals(owner.getName())) return owner;
             }
+            return null;
         }
 
-        // Return the first one found on the line
+        // No symbol requested: return the first declaration found on the line.
         return onLine.get(0);
+    }
+
+    /**
+     * Finds the first PsiNameIdentifierOwner declared anywhere in the file whose name matches the
+     * given symbol. Used as a file-wide fallback when a precise line is unavailable.
+     */
+    @Nullable
+    public static PsiNameIdentifierOwner findNamedElementInFile(@NotNull PsiFile psiFile, @Nullable String symbolName) {
+        if (symbolName == null || symbolName.isBlank()) return null;
+        for (PsiNameIdentifierOwner owner : PsiTreeUtil.findChildrenOfType(psiFile, PsiNameIdentifierOwner.class)) {
+            if (symbolName.equals(owner.getName())) return owner;
+        }
+        return null;
     }
 
     /**

--- a/src/main/java/com/devoxx/genie/service/analyzer/DevoxxGenieGenerator.java
+++ b/src/main/java/com/devoxx/genie/service/analyzer/DevoxxGenieGenerator.java
@@ -29,6 +29,7 @@ public class DevoxxGenieGenerator {
     private final Project project;
     private final VirtualFile baseDir;
     private final Boolean includeTree;
+    private final int treeDepth;
     private final ProgressIndicator indicator;
     
     // Components
@@ -51,6 +52,7 @@ public class DevoxxGenieGenerator {
                                 ProgressIndicator indicator) {
         this.project = project;
         this.includeTree = includeTree;
+        this.treeDepth = treeDepth;
         this.baseDir = ProjectUtil.guessProjectDir(project);
         this.indicator = indicator;
         
@@ -79,7 +81,7 @@ public class DevoxxGenieGenerator {
             // Step 1: Analyze the project and create prompt - computeInNonDispatchThread to avoid EDT blocking
             indicator.setText("Analyzing project structure...");
             Map<String, Object> projectInfo = com.intellij.openapi.application.ReadAction.nonBlocking(() -> {
-                ProjectAnalyzer scanner = new ProjectAnalyzer(project, baseDir);
+                ProjectAnalyzer scanner = new ProjectAnalyzer(project, baseDir, indicator);
                 return scanner.scanProject();
             }).executeSynchronously();
             
@@ -100,10 +102,10 @@ public class DevoxxGenieGenerator {
             
             // Step 4: Handle project tree generation if needed - also requires write action
             if (Boolean.TRUE.equals(includeTree)) {
-                indicator.setText("Generating project tree...");
+                indicator.setText("Generating project tree (depth " + treeDepth + ")...");
                 com.intellij.openapi.application.WriteAction.runAndWait(() -> {
                     try {
-                        treeGenerator.appendProjectTree(baseDir, DEVOXX_GENIE_MD);
+                        treeGenerator.appendProjectTree(baseDir, DEVOXX_GENIE_MD, treeDepth, indicator);
                     } catch (Exception e) {
                         throw new RuntimeException(e);
                     }
@@ -115,20 +117,16 @@ public class DevoxxGenieGenerator {
                 NotificationUtil.sendNotification(project, "DEVOXXGENIE.md generated successfully in " 
                         + baseDir.getPath());
             });
+        } catch (com.intellij.openapi.progress.ProcessCanceledException e) {
+            // User cancelled the background task - not an error.
+            log.info("DEVOXXGENIE.md generation cancelled by user");
+            com.intellij.openapi.application.ApplicationManager.getApplication().invokeLater(() ->
+                    NotificationUtil.sendNotification(project, "DEVOXXGENIE.md generation cancelled"));
         } catch (Exception e) {
             log.error("Error generating DEVOXXGENIE.md", e);
             com.intellij.openapi.application.ApplicationManager.getApplication().invokeLater(() -> {
                 NotificationUtil.sendNotification(project, "Error generating DEVOXXGENIE.md: " + e.getMessage());
             });
         }
-    }
-
-    /**
-     * Scans the project for information.
-     */
-    private Map<String, Object> scanProject() {
-        ProjectAnalyzer scanner = new ProjectAnalyzer(project, baseDir);
-        indicator.setText("Analyzing project structure...");
-        return ReadAccess.compute(scanner::scanProject);
     }
 }

--- a/src/main/java/com/devoxx/genie/service/analyzer/ProjectAnalyzer.java
+++ b/src/main/java/com/devoxx/genie/service/analyzer/ProjectAnalyzer.java
@@ -3,6 +3,7 @@ package com.devoxx.genie.service.analyzer;
 import com.devoxx.genie.service.analyzer.tools.GlobTool;
 import com.devoxx.genie.service.analyzer.util.GitignoreParser;
 import com.devoxx.genie.util.ReadAccess;
+import com.intellij.openapi.progress.ProgressIndicator;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.roots.ProjectFileIndex;
 import com.intellij.openapi.vfs.VfsUtil;
@@ -81,10 +82,16 @@ public class ProjectAnalyzer {
     private final Project project;
     private final VirtualFile baseDir;
     private final GitignoreParser gitignoreParser;
+    private final ProgressIndicator indicator;
 
     public ProjectAnalyzer(Project project, VirtualFile baseDir) {
+        this(project, baseDir, null);
+    }
+
+    public ProjectAnalyzer(Project project, VirtualFile baseDir, @Nullable ProgressIndicator indicator) {
         this.project = project;
         this.baseDir = baseDir;
+        this.indicator = indicator;
 
         // Initialize the GitignoreParser with support for nested .gitignore files
         this.gitignoreParser = new GitignoreParser(baseDir);
@@ -96,10 +103,20 @@ public class ProjectAnalyzer {
             Map<String, Object> projectInfo = new HashMap<>();
 
             // IDE-agnostic detection
+            setStep("Detecting build system...");
             projectInfo.put("buildSystem", detectBuildSystem());
-            projectInfo.put("languages", detectLanguages());
+
+            setStep("Detecting code style...");
             projectInfo.put("codeStyle", detectCodeStyle());
-            projectInfo.put("frameworks", detectFrameworks());
+
+            // A single walk of the project tree feeds both language and framework detection,
+            // instead of one walk for languages plus ~10 more (one per framework pattern).
+            setStep("Scanning source files...");
+            SourceScanResult scan = scanSourceTree();
+            projectInfo.put("languages", scan.toLanguagesMap());
+            projectInfo.put("frameworks", buildFrameworks(scan));
+
+            setStep("Detecting dependencies...");
             projectInfo.put("dependencies", detectDependencies());
 
             // IDE-specific enhancements through extension points
@@ -109,6 +126,24 @@ public class ProjectAnalyzer {
 
             return projectInfo;
         });
+    }
+
+    /** Updates the main progress label, when an indicator is available. */
+    private void setStep(@NotNull String text) {
+        if (indicator != null) {
+            indicator.setText(text);
+        }
+    }
+
+    /**
+     * Reports the file/dir currently being read and honours cancellation
+     * (throws {@link com.intellij.openapi.progress.ProcessCanceledException} when the user cancels).
+     */
+    private void reportProgress(@NotNull VirtualFile file) {
+        if (indicator != null) {
+            indicator.checkCanceled();
+            indicator.setText2(file.getPath());
+        }
     }
 
     private @NotNull Map<String, Object> detectBuildSystem() {
@@ -163,116 +198,101 @@ public class ProjectAnalyzer {
         return buildInfo;
     }
 
-    private @NotNull Map<String, Object> detectLanguages() {
-        Map<String, Object> languages = new HashMap<>();
-        Set<String> detectedLanguages = new HashSet<>();
-        Map<String, Integer> languageFileCount = new HashMap<>();
-
-        // Check for language-specific project files first
-        if (baseDir.findChild(CARGO_TOML) != null) {
-            detectedLanguages.add(RUST);
-            languageFileCount.put(RUST, 1);  // Start with 1 for the project file
-        }
-        if (baseDir.findChild(POM_XML) != null) {
-            detectedLanguages.add(JAVA);
-            languageFileCount.put(JAVA, 1);
-        }
-        if (baseDir.findChild(BUILD_GRADLE) != null || baseDir.findChild(BUILD_GRADLE_KTS) != null) {
-            detectedLanguages.add(JAVA);
-            detectedLanguages.add(KOTLIN);
-            languageFileCount.put(JAVA, languageFileCount.getOrDefault(JAVA, 0) + 1);
-            languageFileCount.put(KOTLIN, languageFileCount.getOrDefault(KOTLIN, 0) + 1);
-        }
-        if (baseDir.findChild(GO_MOD) != null) {
-            detectedLanguages.add(GO);
-            languageFileCount.put(GO, 1);
-        }
-        if (baseDir.findChild(PACKAGE_JSON) != null) {
-            detectedLanguages.add(JAVA_SCRIPT_TYPE_SCRIPT);
-            languageFileCount.put(JAVA_SCRIPT_TYPE_SCRIPT, 1);
-        }
-        if (baseDir.findChild(CMAKE_LISTS_TXT) != null) {
-            detectedLanguages.add(C_C_PLUS_PLUS);
-            languageFileCount.put(C_C_PLUS_PLUS, 1);
-        }
+    /**
+     * Walks the project tree exactly once, collecting both language statistics and framework
+     * matches. Gitignored files and directories are skipped (their subtrees are not descended).
+     */
+    private @NotNull SourceScanResult scanSourceTree() {
+        SourceScanResult result = new SourceScanResult(createFrameworkMatchers());
+        seedLanguagesFromProjectFiles(result);
 
         VfsUtil.visitChildrenRecursively(baseDir, new VirtualFileVisitor<Void>() {
             @Override
             public boolean visitFile(@NotNull VirtualFile file) {
-                // Check if the file should be ignored based on .gitignore rules
+                // Skip ignored files and do not descend into ignored directories.
                 String relativePath = getRelativePath(baseDir, file);
                 if (relativePath != null && gitignoreParser.shouldIgnore(relativePath, file.isDirectory())) {
-                    return true; // Skip this file and its children
+                    return false;
                 }
 
-                if (!file.isDirectory()) {
-                    // Use ReadAction to safely access the ProjectFileIndex
-                    boolean isInContent = ReadAccess.compute(() ->
-                            ProjectFileIndex.getInstance(project).isInContent(file));
+                reportProgress(file);
 
-                    if (isInContent) {
-                        String extension = file.getExtension();
-                        if (extension != null) {
-                            switch (extension) {
-                                case "java" -> {
-                                    detectedLanguages.add(JAVA);
-                                    languageFileCount.put(JAVA, languageFileCount.getOrDefault(JAVA, 0) + 1);
-                                }
-                                case "kt" -> {
-                                    detectedLanguages.add(KOTLIN);
-                                    languageFileCount.put(KOTLIN, languageFileCount.getOrDefault(KOTLIN, 0) + 1);
-                                }
-                                case "php" -> {
-                                    detectedLanguages.add(PHP);
-                                    languageFileCount.put(PHP, languageFileCount.getOrDefault(PHP, 0) + 1);
-                                }
-                                case "py" -> {
-                                    detectedLanguages.add(PYTHON);
-                                    languageFileCount.put(PYTHON, languageFileCount.getOrDefault(PYTHON, 0) + 1);
-                                }
-                                case "js", "ts" -> {
-                                    detectedLanguages.add(JAVA_SCRIPT_TYPE_SCRIPT);
-                                    languageFileCount.put(JAVA_SCRIPT_TYPE_SCRIPT, languageFileCount.getOrDefault(JAVA_SCRIPT_TYPE_SCRIPT, 0) + 1);
-                                }
-                                case "cpp", "h", "c" -> {
-                                    detectedLanguages.add(C_C_PLUS_PLUS);
-                                    languageFileCount.put(C_C_PLUS_PLUS, languageFileCount.getOrDefault(C_C_PLUS_PLUS, 0) + 1);
-                                }
-                                case "rs" -> {
-                                    detectedLanguages.add(RUST);
-                                    languageFileCount.put(RUST, languageFileCount.getOrDefault(RUST, 0) + 1);
-                                }
-                                case "go" -> {
-                                    detectedLanguages.add(GO);
-                                    languageFileCount.put(GO, languageFileCount.getOrDefault(GO, 0) + 1);
-                                }
-                            }
-                        }
-                    }
+                if (!file.isDirectory()) {
+                    countLanguageForFile(file, result);
+                    matchFrameworks(file, result);
                 }
                 return true;
             }
         });
 
-        // Determine primary language based on file count
-        if (!detectedLanguages.isEmpty()) {
-            languages.put("detected", new ArrayList<>(detectedLanguages));
+        return result;
+    }
 
-            // Find the language with the most files
-            String primaryLanguage = detectedLanguages.iterator().next();
-            int maxFiles = 0;
+    /** Seeds language counts from language-specific project files (pom.xml, Cargo.toml, ...). */
+    private void seedLanguagesFromProjectFiles(@NotNull SourceScanResult result) {
+        if (baseDir.findChild(CARGO_TOML) != null) {
+            result.addLanguage(RUST);
+        }
+        if (baseDir.findChild(POM_XML) != null) {
+            result.addLanguage(JAVA);
+        }
+        if (baseDir.findChild(BUILD_GRADLE) != null || baseDir.findChild(BUILD_GRADLE_KTS) != null) {
+            result.addLanguage(JAVA);
+            result.addLanguage(KOTLIN);
+        }
+        if (baseDir.findChild(GO_MOD) != null) {
+            result.addLanguage(GO);
+        }
+        if (baseDir.findChild(PACKAGE_JSON) != null) {
+            result.addLanguage(JAVA_SCRIPT_TYPE_SCRIPT);
+        }
+        if (baseDir.findChild(CMAKE_LISTS_TXT) != null) {
+            result.addLanguage(C_C_PLUS_PLUS);
+        }
+    }
 
-            for (Map.Entry<String, Integer> entry : languageFileCount.entrySet()) {
-                if (entry.getValue() > maxFiles) {
-                    maxFiles = entry.getValue();
-                    primaryLanguage = entry.getKey();
-                }
-            }
-
-            languages.put("primary", primaryLanguage);
+    /** Counts a single file towards its language, if it is part of the project content. */
+    private void countLanguageForFile(@NotNull VirtualFile file, @NotNull SourceScanResult result) {
+        String extension = file.getExtension();
+        if (extension == null) {
+            return;
         }
 
-        return languages;
+        boolean isInContent = ReadAccess.compute(() ->
+                ProjectFileIndex.getInstance(project).isInContent(file));
+        if (!isInContent) {
+            return;
+        }
+
+        String language = languageForExtension(extension);
+        if (language != null) {
+            result.addLanguage(language);
+        }
+    }
+
+    @Nullable
+    private static String languageForExtension(@NotNull String extension) {
+        return switch (extension) {
+            case "java" -> JAVA;
+            case "kt" -> KOTLIN;
+            case "php" -> PHP;
+            case "py" -> PYTHON;
+            case "js", "ts" -> JAVA_SCRIPT_TYPE_SCRIPT;
+            case "cpp", "h", "c" -> C_C_PLUS_PLUS;
+            case "rs" -> RUST;
+            case "go" -> GO;
+            default -> null;
+        };
+    }
+
+    /** Marks any framework whose path pattern matches this file as found. */
+    private void matchFrameworks(@NotNull VirtualFile file, @NotNull SourceScanResult result) {
+        String path = file.getPath();
+        for (FrameworkMatcher matcher : result.frameworkMatchers) {
+            if (!matcher.found && matcher.matches(path)) {
+                matcher.found = true;
+            }
+        }
     }
 
     private @NotNull Map<String, Object> detectCodeStyle() {
@@ -308,82 +328,118 @@ public class ProjectAnalyzer {
         return styleInfo;
     }
 
-    private @NotNull Map<String, Object> detectFrameworks() {
+    /** The framework path patterns evaluated during the single source-tree walk. */
+    private @NotNull List<FrameworkMatcher> createFrameworkMatchers() {
+        List<FrameworkMatcher> matchers = new ArrayList<>();
+        // Testing frameworks
+        matchers.add(new FrameworkMatcher(J_UNIT, TESTING, TEST_JAVA_PATTERN, "**/JUnit*.java"));
+        matchers.add(new FrameworkMatcher(PHP_UNIT, TESTING, TEST_PHP_PATTERN, "**/PHPUnit*.php"));
+        matchers.add(new FrameworkMatcher(PYTEST, TESTING, TEST_PY_PATTERN, "**/pytest*.py"));
+        matchers.add(new FrameworkMatcher(GO_TESTING, TESTING, TEST_GO_PATTERN));
+        matchers.add(new FrameworkMatcher(JEST, TESTING, SPEC_JS_PATTERN, "**/jest.config.js"));
+        matchers.add(new FrameworkMatcher(RUST_TESTING, TESTING, TEST_RS_PATTERN));
+        // Web frameworks
+        matchers.add(new FrameworkMatcher(SPRING_BOOT, WEB, SPRING_BOOT_JAR, "**/SpringBoot*.java"));
+        matchers.add(new FrameworkMatcher(LARAVEL, WEB, LARAVEL_PHP));
+        matchers.add(new FrameworkMatcher(DJANGO, WEB, DJANGO_PY));
+        matchers.add(new FrameworkMatcher(REACT, WEB, REACT_JS));
+        return matchers;
+    }
+
+    /**
+     * Builds the frameworks map from the single walk's matches, plus a few content-based checks
+     * that only read direct child files (no tree walk required).
+     */
+    private @NotNull Map<String, Object> buildFrameworks(@NotNull SourceScanResult scan) {
         Map<String, Object> frameworks = new HashMap<>();
         List<String> testingFrameworks = new ArrayList<>();
         List<String> webFrameworks = new ArrayList<>();
-        List<String> otherFrameworks = new ArrayList<>();
 
-        // Check for testing frameworks in various languages
-        if (containsFile(baseDir, TEST_JAVA_PATTERN) || containsFile(baseDir, "**/JUnit*.java")) {
-            testingFrameworks.add(J_UNIT);
-        }
-        if (containsFile(baseDir, TEST_PHP_PATTERN) || containsFile(baseDir, "**/PHPUnit*.php")) {
-            testingFrameworks.add(PHP_UNIT);
-        }
-        if (containsFile(baseDir, TEST_PY_PATTERN) || containsFile(baseDir, "**/pytest*.py")) {
-            testingFrameworks.add(PYTEST);
-        }
-        if (containsFile(baseDir, TEST_GO_PATTERN)) {
-            testingFrameworks.add(GO_TESTING);
-        }
-        if (containsFile(baseDir, SPEC_JS_PATTERN) || containsFile(baseDir, "**/jest.config.js")) {
-            testingFrameworks.add(JEST);
-        }
-        if (containsFile(baseDir, TEST_RS_PATTERN)) {
-            testingFrameworks.add(RUST_TESTING);
+        for (FrameworkMatcher matcher : scan.frameworkMatchers) {
+            if (matcher.found) {
+                (TESTING.equals(matcher.category) ? testingFrameworks : webFrameworks).add(matcher.name);
+            }
         }
 
-        // Web frameworks detection
-        if (containsFile(baseDir, SPRING_BOOT_JAR) || containsFile(baseDir, "**/SpringBoot*.java")) {
-            webFrameworks.add(SPRING_BOOT);
-        }
-        if (containsFile(baseDir, LARAVEL_PHP) || findInFile(baseDir, "composer.json", "laravel/framework")) {
-            webFrameworks.add(LARAVEL);
-        }
-        if (containsFile(baseDir, DJANGO_PY) || findInFile(baseDir, "requirements.txt", "django")) {
-            webFrameworks.add(DJANGO);
-        }
-        if (containsFile(baseDir, REACT_JS) || findInFile(baseDir, PACKAGE_JSON, "react")) {
-            webFrameworks.add(REACT);
-        }
+        // Content-based detection (direct child reads, not tree walks).
+        addIfAbsent(webFrameworks, LARAVEL, findInFile(baseDir, "composer.json", "laravel/framework"));
+        addIfAbsent(webFrameworks, DJANGO, findInFile(baseDir, "requirements.txt", "django"));
+        addIfAbsent(webFrameworks, REACT, findInFile(baseDir, PACKAGE_JSON, "react"));
 
         frameworks.put(TESTING, testingFrameworks);
         frameworks.put(WEB, webFrameworks);
-        frameworks.put(OTHER, otherFrameworks);
+        frameworks.put(OTHER, new ArrayList<>());
 
         return frameworks;
     }
 
-    private boolean containsFile(VirtualFile dir, String pattern) {
-        // Use a direct approach without GlobalSearchScope for better reliability
-        Pattern regex = Pattern.compile(GlobTool.convertGlobToRegex(pattern));
+    private static void addIfAbsent(@NotNull List<String> list, @NotNull String value, boolean condition) {
+        if (condition && !list.contains(value)) {
+            list.add(value);
+        }
+    }
 
-        final boolean[] found = {false};
+    /** Accumulates language statistics and framework matches gathered during a single tree walk. */
+    private static final class SourceScanResult {
+        private final Set<String> detectedLanguages = new HashSet<>();
+        private final Map<String, Integer> languageFileCount = new HashMap<>();
+        private final List<FrameworkMatcher> frameworkMatchers;
 
-        // Manually search through the directory structure
-        VfsUtil.visitChildrenRecursively(dir, new VirtualFileVisitor<Void>() {
-            @Override
-            public boolean visitFile(@NotNull VirtualFile file) {
-                // Check if the file should be ignored based on .gitignore rules
-                String relativePath = getRelativePath(dir, file);
-                if (relativePath != null && gitignoreParser.shouldIgnore(relativePath, file.isDirectory())) {
-                    return true; // Skip this file and its children
-                }
+        SourceScanResult(@NotNull List<FrameworkMatcher> frameworkMatchers) {
+            this.frameworkMatchers = frameworkMatchers;
+        }
 
-                // Only check file contents, not directories
-                if (!file.isDirectory()) {
-                    // Check if the path matches our pattern
-                    if (regex.matcher(file.getPath()).find()) {
-                        found[0] = true;
-                        return false; // Stop visiting once found
-                    }
-                }
-                return true;
+        void addLanguage(@NotNull String language) {
+            detectedLanguages.add(language);
+            languageFileCount.merge(language, 1, Integer::sum);
+        }
+
+        @NotNull Map<String, Object> toLanguagesMap() {
+            Map<String, Object> languages = new HashMap<>();
+            if (detectedLanguages.isEmpty()) {
+                return languages;
             }
-        });
 
-        return found[0];
+            languages.put("detected", new ArrayList<>(detectedLanguages));
+
+            // Primary language = the one with the most files.
+            String primaryLanguage = detectedLanguages.iterator().next();
+            int maxFiles = 0;
+            for (Map.Entry<String, Integer> entry : languageFileCount.entrySet()) {
+                if (entry.getValue() > maxFiles) {
+                    maxFiles = entry.getValue();
+                    primaryLanguage = entry.getKey();
+                }
+            }
+            languages.put("primary", primaryLanguage);
+            return languages;
+        }
+    }
+
+    /** A framework and the path patterns that, when matched by any project file, indicate its use. */
+    private static final class FrameworkMatcher {
+        private final String name;
+        private final String category;
+        private final List<Pattern> patterns;
+        private boolean found;
+
+        FrameworkMatcher(@NotNull String name, @NotNull String category, @NotNull String... globs) {
+            this.name = name;
+            this.category = category;
+            this.patterns = new ArrayList<>(globs.length);
+            for (String glob : globs) {
+                patterns.add(Pattern.compile(GlobTool.convertGlobToRegex(glob)));
+            }
+        }
+
+        boolean matches(@NotNull String path) {
+            for (Pattern pattern : patterns) {
+                if (pattern.matcher(path).find()) {
+                    return true;
+                }
+            }
+            return false;
+        }
     }
 
     /**

--- a/src/main/java/com/devoxx/genie/service/generator/tree/ProjectTreeGenerator.java
+++ b/src/main/java/com/devoxx/genie/service/generator/tree/ProjectTreeGenerator.java
@@ -3,9 +3,11 @@ package com.devoxx.genie.service.generator.tree;
 import com.devoxx.genie.service.generator.file.FileManager;
 import com.devoxx.genie.service.projectscanner.FileScanner;
 import com.devoxx.genie.util.ReadAccess;
+import com.intellij.openapi.progress.ProgressIndicator;
 import com.intellij.openapi.vfs.VirtualFile;
 import lombok.extern.slf4j.Slf4j;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Handles generation of project tree structure.
@@ -27,17 +29,22 @@ public class ProjectTreeGenerator {
     }
     
     /**
-     * Appends a project tree to the specified file.
-     * 
+     * Appends a project tree to the specified file, descending at most {@code maxDepth} levels.
+     *
      * @param baseDir The base directory
      * @param fileName The file to append the tree to
+     * @param maxDepth The maximum number of directory levels to descend
+     * @param indicator Optional progress indicator for status updates and cancellation
      */
-    public void appendProjectTree(VirtualFile baseDir, String fileName) {
+    public void appendProjectTree(VirtualFile baseDir,
+                                  String fileName,
+                                  int maxDepth,
+                                  @Nullable ProgressIndicator indicator) {
         try {
-            log.info("Generating project tree for file: {}", fileName);
-            
+            log.info("Generating project tree for file: {} (maxDepth={})", fileName, maxDepth);
+
             // Generate tree content
-            String treeContent = generateTreeContent(baseDir);
+            String treeContent = generateTreeContent(baseDir, maxDepth, indicator);
             String formattedTree = formatTreeContent(treeContent);
             
             // Get file reference
@@ -59,11 +66,11 @@ public class ProjectTreeGenerator {
     }
     
     /**
-     * Generates tree content using the FileScanner.
+     * Generates tree content using the FileScanner, bounded by {@code maxDepth}.
      */
-    private String generateTreeContent(VirtualFile baseDir) {
-        return ReadAccess.compute(() -> 
-            fileScanner.generateSourceTreeRecursive(baseDir, 0)
+    private String generateTreeContent(VirtualFile baseDir, int maxDepth, @Nullable ProgressIndicator indicator) {
+        return ReadAccess.compute(() ->
+            fileScanner.generateSourceTreeRecursive(baseDir, 0, maxDepth, indicator)
         );
     }
     

--- a/src/main/java/com/devoxx/genie/service/projectscanner/FileScanner.java
+++ b/src/main/java/com/devoxx/genie/service/projectscanner/FileScanner.java
@@ -5,6 +5,7 @@ import com.devoxx.genie.service.DevoxxGenieSettingsService;
 import com.devoxx.genie.ui.settings.DevoxxGenieStateService;
 import com.devoxx.genie.ui.util.NotificationUtil;
 import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.progress.ProgressIndicator;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.project.ProjectUtil;
 import com.intellij.openapi.roots.ProjectFileIndex;
@@ -273,14 +274,43 @@ public class FileScanner {
     }
 
     /**
-     * Generates a source tree representation of a directory.
+     * Generates a source tree representation of a directory, without a depth limit.
+     * Kept for backwards compatibility; prefer the overload that takes a {@code maxDepth}.
      *
      * @param virtualFile the directory to represent
      * @param depth       the current recursion depth
      * @return a string representation of the source tree
      */
     public String generateSourceTreeRecursive(VirtualFile virtualFile, int depth) {
+        return generateSourceTreeRecursive(virtualFile, depth, Integer.MAX_VALUE, null);
+    }
+
+    /**
+     * Generates a source tree representation of a directory, bounded by {@code maxDepth}.
+     * <p>
+     * The {@code maxDepth} is the number of directory levels to descend, counting the
+     * starting directory as level 0. For example {@code maxDepth == 1} lists the starting
+     * directory, its files and the names of its immediate sub-directories, but does not
+     * descend into those sub-directories. This prevents the generator from walking the
+     * entire project tree (and from looping forever on symlink cycles).
+     *
+     * @param virtualFile the directory to represent
+     * @param depth       the current recursion depth (start at 0)
+     * @param maxDepth    the maximum number of levels to descend
+     * @param indicator   optional progress indicator for status updates and cancellation
+     * @return a string representation of the source tree
+     */
+    public String generateSourceTreeRecursive(VirtualFile virtualFile,
+                                              int depth,
+                                              int maxDepth,
+                                              @Nullable ProgressIndicator indicator) {
         StringBuilder result = new StringBuilder();
+
+        // Stop quietly if the user cancelled the background task.
+        if (indicator != null && indicator.isCanceled()) {
+            return result.toString();
+        }
+
         String indent = "  ".repeat(depth);
 
         boolean excludeFile = shouldExcludeFile(virtualFile);
@@ -291,11 +321,20 @@ public class FileScanner {
 
         result.append(indent).append(virtualFile.getName()).append("/\n");
 
+        if (indicator != null) {
+            indicator.setText2(virtualFile.getPath());
+        }
+
+        // Stop descending once the configured depth has been reached.
+        if (depth + 1 > maxDepth) {
+            return result.toString();
+        }
+
         VirtualFile[] children = virtualFile.getChildren();
         if (children != null) {
             for (VirtualFile child : children) {
                 if (child.isDirectory()) {
-                    result.append(generateSourceTreeRecursive(child, depth + 1));
+                    result.append(generateSourceTreeRecursive(child, depth + 1, maxDepth, indicator));
                 } else if (shouldIncludeFile(child)) {
                     result.append(indent).append("  ").append(child.getName()).append("\n");
                 }

--- a/src/main/java/com/devoxx/genie/ui/processor/CommandProcessor.java
+++ b/src/main/java/com/devoxx/genie/ui/processor/CommandProcessor.java
@@ -58,7 +58,7 @@ public class CommandProcessor {
         Integer treeDepth = DevoxxGenieStateService.getInstance().getProjectTreeDepth();
         
         // Use ProgressManager to run in a background task
-        ProgressManager.getInstance().run(new Task.Backgroundable(project, "Generating DEVOXXGENIE.md", false) {
+        ProgressManager.getInstance().run(new Task.Backgroundable(project, "Generating DEVOXXGENIE.md", true) {
             @Override
             public void run(@NotNull ProgressIndicator indicator) {
                 try {

--- a/src/main/java/com/devoxx/genie/ui/settings/mcp/dialog/MCPServerDialog.java
+++ b/src/main/java/com/devoxx/genie/ui/settings/mcp/dialog/MCPServerDialog.java
@@ -39,6 +39,8 @@ public class MCPServerDialog extends DialogWrapper {
     
     private final MCPServer existingServer;
     private MCPServer server;
+
+    private final ExistingServerConfigurationSupport existingServerSupport = new ExistingServerConfigurationSupport();
     
     // Environment variables components
     private final EnvVarTableModel envVarTableModel = new EnvVarTableModel();
@@ -297,8 +299,7 @@ public class MCPServerDialog extends DialogWrapper {
                     // Step 1: Create client (pass headers from existing server for auth)
                     indicator.setText("Connecting to MCP server...");
                     indicator.setIndeterminate(true);
-                    Map<String, String> headers = existingServer != null && existingServer.getHeaders() != null
-                            ? existingServer.getHeaders() : Map.of();
+                    Map<String, String> headers = existingServerSupport.headersForConnection(existingServer);
                     mcpClient = panel.createClient(headers);
 
                     indicator.checkCanceled();
@@ -318,10 +319,7 @@ public class MCPServerDialog extends DialogWrapper {
                     panel.processTools(tools, builder);
 
                     if (existingServer != null) {
-                        builder.env(new HashMap<>(existingServer.getEnv()));
-                        if (existingServer.getHeaders() != null && !existingServer.getHeaders().isEmpty()) {
-                            builder.headers(new HashMap<>(existingServer.getHeaders()));
-                        }
+                        existingServerSupport.applyPreservedSettings(existingServer, builder);
                     }
 
                     result[0] = builder.build();
@@ -395,14 +393,57 @@ public class MCPServerDialog extends DialogWrapper {
         // Apply environment variables from the table
         builder.env(envVarTableModel.getEnvVars());
 
-        // Preserve headers from existing server
-        if (existingServer != null && existingServer.getHeaders() != null && !existingServer.getHeaders().isEmpty()) {
-            builder.headers(new HashMap<>(existingServer.getHeaders()));
+        // Preserve headers from existing server (env is already set from the table above)
+        if (existingServer != null) {
+            existingServerSupport.applyPreservedHeaders(existingServer, builder);
         }
 
         return builder.build();
     }
     
+    /**
+     * Encapsulates how configuration from an existing (edited) MCP server is preserved when
+     * building an updated server. Extracted as a static, dependency-free helper so the
+     * preservation rules can be unit-tested without constructing the Swing dialog.
+     */
+    public static class ExistingServerConfigurationSupport {
+
+        /**
+         * Returns the headers to use when opening a connection to {@code server}, as a defensive
+         * copy. Never returns null; an absent or empty header set yields an empty map.
+         */
+        @NotNull
+        public Map<String, String> headersForConnection(@Nullable MCPServer server) {
+            if (server == null || server.getHeaders() == null || server.getHeaders().isEmpty()) {
+                return new HashMap<>();
+            }
+            return new HashMap<>(server.getHeaders());
+        }
+
+        /**
+         * Copies both the environment variables and the (non-empty) headers from
+         * {@code existingServer} onto {@code builder}.
+         */
+        public void applyPreservedSettings(@NotNull MCPServer existingServer,
+                                           @NotNull MCPServer.MCPServerBuilder builder) {
+            if (existingServer.getEnv() != null) {
+                builder.env(new HashMap<>(existingServer.getEnv()));
+            }
+            applyPreservedHeaders(existingServer, builder);
+        }
+
+        /**
+         * Copies only the (non-empty) headers from {@code existingServer} onto {@code builder},
+         * leaving any environment variables already set on the builder untouched.
+         */
+        public void applyPreservedHeaders(@NotNull MCPServer existingServer,
+                                          @NotNull MCPServer.MCPServerBuilder builder) {
+            if (existingServer.getHeaders() != null && !existingServer.getHeaders().isEmpty()) {
+                builder.headers(new HashMap<>(existingServer.getHeaders()));
+            }
+        }
+    }
+
     /**
      * Table model for environment variables
      */

--- a/src/main/java/com/devoxx/genie/ui/settings/prompt/PromptSettingsComponent.java
+++ b/src/main/java/com/devoxx/genie/ui/settings/prompt/PromptSettingsComponent.java
@@ -274,7 +274,7 @@ public class PromptSettingsComponent extends AbstractSettingsComponent {
     private void createDevoxxGenieMdFile() {
         createDevoxxGenieMdButton.setEnabled(false);
 
-        ProgressManager.getInstance().run(new Task.Backgroundable(project, "Generating DEVOXXGENIE.md", false) {
+        ProgressManager.getInstance().run(new Task.Backgroundable(project, "Generating DEVOXXGENIE.md", true) {
             @Override
             public void run(@NotNull ProgressIndicator indicator) {
                 try {

--- a/src/test/java/com/devoxx/genie/service/projectscanner/FileScannerTest.java
+++ b/src/test/java/com/devoxx/genie/service/projectscanner/FileScannerTest.java
@@ -347,6 +347,55 @@ class FileScannerTest {
     }
 
     @Test
+    void testGenerateSourceTreeRecursive_respectsMaxDepth() {
+        try (MockedStatic<DevoxxGenieStateService> mockedSettings = mockStatic(DevoxxGenieStateService.class)) {
+            mockedSettings.when(DevoxxGenieStateService::getInstance).thenReturn(mockStateService);
+
+            when(mockStateService.getExcludedDirectories()).thenReturn(List.of());
+            when(mockStateService.getExcludedFiles()).thenReturn(List.of());
+            when(mockStateService.getIncludedFileExtensions()).thenReturn(List.of("java"));
+            when(mockStateService.getUseGitIgnore()).thenReturn(false);
+
+            // Build a 3-level deep tree: root -> level1 -> level2 (with a file at the deepest level)
+            VirtualFile deepFile = mock(VirtualFile.class);
+            when(deepFile.isDirectory()).thenReturn(false);
+            when(deepFile.getName()).thenReturn("Deep.java");
+            when(deepFile.getPath()).thenReturn("/project/root/level1/level2/Deep.java");
+            when(deepFile.getExtension()).thenReturn("java");
+
+            VirtualFile level2 = mock(VirtualFile.class);
+            when(level2.isDirectory()).thenReturn(true);
+            when(level2.getName()).thenReturn("level2");
+            when(level2.getPath()).thenReturn("/project/root/level1/level2");
+            when(level2.getChildren()).thenReturn(new VirtualFile[]{deepFile});
+
+            VirtualFile level1 = mock(VirtualFile.class);
+            when(level1.isDirectory()).thenReturn(true);
+            when(level1.getName()).thenReturn("level1");
+            when(level1.getPath()).thenReturn("/project/root/level1");
+            when(level1.getChildren()).thenReturn(new VirtualFile[]{level2});
+
+            VirtualFile root = mock(VirtualFile.class);
+            when(root.isDirectory()).thenReturn(true);
+            when(root.getName()).thenReturn("root");
+            when(root.getPath()).thenReturn("/project/root");
+            when(root.getChildren()).thenReturn(new VirtualFile[]{level1});
+
+            // maxDepth = 1 => only the root level should be descended; deeper dirs/files must NOT appear
+            String shallow = fileScanner.generateSourceTreeRecursive(root, 0, 1, null);
+            assertTrue("Root must be present", shallow.contains("root/"));
+            assertTrue("Immediate child dir name must be present", shallow.contains("level1/"));
+            assertFalse("level2 must NOT be traversed at depth 1", shallow.contains("level2/"));
+            assertFalse("Deep file must NOT appear at depth 1", shallow.contains("Deep.java"));
+
+            // A generous maxDepth should include everything
+            String deep = fileScanner.generateSourceTreeRecursive(root, 0, 10, null);
+            assertTrue(deep.contains("level2/"));
+            assertTrue(deep.contains("Deep.java"));
+        }
+    }
+
+    @Test
     void testScanDirectory() {
         try (MockedStatic<DevoxxGenieStateService> mockedSettings = mockStatic(DevoxxGenieStateService.class)) {
             mockedSettings.when(DevoxxGenieStateService::getInstance).thenReturn(mockStateService);


### PR DESCRIPTION
## Summary
- **DEVOXXGENIE.md generation no longer hangs.** The "Tree depth" setting was never wired through, so generation always walked the entire project. Now the depth is honored (bounded recursion), the generation task is cancellable, and the current file/dir is shown via the progress indicator.
- **"Analyzing project structure…" is dramatically faster.** `ProjectAnalyzer` did ~11+ full project-tree walks (one for languages + one per framework pattern), and its `.gitignore` skip returned `true` (which *descends*), so `node_modules`/`.git`/`build` were walked anyway. Collapsed into a single walk, fixed the gitignore skip to actually skip subtrees, and added per-file progress + cancellation.
- **Restored the master test suite.** Commit `8576509c` added regression tests whose production code was never merged, breaking `compileTestJava` and blocking the whole suite. Re-added the missing implementations in `PsiToolUtils`, `FindDefinitionToolExecutor`, and `MCPServerDialog` (`ExistingServerConfigurationSupport`).

## Notes
- 2 pre-existing, unrelated failures remain (`LLMProvidersConfigurableTest` Ollama tests) — they build the real Swing panel under a mocked `Application` that can't resolve the platform `ExperimentalUI` service (from commit `92e7049f`). Left out of scope by request.
- Behavior change worth noting: files inside gitignored directories no longer count toward language/framework detection (this is the intended correctness fix).

## Test plan
- [x] `./gradlew test` — 3023/3025 pass (only the 2 pre-existing Ollama UI tests fail)
- [x] New regression test `FileScannerTest.testGenerateSourceTreeRecursive_respectsMaxDepth`
- [x] `PsiToolUtilsTest`, `FindDefinitionToolExecutorPsiTest`, `MCPServerDialogExistingServerSupportTest` all green
- [ ] Manual: enable "Generate DEVOXXGENIE.md" + "Include project tree" with depth 1 and confirm fast generation with visible per-file status and a working Cancel button

🤖 Generated with [Claude Code](https://claude.com/claude-code)