### PR TITLE
Improve chat response bubble token display

### DIFF
--- a/src/main/kotlin/com/devoxx/genie/ui/compose/components/AiBubble.kt
+++ b/src/main/kotlin/com/devoxx/genie/ui/compose/components/AiBubble.kt
@@ -39,9 +39,9 @@ import kotlin.math.roundToInt
 
 /**
  * Compact token formatter for the metadata row, mirroring WindowContextFormatterUtil
- * (e.g. 128000 -> "128K", 1_000_000 -> "1M"). Keeps the context indicator short while
- * preserving one decimal of precision for smaller magnitudes (10502 -> "10.5K") so the
- * per-exchange token counts stay readable instead of being truncated to "10K".
+ * (e.g. 128000 -> "128K", 1_000_000 -> "1M"). Keeps the per-exchange counts short while
+ * preserving one decimal of precision for smaller magnitudes (10502 -> "10.5K") so they
+ * stay readable instead of being truncated to "10K".
  */
 internal fun formatTokens(tokens: Long): String = when {
     tokens >= 1_000_000_000 -> scaled(tokens, 1_000_000_000.0) + "B"
@@ -69,9 +69,11 @@ private fun scaled(tokens: Long, unit: Double): String {
 
 /**
  * Builds the right-aligned metadata summary shown next to the model name: elapsed time,
- * token usage (clearly labelled input/output), cost, and how much of the model's context
- * window the exchange occupied. Extracted as an internal, Compose-free function so the
- * formatting can be unit-tested directly. Returns an empty string when nothing is known.
+ * token usage (clearly labelled input/output) and cost. The model's overall context-window
+ * usage is intentionally omitted here — it is already surfaced as a persistent indicator
+ * under the prompt, so repeating it per-bubble was redundant noise (e.g. "1.8s ~ 10.5K in
+ * / 179 out"). Extracted as an internal, Compose-free function so the formatting can be
+ * unit-tested directly. Returns an empty string when nothing is known.
  */
 internal fun formatMetadataSummary(message: MessageUiModel): String {
     val parts = mutableListOf<String>()
@@ -90,13 +92,7 @@ internal fun formatMetadataSummary(message: MessageUiModel): String {
     if (usage.cost > 0) {
         parts.add(String.format(java.util.Locale.US, "$%.4f", usage.cost))
     }
-    // Used window context: how much of the model's input window this exchange occupied.
-    if (usage.contextWindowMax > 0 && (usage.inputTokens > 0 || usage.outputTokens > 0)) {
-        val used = usage.inputTokens + usage.outputTokens
-        val pct = (used.toDouble() / usage.contextWindowMax * 100).roundToInt()
-        parts.add("${formatTokens(used)}/${formatTokens(usage.contextWindowMax)} context ($pct%)")
-    }
-    return parts.joinToString(" | ")
+    return parts.joinToString(" ~ ")
 }
 
 /**

--- a/src/main/kotlin/com/devoxx/genie/ui/compose/components/AiBubble.kt
+++ b/src/main/kotlin/com/devoxx/genie/ui/compose/components/AiBubble.kt
@@ -39,13 +39,64 @@ import kotlin.math.roundToInt
 
 /**
  * Compact token formatter for the metadata row, mirroring WindowContextFormatterUtil
- * (e.g. 128000 -> "128K", 1_000_000 -> "1M"). Keeps the context indicator short.
+ * (e.g. 128000 -> "128K", 1_000_000 -> "1M"). Keeps the context indicator short while
+ * preserving one decimal of precision for smaller magnitudes (10502 -> "10.5K") so the
+ * per-exchange token counts stay readable instead of being truncated to "10K".
  */
-private fun formatTokens(tokens: Long): String = when {
-    tokens >= 1_000_000_000 -> "${tokens / 1_000_000_000}B"
-    tokens >= 1_000_000 -> "${tokens / 1_000_000}M"
-    tokens >= 1_000 -> "${tokens / 1_000}K"
+internal fun formatTokens(tokens: Long): String = when {
+    tokens >= 1_000_000_000 -> scaled(tokens, 1_000_000_000.0) + "B"
+    tokens >= 1_000_000 -> scaled(tokens, 1_000_000.0) + "M"
+    tokens >= 1_000 -> scaled(tokens, 1_000.0) + "K"
     else -> tokens.toString()
+}
+
+/**
+ * Scales [tokens] by [unit] and renders it with one decimal when the result is below 100
+ * (e.g. 10.5, 1.5), otherwise as a rounded integer (e.g. 131, 476). Trailing ".0" is
+ * dropped so 1_000_000 renders as "1M" rather than "1.0M". Uses Locale.US so the decimal
+ * separator is always a period — a comma would be ambiguous with thousands grouping.
+ */
+private fun scaled(tokens: Long, unit: Double): String {
+    val value = tokens / unit
+    return if (value < 100.0) {
+        val oneDecimal = (value * 10).roundToInt() / 10.0
+        if (oneDecimal % 1.0 == 0.0) oneDecimal.toInt().toString()
+        else String.format(java.util.Locale.US, "%.1f", oneDecimal)
+    } else {
+        value.roundToInt().toString()
+    }
+}
+
+/**
+ * Builds the right-aligned metadata summary shown next to the model name: elapsed time,
+ * token usage (clearly labelled input/output), cost, and how much of the model's context
+ * window the exchange occupied. Extracted as an internal, Compose-free function so the
+ * formatting can be unit-tested directly. Returns an empty string when nothing is known.
+ */
+internal fun formatMetadataSummary(message: MessageUiModel): String {
+    val parts = mutableListOf<String>()
+    if (message.executionTimeMs > 0) {
+        val seconds = message.executionTimeMs / 1000.0
+        // Locale.US keeps the decimal separator a period so the row reads consistently
+        // with the period-formatted token counts (a comma locale gave "7,7s").
+        parts.add(String.format(java.util.Locale.US, "%.1fs", seconds))
+    }
+    val usage = message.tokenUsage
+    if (usage.inputTokens > 0 || usage.outputTokens > 0) {
+        // Label the two counts so it's unambiguous which is the prompt (input) and which
+        // is the generated response (output); "12/34 tokens" gave no such hint.
+        parts.add("${formatTokens(usage.inputTokens)} in / ${formatTokens(usage.outputTokens)} out")
+    }
+    if (usage.cost > 0) {
+        parts.add(String.format(java.util.Locale.US, "$%.4f", usage.cost))
+    }
+    // Used window context: how much of the model's input window this exchange occupied.
+    if (usage.contextWindowMax > 0 && (usage.inputTokens > 0 || usage.outputTokens > 0)) {
+        val used = usage.inputTokens + usage.outputTokens
+        val pct = (used.toDouble() / usage.contextWindowMax * 100).roundToInt()
+        parts.add("${formatTokens(used)}/${formatTokens(usage.contextWindowMax)} context ($pct%)")
+    }
+    return parts.joinToString(" | ")
 }
 
 /**
@@ -301,28 +352,10 @@ private fun MetadataRow(message: MessageUiModel) {
             )
         }
 
-        val parts = mutableListOf<String>()
-        if (message.executionTimeMs > 0) {
-            val seconds = message.executionTimeMs / 1000.0
-            parts.add("%.1fs".format(seconds))
-        }
-        val usage = message.tokenUsage
-        if (usage.inputTokens > 0 || usage.outputTokens > 0) {
-            parts.add("${usage.inputTokens}/${usage.outputTokens} tokens")
-        }
-        if (usage.cost > 0) {
-            parts.add("$%.4f".format(usage.cost))
-        }
-        // Used window context: how much of the model's input window this exchange occupied.
-        if (usage.contextWindowMax > 0 && (usage.inputTokens > 0 || usage.outputTokens > 0)) {
-            val used = usage.inputTokens + usage.outputTokens
-            val pct = (used.toDouble() / usage.contextWindowMax * 100).roundToInt()
-            parts.add("${formatTokens(used)}/${formatTokens(usage.contextWindowMax)} context ($pct%)")
-        }
-
-        if (parts.isNotEmpty()) {
+        val summary = formatMetadataSummary(message)
+        if (summary.isNotEmpty()) {
             BasicText(
-                text = parts.joinToString(" | "),
+                text = summary,
                 style = typography.caption.copy(color = colors.textSecondary),
             )
         }

--- a/src/test/kotlin/com/devoxx/genie/ui/compose/components/MetadataSummaryTest.kt
+++ b/src/test/kotlin/com/devoxx/genie/ui/compose/components/MetadataSummaryTest.kt
@@ -84,7 +84,15 @@ class MetadataSummaryTest {
     }
 
     @Test
-    fun `full row combines time tokens cost and context window`() {
+    fun `time and tokens are joined with a tilde`() {
+        val summary = formatMetadataSummary(message(executionTimeMs = 1_800, inputTokens = 10_502, outputTokens = 179))
+        assertEquals("1.8s ~ 10.5K in / 179 out", summary)
+    }
+
+    @Test
+    fun `context window is never shown in the bubble`() {
+        // The overall context-window usage lives under the prompt; it must not be repeated
+        // per-bubble even when the model's max window is known.
         val summary = formatMetadataSummary(
             message(
                 executionTimeMs = 7_700,
@@ -93,17 +101,19 @@ class MetadataSummaryTest {
                 contextWindowMax = 131_072,
             ),
         )
-        assertEquals("7.7s | 10.5K in / 476 out | 11K/131K context (8%)", summary)
+        assertEquals("7.7s ~ 10.5K in / 476 out", summary)
+    }
+
+    @Test
+    fun `cost is appended when present`() {
+        val summary = formatMetadataSummary(
+            message(executionTimeMs = 1_800, inputTokens = 100, outputTokens = 50, cost = 0.0023),
+        )
+        assertEquals("1.8s ~ 100 in / 50 out ~ \$0.0023", summary)
     }
 
     @Test
     fun `empty when nothing is known`() {
         assertEquals("", formatMetadataSummary(message()))
-    }
-
-    @Test
-    fun `context window omitted when max unknown`() {
-        val summary = formatMetadataSummary(message(inputTokens = 100, outputTokens = 50))
-        assertEquals("100 in / 50 out", summary)
     }
 }

--- a/src/test/kotlin/com/devoxx/genie/ui/compose/components/MetadataSummaryTest.kt
+++ b/src/test/kotlin/com/devoxx/genie/ui/compose/components/MetadataSummaryTest.kt
@@ -1,0 +1,109 @@
+package com.devoxx.genie.ui.compose.components
+
+import com.devoxx.genie.ui.compose.model.MessageUiModel
+import com.devoxx.genie.ui.compose.model.TokenUsageInfo
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+/**
+ * Tests for the AI bubble metadata row formatting (AiBubble.kt):
+ *  - token counts are abbreviated with a formatter (10502 -> "10.5K") instead of being
+ *    printed raw, and
+ *  - input vs output tokens are clearly labelled so "10502/476 tokens" can no longer be
+ *    mistaken for a used/max ratio.
+ */
+class MetadataSummaryTest {
+
+    // --- formatTokens ---
+
+    @Test
+    fun `small counts are printed verbatim`() {
+        assertEquals("0", formatTokens(0))
+        assertEquals("476", formatTokens(476))
+        assertEquals("999", formatTokens(999))
+    }
+
+    @Test
+    fun `thousands keep one decimal below 100K`() {
+        assertEquals("1K", formatTokens(1_000))
+        assertEquals("1.5K", formatTokens(1_500))
+        assertEquals("10.5K", formatTokens(10_502))
+    }
+
+    @Test
+    fun `large thousands round to integer`() {
+        assertEquals("128K", formatTokens(128_000))
+        assertEquals("131K", formatTokens(131_072))
+    }
+
+    @Test
+    fun `millions and billions are abbreviated`() {
+        assertEquals("1M", formatTokens(1_000_000))
+        assertEquals("1.5M", formatTokens(1_500_000))
+        assertEquals("2M", formatTokens(2_000_000))
+        assertEquals("1B", formatTokens(1_000_000_000))
+    }
+
+    @Test
+    fun `decimal separator is always a period regardless of locale`() {
+        val previous = java.util.Locale.getDefault()
+        try {
+            // A locale that uses comma as the decimal separator must not leak into the output.
+            java.util.Locale.setDefault(java.util.Locale.GERMANY)
+            assertEquals("10.5K", formatTokens(10_502))
+            assertEquals("1.5M", formatTokens(1_500_000))
+        } finally {
+            java.util.Locale.setDefault(previous)
+        }
+    }
+
+    // --- formatMetadataSummary ---
+
+    private fun message(
+        executionTimeMs: Long = 0,
+        inputTokens: Long = 0,
+        outputTokens: Long = 0,
+        cost: Double = 0.0,
+        contextWindowMax: Long = 0,
+    ) = MessageUiModel(
+        id = "1",
+        userPrompt = "hi",
+        executionTimeMs = executionTimeMs,
+        tokenUsage = TokenUsageInfo(
+            inputTokens = inputTokens,
+            outputTokens = outputTokens,
+            cost = cost,
+            contextWindowMax = contextWindowMax,
+        ),
+    )
+
+    @Test
+    fun `token usage is labelled input and output`() {
+        val summary = formatMetadataSummary(message(inputTokens = 10_502, outputTokens = 476))
+        assertEquals("10.5K in / 476 out", summary)
+    }
+
+    @Test
+    fun `full row combines time tokens cost and context window`() {
+        val summary = formatMetadataSummary(
+            message(
+                executionTimeMs = 7_700,
+                inputTokens = 10_502,
+                outputTokens = 476,
+                contextWindowMax = 131_072,
+            ),
+        )
+        assertEquals("7.7s | 10.5K in / 476 out | 11K/131K context (8%)", summary)
+    }
+
+    @Test
+    fun `empty when nothing is known`() {
+        assertEquals("", formatMetadataSummary(message()))
+    }
+
+    @Test
+    fun `context window omitted when max unknown`() {
+        val summary = formatMetadataSummary(message(inputTokens = 100, outputTokens = 50))
+        assertEquals("100 in / 50 out", summary)
+    }
+}


### PR DESCRIPTION
The AI bubble metadata row showed token usage as "10502/476 tokens", which
gave no hint as to which number was input vs output and left the larger
counts unformatted. It also repeated the model's overall context-window
usage, which is already shown as a persistent indicator under the prompt.

The per-bubble header now reads, e.g.:

```
1.8s ~ 10.5K in / 179 out
```

Changes:
- **Labelled input/output** — `10.5K in / 179 out` instead of the ambiguous `10502/476 tokens`.
- **Formatter for large counts** — `formatTokens` abbreviates via the same K/M/B scheme as the under-prompt indicator, keeping one decimal of precision below 100 (`10502 → "10.5K"`) so per-exchange counts stay readable instead of being truncated to `10K`.
- **Dropped the context-window readout** (`11K/131K context (8%)`) from the bubble — it duplicated the persistent indicator shown under the prompt.
- **Tilde separator** between parts (`1.8s ~ …`); cost is still appended when known (`… ~ $0.0023`).
- **Locale-stable** — time, cost and token decimals all render with `Locale.US`, so the separator is always a period (a comma locale previously produced `7,7s`).

The summary formatting is extracted into a Compose-free, unit-tested
`formatMetadataSummary()` function (`MetadataSummaryTest.kt`).

https://claude.ai/code/session_01KSfErJpzjtzkh2p6TnVjvp