### PR TITLE
Show used window context during a conversation

### DIFF
--- a/src/main/java/com/devoxx/genie/service/prompt/response/streaming/StreamingResponseHandler.java
+++ b/src/main/java/com/devoxx/genie/service/prompt/response/streaming/StreamingResponseHandler.java
@@ -200,6 +200,14 @@ public class StreamingResponseHandler implements StreamingChatResponseHandler {
             long endTime = System.currentTimeMillis();
             context.setExecutionTimeMs(endTime - startTime);
 
+            // Capture token usage from the final ChatResponse so the chat panel can show
+            // input/output token counts, cost, and the used window context. The non-streaming
+            // path already does this; without it streaming responses (the default) would never
+            // report any token metrics. Local providers may return a null TokenUsage.
+            if (response.tokenUsage() != null) {
+                context.setTokenUsageAndCost(response.tokenUsage());
+            }
+
             // In agent mode the LLM streams intermediate reasoning (e.g. "Let me take a
             // look...") before each tool call. langchain4j delivers those tokens through
             // onPartialResponse (so they accumulate here), but the final ChatResponse only

--- a/src/main/java/com/devoxx/genie/ui/component/TokenUsageBar.java
+++ b/src/main/java/com/devoxx/genie/ui/component/TokenUsageBar.java
@@ -36,18 +36,23 @@ public class TokenUsageBar extends JComponent {
         int width = getWidth();
         int height = getHeight();
 
-        int usageWidth = (int) ((double) usedTokens / maxTokens * width);
-        g.setColor(getColor(usageWidth));
+        double ratio = maxTokens <= 0 ? 0 : Math.min(1.0, (double) usedTokens / maxTokens);
+        int usageWidth = (int) (ratio * width);
+        g.setColor(getColor(ratio));
         g.fillRect(0, 0, usageWidth, height);
     }
 
-    private Color getColor(int usageWidth) {
-        if (usageWidth < 50) {
+    /**
+     * Colors the bar by how full the context window is: green below 50%, yellow up to 80%,
+     * red beyond that to warn the user before the window overflows.
+     */
+    private Color getColor(double ratio) {
+        if (ratio < 0.5) {
             return JBColor.GREEN;
-        } else if (usageWidth < 80) {
+        } else if (ratio < 0.8) {
             return JBColor.YELLOW;
         } else {
-            return JBColor.BLUE;
+            return JBColor.RED;
         }
     }
 }

--- a/src/main/java/com/devoxx/genie/ui/panel/ActionButtonsPanel.java
+++ b/src/main/java/com/devoxx/genie/ui/panel/ActionButtonsPanel.java
@@ -6,6 +6,8 @@ import com.devoxx.genie.controller.listener.TokenCalculationListener;
 import com.devoxx.genie.model.Constant;
 import com.devoxx.genie.model.LanguageModel;
 import com.devoxx.genie.model.enumarations.ModelProvider;
+import com.devoxx.genie.model.request.ChatMessageContext;
+import com.devoxx.genie.ui.listener.ConversationEventListener;
 import com.devoxx.genie.ui.agent.AgentToggleManager;
 import com.devoxx.genie.ui.mcp.MCPToolsManager;
 import com.devoxx.genie.service.spec.SpecTaskRunnerService;
@@ -28,6 +30,9 @@ import com.intellij.openapi.ui.ComboBox;
 import com.intellij.openapi.ui.Messages;
 import com.intellij.openapi.ui.popup.JBPopup;
 import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.ui.JBColor;
+import com.intellij.ui.components.JBLabel;
+import com.intellij.util.ui.JBUI;
 import lombok.Getter;
 import org.jetbrains.annotations.NotNull;
 
@@ -41,7 +46,8 @@ import static com.devoxx.genie.ui.component.button.ButtonFactory.createActionBut
 import static com.devoxx.genie.ui.util.DevoxxGenieIconsUtil.*;
 
 public class ActionButtonsPanel extends JPanel
-        implements SettingsChangeListener, PromptSubmissionListener, GlowingListener, TokenCalculationListener {
+        implements SettingsChangeListener, PromptSubmissionListener, GlowingListener,
+        TokenCalculationListener, ConversationEventListener {
 
     private final transient Project project;
 
@@ -57,6 +63,16 @@ public class ActionButtonsPanel extends JPanel
     private final JPanel calcProjectPanel = createCalcProjectPanel();
     private final PromptInputArea promptInputArea;
     private final TokenUsageBar tokenUsageBar = createTokenUsageBar();
+
+    // Persistent indicator showing how much of the selected model's context window the
+    // ongoing conversation occupies. Updated after every completed response (latest turn's
+    // input + output tokens) and reset when a new conversation starts.
+    private final JBLabel conversationContextLabel = createConversationContextLabel();
+    private final TokenUsageBar conversationContextBar = createConversationContextBar();
+    private final JPanel conversationContextPanel = new JPanel(new BorderLayout());
+    private int conversationMaxTokens;
+    private int conversationUsedTokens;
+
     private final transient DevoxxGenieToolWindowContent devoxxGenieToolWindowContent;
 
     private final transient ActionButtonsPanelController controller;
@@ -186,9 +202,102 @@ public class ActionButtonsPanel extends JPanel
     }
 
     private @NotNull JPanel createProgressPanel() {
-        JPanel progressPanel = new JPanel(new BorderLayout());
-        progressPanel.add(tokenUsageBar, BorderLayout.CENTER);
+        JPanel progressPanel = new JPanel();
+        progressPanel.setLayout(new BoxLayout(progressPanel, BoxLayout.Y_AXIS));
+
+        // Persistent conversation context indicator (label + thin colored bar).
+        conversationContextPanel.add(conversationContextLabel, BorderLayout.CENTER);
+        conversationContextPanel.add(conversationContextBar, BorderLayout.SOUTH);
+        conversationContextPanel.setVisible(false);
+        progressPanel.add(conversationContextPanel);
+
+        // Transient project-context preview bar (shown only while adding project to context).
+        progressPanel.add(tokenUsageBar);
         return progressPanel;
+    }
+
+    private @NotNull JBLabel createConversationContextLabel() {
+        JBLabel label = new JBLabel();
+        label.setBorder(JBUI.Borders.empty(0, 2));
+        Font base = label.getFont();
+        label.setFont(base.deriveFont(base.getSize2D() - 1f));
+        label.setForeground(JBColor.GRAY);
+        return label;
+    }
+
+    private @NotNull TokenUsageBar createConversationContextBar() {
+        TokenUsageBar bar = new TokenUsageBar();
+        bar.setPreferredSize(new Dimension(Integer.MAX_VALUE, 3));
+        bar.setMaximumSize(new Dimension(Integer.MAX_VALUE, 3));
+        return bar;
+    }
+
+    /**
+     * Sets the model's context window (max input tokens) used as the denominator of the
+     * conversation context indicator. Called when the selected model changes. The used-token
+     * count is preserved — switching models does not clear the conversation memory.
+     */
+    public void setConversationContextMax(int maxTokens) {
+        this.conversationMaxTokens = maxTokens;
+        ApplicationManager.getApplication().invokeLater(this::refreshConversationContext);
+    }
+
+    /**
+     * Records the context occupied by the latest completed exchange (input + output tokens)
+     * and refreshes the indicator.
+     */
+    public void updateConversationContextUsage(int usedTokens, int maxTokens) {
+        this.conversationUsedTokens = usedTokens;
+        if (maxTokens > 0) {
+            this.conversationMaxTokens = maxTokens;
+        }
+        ApplicationManager.getApplication().invokeLater(this::refreshConversationContext);
+    }
+
+    /** Resets the conversation context indicator (e.g. when a new conversation starts). */
+    public void resetConversationContext() {
+        this.conversationUsedTokens = 0;
+        ApplicationManager.getApplication().invokeLater(this::refreshConversationContext);
+    }
+
+    private void refreshConversationContext() {
+        if (conversationMaxTokens <= 0) {
+            // No known window (e.g. CLI/ACP/local providers) — hide the indicator entirely.
+            conversationContextPanel.setVisible(false);
+            return;
+        }
+        conversationContextPanel.setVisible(true);
+        conversationContextBar.setTokens(conversationUsedTokens, conversationMaxTokens);
+
+        int pct = (int) Math.round(conversationUsedTokens * 100.0 / conversationMaxTokens);
+        String usedStr = WindowContextFormatterUtil.format(conversationUsedTokens).trim();
+        String maxStr = WindowContextFormatterUtil.format(conversationMaxTokens).trim();
+        conversationContextLabel.setText(String.format("Context window: %s / %s (%d%%)", usedStr, maxStr, pct));
+        conversationContextLabel.setToolTipText(String.format(
+                "This conversation uses %,d of %,d tokens (%d%%) of the model's context window",
+                conversationUsedTokens, conversationMaxTokens, pct));
+    }
+
+    /**
+     * Conversation completion hook (CONVERSATION_TOPIC). Updates the persistent context
+     * indicator for this tab only, using the latest exchange's total token usage.
+     */
+    @Override
+    public void onNewConversation(ChatMessageContext chatMessageContext) {
+        String myTabId = devoxxGenieToolWindowContent.getTabId();
+        String eventTabId = chatMessageContext.getTabId();
+        if (myTabId != null && eventTabId != null && !myTabId.equals(eventTabId)) {
+            return;
+        }
+        var tokenUsage = chatMessageContext.getTokenUsage();
+        if (tokenUsage == null) {
+            return;
+        }
+        int input = tokenUsage.inputTokenCount() != null ? tokenUsage.inputTokenCount() : 0;
+        int output = tokenUsage.outputTokenCount() != null ? tokenUsage.outputTokenCount() : 0;
+        LanguageModel model = chatMessageContext.getLanguageModel();
+        int max = model != null ? model.getInputMaxTokens() : conversationMaxTokens;
+        updateConversationContextUsage(input + output, max);
     }
 
     private void handleProjectContext(ActionEvent e) {
@@ -318,6 +427,7 @@ public class ActionButtonsPanel extends JPanel
 
     public void updateTokenUsage(int maxTokens) {
         ApplicationManager.getApplication().invokeLater(() -> tokenUsageBar.setMaxTokens(maxTokens));
+        setConversationContextMax(maxTokens);
     }
 
     @Override

--- a/src/main/java/com/devoxx/genie/ui/panel/conversation/ConversationManager.java
+++ b/src/main/java/com/devoxx/genie/ui/panel/conversation/ConversationManager.java
@@ -100,6 +100,9 @@ public class ConversationManager implements ConversationEventListener, Conversat
         // Clear the current conversation state
         currentConversation = null;
 
+        // Reset the persistent conversation context indicator for this tab.
+        resetConversationContextIndicator();
+
         chatService.startNewConversation("");
 
         ApplicationManager.getApplication().invokeLater(() -> {
@@ -120,6 +123,19 @@ public class ConversationManager implements ConversationEventListener, Conversat
             }
         });
     }
+    /**
+     * Resets the persistent conversation context indicator on the action buttons panel for
+     * this tab (or every tab when no tabId is set), since the chat memory was just cleared.
+     */
+    private void resetConversationContextIndicator() {
+        ConversationTabRegistry registry = ConversationTabRegistry.getInstance();
+        for (DevoxxGenieToolWindowContent twc : registry.getContentsForProject(project)) {
+            if (tabId == null || tabId.equals(twc.getTabId())) {
+                twc.getSubmitPanel().getActionButtonsPanel().resetConversationContext();
+            }
+        }
+    }
+
     /**
      * Handle selection of a conversation from history.
      *

--- a/src/main/java/com/devoxx/genie/ui/window/DevoxxGenieToolWindowContent.java
+++ b/src/main/java/com/devoxx/genie/ui/window/DevoxxGenieToolWindowContent.java
@@ -209,6 +209,8 @@ public class DevoxxGenieToolWindowContent implements SettingsChangeListener, Glo
 
             MessageBusUtil.subscribe(connection, AppTopics.SETTINGS_CHANGED_TOPIC, submitPanel.getActionButtonsPanel());
             MessageBusUtil.subscribe(connection, AppTopics.PROMPT_SUBMISSION_TOPIC, submitPanel.getActionButtonsPanel());
+            // Keep the persistent conversation context indicator in sync with completed responses.
+            MessageBusUtil.subscribe(connection, AppTopics.CONVERSATION_TOPIC, submitPanel.getActionButtonsPanel());
             MessageBusUtil.subscribe(connection, FileEditorManagerListener.FILE_EDITOR_MANAGER, new FileEditorManagerListener() {
                 @Override
                 public void fileOpened(@NotNull FileEditorManager source, @NotNull VirtualFile file) {

--- a/src/main/kotlin/com/devoxx/genie/ui/compose/components/AiBubble.kt
+++ b/src/main/kotlin/com/devoxx/genie/ui/compose/components/AiBubble.kt
@@ -35,6 +35,18 @@ import dev.snipme.highlights.Highlights
 import dev.snipme.highlights.model.SyntaxThemes
 import org.intellij.markdown.MarkdownElementTypes
 import org.intellij.markdown.MarkdownTokenTypes
+import kotlin.math.roundToInt
+
+/**
+ * Compact token formatter for the metadata row, mirroring WindowContextFormatterUtil
+ * (e.g. 128000 -> "128K", 1_000_000 -> "1M"). Keeps the context indicator short.
+ */
+private fun formatTokens(tokens: Long): String = when {
+    tokens >= 1_000_000_000 -> "${tokens / 1_000_000_000}B"
+    tokens >= 1_000_000 -> "${tokens / 1_000_000}M"
+    tokens >= 1_000 -> "${tokens / 1_000}K"
+    else -> tokens.toString()
+}
 
 /**
  * Extracts the raw code text from a code fence or code block AST node.
@@ -300,6 +312,12 @@ private fun MetadataRow(message: MessageUiModel) {
         }
         if (usage.cost > 0) {
             parts.add("$%.4f".format(usage.cost))
+        }
+        // Used window context: how much of the model's input window this exchange occupied.
+        if (usage.contextWindowMax > 0 && (usage.inputTokens > 0 || usage.outputTokens > 0)) {
+            val used = usage.inputTokens + usage.outputTokens
+            val pct = (used.toDouble() / usage.contextWindowMax * 100).roundToInt()
+            parts.add("${formatTokens(used)}/${formatTokens(usage.contextWindowMax)} context ($pct%)")
         }
 
         if (parts.isNotEmpty()) {

--- a/src/main/kotlin/com/devoxx/genie/ui/compose/model/MessageUiModel.kt
+++ b/src/main/kotlin/com/devoxx/genie/ui/compose/model/MessageUiModel.kt
@@ -23,6 +23,12 @@ data class TokenUsageInfo(
     val inputTokens: Long = 0,
     val outputTokens: Long = 0,
     val cost: Double = 0.0,
+    /**
+     * Max input context window of the model used for this message (0 when unknown, e.g.
+     * local providers). Combined with [inputTokens] + [outputTokens] it lets the UI show
+     * how much of the model's window this exchange occupied.
+     */
+    val contextWindowMax: Long = 0,
 )
 
 data class FileReferenceUiModel(

--- a/src/main/kotlin/com/devoxx/genie/ui/compose/viewmodel/ConversationViewModel.kt
+++ b/src/main/kotlin/com/devoxx/genie/ui/compose/viewmodel/ConversationViewModel.kt
@@ -197,13 +197,7 @@ class ConversationViewModel(
             msg.copy(
                 aiResponseMarkdown = aiText,
                 executionTimeMs = context.executionTimeMs,
-                tokenUsage = context.tokenUsage?.let {
-                    TokenUsageInfo(
-                        inputTokens = it.inputTokenCount()?.toLong() ?: 0,
-                        outputTokens = it.outputTokenCount()?.toLong() ?: 0,
-                        cost = context.cost,
-                    )
-                } ?: msg.tokenUsage,
+                tokenUsage = buildTokenUsage(context) ?: msg.tokenUsage,
                 modelName = formatModelDisplayName(context.languageModel).ifEmpty { msg.modelName },
             )
         }
@@ -216,13 +210,7 @@ class ConversationViewModel(
             aiResponseMarkdown = context.aiMessage?.text() ?: "",
             modelName = formatModelDisplayName(context.languageModel),
             executionTimeMs = context.executionTimeMs,
-            tokenUsage = context.tokenUsage?.let {
-                TokenUsageInfo(
-                    inputTokens = it.inputTokenCount()?.toLong() ?: 0,
-                    outputTokens = it.outputTokenCount()?.toLong() ?: 0,
-                    cost = context.cost,
-                )
-            } ?: TokenUsageInfo(),
+            tokenUsage = buildTokenUsage(context) ?: TokenUsageInfo(),
         )
 
         val currentState = state
@@ -630,6 +618,21 @@ class ConversationViewModel(
             }
             state = current.copy(messages = updated)
         }
+    }
+
+    /**
+     * Builds the per-message token usage info from a completed context, or null when the
+     * provider returned no token usage (e.g. some local models). The model's input context
+     * window is carried along so the chat bubble can show how full the window was.
+     */
+    private fun buildTokenUsage(context: ChatMessageContext): TokenUsageInfo? {
+        val usage = context.tokenUsage ?: return null
+        return TokenUsageInfo(
+            inputTokens = usage.inputTokenCount()?.toLong() ?: 0,
+            outputTokens = usage.outputTokenCount()?.toLong() ?: 0,
+            cost = context.cost,
+            contextWindowMax = context.languageModel?.inputMaxTokens?.toLong() ?: 0,
+        )
     }
 
     private fun formatModelDisplayName(model: LanguageModel?): String {

--- a/src/test/java/com/devoxx/genie/service/prompt/response/streaming/StreamingResponseHandlerTest.java
+++ b/src/test/java/com/devoxx/genie/service/prompt/response/streaming/StreamingResponseHandlerTest.java
@@ -156,6 +156,33 @@ class StreamingResponseHandlerTest {
     }
 
     @Test
+    void onCompleteResponse_capturesTokenUsageFromResponse() {
+        StreamingResponseHandler handler = createHandler();
+
+        TokenUsage tokenUsage = new TokenUsage(120, 30);
+        handler.onCompleteResponse(ChatResponse.builder()
+            .aiMessage(AiMessage.from("Hello World"))
+            .tokenUsage(tokenUsage)
+            .build());
+
+        // The streaming path must record token usage so the chat panel can show token
+        // counts, cost, and used window context (previously only the non-streaming path did).
+        verify(mockContext).setTokenUsageAndCost(tokenUsage);
+    }
+
+    @Test
+    void onCompleteResponse_withoutTokenUsage_doesNotSetUsage() {
+        StreamingResponseHandler handler = createHandler();
+
+        handler.onCompleteResponse(ChatResponse.builder()
+            .aiMessage(AiMessage.from("Hello World"))
+            .build());
+
+        // Local providers may return a null TokenUsage — we must not call through with null.
+        verify(mockContext, never()).setTokenUsageAndCost(any());
+    }
+
+    @Test
     void onPartialResponse_batchesUiUpdatesAtFixedCadence() {
         StreamingResponseHandler handler = createHandler();
 


### PR DESCRIPTION
Surface how much of the selected model's context window the ongoing
conversation occupies, complementing the per-model window size already
shown in the model dropdown.

- Persistent indicator near the prompt input (ActionButtonsPanel): a small
  "Context window: used / max (pct%)" label plus a thin colored bar that
  updates after every completed response and resets on a new conversation.
- Per-message metadata line (AiBubble): appends "used/max context (pct%)"
  next to the existing token/cost info.
- Fix: the streaming path never recorded TokenUsage, so streaming responses
  (the default) reported no token metrics. onCompleteResponse now calls
  setTokenUsageAndCost from the final ChatResponse (guarded for local
  providers that return null usage).
- TokenUsageBar now colors by fill ratio (green/yellow/red) instead of by
  pixel width, so the bar is meaningful and warns near overflow.

The used value comes from the provider's TokenUsage (input + output tokens
of the latest turn) against the model's inputMaxTokens; no separate local
re-tokenization is needed.