### PR TITLE
fix: stop LLMProvidersConfigurable tests from building the Swing panel

### DIFF
--- a/src/test/java/com/devoxx/genie/ui/settings/llm/LLMProvidersConfigurableTest.java
+++ b/src/test/java/com/devoxx/genie/ui/settings/llm/LLMProvidersConfigurableTest.java
@@ -88,7 +88,6 @@ class LLMProvidersConfigurableTest {
 
     @Test
     void shouldApplyOllamaContextWindowOverrideSetting() {
-        configurable.createComponent();
         LLMProvidersComponent component = getSettingsComponent();
 
         component.getOllamaContextWindowOverrideCheckBox().setSelected(true);
@@ -103,7 +102,6 @@ class LLMProvidersConfigurableTest {
     @Test
     void shouldResetOllamaContextWindowOverrideSetting() {
         stateService.setOllamaContextWindowOverrideEnabled(true);
-        configurable.createComponent();
 
         configurable.reset();
 


### PR DESCRIPTION
## Summary
- The two newest tests in `LLMProvidersConfigurableTest` — `shouldApplyOllamaContextWindowOverrideSetting` and `shouldResetOllamaContextWindowOverrideSetting` (added in PR #979) — failed with `IllegalStateException: Cannot find service com.intellij.ui.ExperimentalUI`.
- Root cause: both called `configurable.createComponent()`, which builds the full Swing settings panel; JetBrains UI widgets resolve `ExperimentalUI` via `getApplication().getService(...)`, which returns `null` on the Mockito-mocked `Application`. These were the only two tests in the file that built the panel, and had been failing since they landed.
- Fix: removed the unnecessary `createComponent()` calls. The checkbox and all widgets are field initializers built in the `LLMProvidersComponent` constructor (already run in `setUp`); `isModified()`/`apply()`/`reset()` only read/write those fields and never need the laid-out panel. This makes the two tests consistent with the other 13 in the file.

## Test plan
- [x] `./gradlew test --tests "com.devoxx.genie.ui.settings.llm.LLMProvidersConfigurableTest"` → BUILD SUCCESSFUL
- [x] Full `./gradlew test` suite → BUILD SUCCESSFUL (no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)