### PR TITLE
Page MCP Marketplace registry instead of loading the entire list

### DIFF
--- a/src/main/java/com/devoxx/genie/service/mcp/MCPRegistryService.java
+++ b/src/main/java/com/devoxx/genie/service/mcp/MCPRegistryService.java
@@ -54,14 +54,14 @@ public class MCPRegistryService {
     }
 
     /**
-     * Fetch all servers from the registry and cache them in memory.
+     * Fetch all MCP servers from the marketplace registry and cache them in memory.
      *
      * @param forceRefresh if true, re-fetches from the registry even if cached
      * @return the complete list of servers
      * @throws IOException if any network request fails
      */
     @NotNull
-    public List<MCPRegistryServerEntry> fetchAllServers(boolean forceRefresh) throws IOException {
+    public List<MCPRegistryServerEntry> fetchAllMarketplaceMCPServers(boolean forceRefresh) throws IOException {
         if (cachedServers != null && !forceRefresh) {
             return cachedServers;
         }

--- a/src/main/java/com/devoxx/genie/service/mcp/MCPRegistryService.java
+++ b/src/main/java/com/devoxx/genie/service/mcp/MCPRegistryService.java
@@ -23,6 +23,7 @@ public class MCPRegistryService {
     private static final String REGISTRY_BASE_URL = "https://registry.modelcontextprotocol.io/v0.1/servers";
     private final OkHttpClient client;
     private final Gson gson;
+    private final String registryBaseUrl;
 
     private List<MCPRegistryServerEntry> cachedServers = null;
 
@@ -34,8 +35,17 @@ public class MCPRegistryService {
      * Package-private constructor for testing with injectable dependencies.
      */
     MCPRegistryService(OkHttpClient client, Gson gson) {
+        this(client, gson, REGISTRY_BASE_URL);
+    }
+
+    /**
+     * Package-private constructor allowing the registry base URL to be overridden, so integration
+     * tests can point the real {@link #searchServers} implementation at a local mock server.
+     */
+    MCPRegistryService(OkHttpClient client, Gson gson, String registryBaseUrl) {
         this.client = client;
         this.gson = gson;
+        this.registryBaseUrl = registryBaseUrl;
     }
 
     @NotNull
@@ -70,8 +80,11 @@ public class MCPRegistryService {
 
     /**
      * Search for MCP servers in the registry.
+     * <p>
+     * Note: the registry's {@code search} parameter performs a substring match on the
+     * server <em>name</em> only (it does not search descriptions).
      *
-     * @param query  optional search query
+     * @param query  optional search query (substring match on server name)
      * @param cursor optional pagination cursor from a previous response
      * @param limit  max number of results to return
      * @return the registry response containing servers and pagination metadata
@@ -81,11 +94,11 @@ public class MCPRegistryService {
     public MCPRegistryResponse searchServers(@Nullable String query,
                                              @Nullable String cursor,
                                              int limit) throws IOException {
-        HttpUrl.Builder urlBuilder = Objects.requireNonNull(HttpUrl.parse(REGISTRY_BASE_URL)).newBuilder();
+        HttpUrl.Builder urlBuilder = Objects.requireNonNull(HttpUrl.parse(registryBaseUrl)).newBuilder();
         urlBuilder.addQueryParameter("limit", String.valueOf(limit));
 
         if (query != null && !query.isBlank()) {
-            urlBuilder.addQueryParameter("q", query);
+            urlBuilder.addQueryParameter("search", query);
         }
         if (cursor != null && !cursor.isBlank()) {
             urlBuilder.addQueryParameter("cursor", cursor);

--- a/src/main/java/com/devoxx/genie/ui/settings/mcp/dialog/MCPMarketplaceDialog.java
+++ b/src/main/java/com/devoxx/genie/ui/settings/mcp/dialog/MCPMarketplaceDialog.java
@@ -1,12 +1,12 @@
 package com.devoxx.genie.ui.settings.mcp.dialog;
 
 import com.devoxx.genie.model.mcp.MCPServer;
+import com.devoxx.genie.model.mcp.registry.MCPRegistryResponse;
 import com.devoxx.genie.model.mcp.registry.MCPRegistryServerEntry;
 import com.devoxx.genie.model.mcp.registry.MCPRegistryServerInfo;
 import com.devoxx.genie.service.mcp.MCPRegistryService;
-import com.intellij.openapi.progress.ProcessCanceledException;
-import com.intellij.openapi.progress.ProgressIndicator;
-import com.intellij.openapi.progress.ProgressManager;
+import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.application.ModalityState;
 import com.intellij.openapi.ui.DialogWrapper;
 import com.intellij.ui.SearchTextField;
 import com.intellij.ui.components.JBScrollPane;
@@ -21,6 +21,7 @@ import javax.swing.table.AbstractTableModel;
 import java.awt.*;
 import java.util.*;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
 
 @Slf4j
 public class MCPMarketplaceDialog extends DialogWrapper {
@@ -29,19 +30,30 @@ public class MCPMarketplaceDialog extends DialogWrapper {
     private static final String LOCAL_FILTER = "Local";
     private static final String REMOTE_FILTER = "Remote";
 
+    /** Number of servers requested per registry page. */
+    private static final int PAGE_SIZE = 100;
+    /** Debounce delay (ms) before a search keystroke triggers a registry request. */
+    private static final int SEARCH_DEBOUNCE_MS = 350;
+
     private final SearchTextField searchField = new SearchTextField();
     private final JComboBox<String> locationFilter = new JComboBox<>(new String[]{ALL_FILTER, LOCAL_FILTER, REMOTE_FILTER});
     private final JComboBox<String> typeFilter = new JComboBox<>(new String[]{ALL_FILTER});
     private final ServerTableModel tableModel = new ServerTableModel();
     private final JBTable serverTable = new JBTable(tableModel);
     private final JButton refreshButton = new JButton("Refresh");
+    private final JButton loadMoreButton = new JButton("Load More");
     private final JLabel statusLabel = new JLabel("Loading...");
 
     @Getter
     private MCPServer selectedMcpServer;
 
-    private List<MCPRegistryServerEntry> allServers = new ArrayList<>();
+    /** Accumulated paging state for the current search query (loaded servers + cursor). */
+    private final PagingState pagingState = new PagingState();
+    /** Monotonic counter used to discard responses from superseded (stale) requests. */
+    private final AtomicInteger requestGeneration = new AtomicInteger();
+    private final Timer searchDebounceTimer = new Timer(SEARCH_DEBOUNCE_MS, e -> triggerSearch());
     private boolean populatingFilters;
+    private boolean disposed;
 
     public MCPMarketplaceDialog() {
         super(true);
@@ -51,18 +63,29 @@ public class MCPMarketplaceDialog extends DialogWrapper {
 
         init();
 
-        // Initial load (uses cache if available)
-        loadAllServers(false);
+        searchDebounceTimer.setRepeats(false);
 
-        // Search field and filter combos all trigger the same local filter
+        // Initial load: first page only, no query.
+        pagingState.setQuery("");
+        loadPage(false);
+
+        // Typing in the search field triggers a debounced server-side search.
         searchField.addDocumentListener(new com.intellij.ui.DocumentAdapter() {
             @Override
             protected void textChanged(javax.swing.event.@NotNull DocumentEvent e) {
-                applyFilters();
+                searchDebounceTimer.restart();
             }
         });
+        // Location/Type are client-side filters over the pages loaded so far.
         locationFilter.addActionListener(e -> applyFilters());
         typeFilter.addActionListener(e -> applyFilters());
+    }
+
+    @Override
+    protected void dispose() {
+        disposed = true;
+        searchDebounceTimer.stop();
+        super.dispose();
     }
 
     @Override
@@ -99,10 +122,15 @@ public class MCPMarketplaceDialog extends DialogWrapper {
         JBScrollPane scrollPane = new JBScrollPane(serverTable);
         mainPanel.add(scrollPane, BorderLayout.CENTER);
 
-        // Bottom panel with Refresh and status
+        // Bottom panel with Refresh, Load More and status
         JPanel bottomPanel = new JPanel(new BorderLayout());
-        refreshButton.addActionListener(e -> loadAllServers(true));
-        bottomPanel.add(refreshButton, BorderLayout.WEST);
+        JPanel leftButtons = new JPanel(new FlowLayout(FlowLayout.LEFT, 8, 0));
+        refreshButton.addActionListener(e -> loadPage(false));
+        loadMoreButton.addActionListener(e -> loadPage(true));
+        loadMoreButton.setEnabled(false);
+        leftButtons.add(refreshButton);
+        leftButtons.add(loadMoreButton);
+        bottomPanel.add(leftButtons, BorderLayout.WEST);
         bottomPanel.add(statusLabel, BorderLayout.EAST);
         mainPanel.add(bottomPanel, BorderLayout.SOUTH);
 
@@ -137,53 +165,73 @@ public class MCPMarketplaceDialog extends DialogWrapper {
         setOKActionEnabled(serverTable.getSelectedRow() >= 0);
     }
 
-    @SuppressWarnings("unchecked")
-    private void loadAllServers(boolean forceRefresh) {
-        refreshButton.setEnabled(false);
+    /**
+     * Trigger a fresh server-side search using the current text in the search field.
+     * Invoked (debounced) when the user types.
+     */
+    private void triggerSearch() {
+        pagingState.setQuery(searchField.getText().trim());
+        loadPage(false);
+    }
+
+    /**
+     * Load a single page of registry results on a background thread and update the table on the EDT.
+     * <p>
+     * The registry is paged rather than fully downloaded, so this never blocks on an unbounded
+     * loop. A monotonically increasing generation counter ensures that if a newer request starts
+     * (e.g. the user keeps typing) the response of a superseded request is discarded.
+     *
+     * @param append {@code true} to fetch the next page and append it; {@code false} to (re)load
+     *               the first page of the current query, replacing the loaded list
+     */
+    private void loadPage(boolean append) {
+        final int generation = requestGeneration.incrementAndGet();
+        setLoading(true);
         statusLabel.setText("Loading...");
 
-        final List<MCPRegistryServerEntry>[] result = new List[]{null};
-        final Exception[] error = {null};
-        boolean cancelled = false;
+        final String query = pagingState.getQuery();
+        final String effectiveQuery = (query == null || query.isBlank()) ? null : query;
+        final String cursor = append ? pagingState.getNextCursor() : null;
+        ApplicationManager.getApplication().executeOnPooledThread(() -> {
+            MCPRegistryResponse response = null;
+            Exception error = null;
+            try {
+                response = MCPRegistryService.getInstance().searchServers(effectiveQuery, cursor, PAGE_SIZE);
+            } catch (Exception e) {
+                error = e;
+            }
+            final MCPRegistryResponse result = response;
+            final Exception err = error;
+            ApplicationManager.getApplication().invokeLater(
+                    () -> onPageLoaded(generation, result, err, append),
+                    ModalityState.any());
+        });
+    }
 
-        try {
-            ProgressManager.getInstance().runProcessWithProgressSynchronously(() -> {
-                ProgressIndicator indicator = ProgressManager.getInstance().getProgressIndicator();
-                indicator.setIndeterminate(true);
-                indicator.setText("Fetching servers from MCP registry...");
-                try {
-                    result[0] = MCPRegistryService.getInstance().fetchAllServers(forceRefresh);
-                } catch (ProcessCanceledException e) {
-                    throw e;
-                } catch (Exception e) {
-                    error[0] = e;
-                }
-            }, "Loading MCP Servers", true, null);
-        } catch (ProcessCanceledException e) {
-            cancelled = true;
+    private void onPageLoaded(int generation, @Nullable MCPRegistryResponse result,
+                              @Nullable Exception error, boolean append) {
+        // Discard stale responses and updates after the dialog has been closed.
+        if (disposed || generation != requestGeneration.get()) {
+            return;
         }
+        setLoading(false);
 
-        refreshButton.setEnabled(true);
-
-        if (cancelled) {
-            statusLabel.setText("Cancelled");
+        if (error != null) {
+            log.error("Failed to fetch MCP servers from registry", error);
+            statusLabel.setText("Error: " + error.getMessage());
             return;
         }
 
-        if (error[0] != null) {
-            log.error("Failed to fetch MCP servers from registry", error[0]);
-            statusLabel.setText("Error: " + error[0].getMessage());
-            return;
-        }
-
-        if (result[0] == null) {
-            allServers = new ArrayList<>();
-        } else {
-            allServers = new ArrayList<>(result[0]);
-        }
+        pagingState.apply(result, append);
 
         populateTypeFilter();
         applyFilters();
+    }
+
+    /** Toggle button state while a registry request is in flight. */
+    private void setLoading(boolean loading) {
+        refreshButton.setEnabled(!loading);
+        loadMoreButton.setEnabled(!loading && pagingState.hasMorePages());
     }
 
     private void populateTypeFilter() {
@@ -191,40 +239,113 @@ public class MCPMarketplaceDialog extends DialogWrapper {
         try {
             MCPRegistryService registryService = MCPRegistryService.getInstance();
             Set<String> types = new TreeSet<>();
-            for (MCPRegistryServerEntry entry : allServers) {
+            for (MCPRegistryServerEntry entry : pagingState.getLoadedServers()) {
                 if (entry.getServer() != null) {
                     types.add(registryService.getServerType(entry.getServer()));
                 }
             }
+            // Preserve the current selection across rebuilds (types only ever grow as more pages load).
+            String previouslySelected = (String) typeFilter.getSelectedItem();
             typeFilter.removeAllItems();
             typeFilter.addItem(ALL_FILTER);
             for (String type : types) {
                 typeFilter.addItem(type);
+            }
+            if (previouslySelected != null) {
+                typeFilter.setSelectedItem(previouslySelected);
             }
         } finally {
             populatingFilters = false;
         }
     }
 
+    /**
+     * Apply the client-side Location/Type filters over the pages loaded so far.
+     * Text search is performed server-side (see {@link #loadPage}), so it is not re-applied here.
+     */
     private void applyFilters() {
         if (populatingFilters) {
             return;
         }
-        String query = searchField.getText().trim();
         String selectedLocation = (String) locationFilter.getSelectedItem();
         String selectedType = (String) typeFilter.getSelectedItem();
         MCPRegistryService registryService = MCPRegistryService.getInstance();
 
-        List<MCPRegistryServerEntry> filtered = allServers.stream()
-                .filter(entry -> SERVER_FILTER.matches(entry, query, selectedLocation, selectedType, registryService))
+        List<MCPRegistryServerEntry> filtered = pagingState.getLoadedServers().stream()
+                .filter(entry -> SERVER_FILTER.matches(entry, "", selectedLocation, selectedType, registryService))
                 .toList();
 
         tableModel.setServers(filtered);
-        statusLabel.setText("Showing " + filtered.size() + " of " + allServers.size() + " servers");
+        statusLabel.setText(buildStatusText(filtered.size()));
+        loadMoreButton.setEnabled(refreshButton.isEnabled() && pagingState.hasMorePages());
         updateOkAction();
     }
 
+    private String buildStatusText(int shownCount) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("Showing ").append(shownCount).append(" of ")
+                .append(pagingState.size()).append(" loaded");
+        if (pagingState.hasMorePages()) {
+            sb.append(" (more available)");
+        }
+        return sb.toString();
+    }
+
     private static final ServerEntryFilter SERVER_FILTER = new ServerEntryFilter();
+
+    /**
+     * Holds the accumulated paging state for the currently active search query: the servers
+     * loaded so far and the cursor for the next page. Extracted as a static nested class so the
+     * append/replace/cursor-exhaustion logic can be unit tested without the IntelliJ platform.
+     */
+    static class PagingState {
+        private final List<MCPRegistryServerEntry> loadedServers = new ArrayList<>();
+        private String nextCursor;
+        private String query = "";
+
+        void setQuery(@Nullable String query) {
+            this.query = query == null ? "" : query;
+        }
+
+        String getQuery() {
+            return query;
+        }
+
+        /**
+         * Merge a page of registry results into the loaded state.
+         *
+         * @param response the registry response (may be {@code null} on a no-op load)
+         * @param append   {@code true} to append to the existing list (Load More),
+         *                 {@code false} to replace it (new search / refresh)
+         */
+        void apply(@Nullable MCPRegistryResponse response, boolean append) {
+            if (!append) {
+                loadedServers.clear();
+            }
+            if (response != null && response.getServers() != null) {
+                loadedServers.addAll(response.getServers());
+            }
+            nextCursor = (response != null && response.getMetadata() != null)
+                    ? response.getMetadata().getNextCursor() : null;
+        }
+
+        List<MCPRegistryServerEntry> getLoadedServers() {
+            return loadedServers;
+        }
+
+        @Nullable
+        String getNextCursor() {
+            return nextCursor;
+        }
+
+        boolean hasMorePages() {
+            return nextCursor != null && !nextCursor.isBlank();
+        }
+
+        int size() {
+            return loadedServers.size();
+        }
+    }
 
     /**
      * Pure filter logic for MCP registry server entries.

--- a/src/test/java/com/devoxx/genie/service/mcp/MCPRegistryServiceTest.java
+++ b/src/test/java/com/devoxx/genie/service/mcp/MCPRegistryServiceTest.java
@@ -266,24 +266,17 @@ class MCPRegistryServiceTest {
             mockServer.shutdown();
         }
 
-        private MCPRegistryService createServiceWithMockUrl() throws Exception {
-            // We need to override the base URL; use reflection to replace the constant
-            // or use a subclass. Simpler: create a testable subclass that overrides the URL.
-            // Actually, the service uses a hardcoded URL. We'll use MockWebServer + OkHttpClient
-            // and test searchServers indirectly through fetchAllServers with a test subclass.
-
-            // Better approach: create a package-private MCPRegistryService with the mock URL injected.
-            // For now, we'll test the service by pointing the OkHttpClient to mock server via interceptor.
+        private MCPRegistryService createServiceWithMockUrl() {
+            // Point the real service at the local MockWebServer via the injectable base URL,
+            // so these tests exercise the production searchServers() implementation.
             String mockUrl = mockServer.url("/v0.1/servers").toString();
             OkHttpClient client = new OkHttpClient.Builder().build();
             Gson testGson = new GsonBuilder().create();
-
-            // Create a service that uses our mock server URL
-            return new TestMCPRegistryService(client, testGson, mockUrl);
+            return new MCPRegistryService(client, testGson, mockUrl);
         }
 
         @Test
-        void searchServers_buildsUrlWithQueryParameter() throws Exception {
+        void searchServers_buildsUrlWithSearchParameter() throws Exception {
             MCPRegistryResponse responseBody = new MCPRegistryResponse();
             mockServer.enqueue(new MockResponse()
                     .addHeader("Content-Type", "application/json")
@@ -293,7 +286,9 @@ class MCPRegistryServiceTest {
             service.searchServers("my-search", null, 50);
 
             RecordedRequest request = mockServer.takeRequest();
-            assertThat(request.getRequestUrl().queryParameter("q")).isEqualTo("my-search");
+            // The registry expects "search" (substring match on name), not "q".
+            assertThat(request.getRequestUrl().queryParameter("search")).isEqualTo("my-search");
+            assertThat(request.getRequestUrl().queryParameter("q")).isNull();
             assertThat(request.getRequestUrl().queryParameter("limit")).isEqualTo("50");
         }
 
@@ -309,7 +304,7 @@ class MCPRegistryServiceTest {
 
             RecordedRequest request = mockServer.takeRequest();
             assertThat(request.getRequestUrl().queryParameter("cursor")).isEqualTo("abc123");
-            assertThat(request.getRequestUrl().queryParameter("q")).isNull();
+            assertThat(request.getRequestUrl().queryParameter("search")).isNull();
         }
 
         @Test
@@ -373,7 +368,7 @@ class MCPRegistryServiceTest {
             String mockUrl = mockServer.url("/v0.1/servers").toString();
             OkHttpClient client = new OkHttpClient.Builder().build();
             Gson testGson = new GsonBuilder().create();
-            service = new TestMCPRegistryService(client, testGson, mockUrl);
+            service = new MCPRegistryService(client, testGson, mockUrl);
         }
 
         @AfterEach
@@ -477,69 +472,111 @@ class MCPRegistryServiceTest {
         }
     }
 
-    // ─── Test subclass with overridable URL ────────────────────
+    // ─── Paged server-side search integration tests ────────────
+    //
+    // These exercise the real searchServers() against a local MockWebServer, mirroring how the
+    // MCP Marketplace dialog now drives paging: load the first page only, then page lazily via the
+    // cursor, with the search query pushed server-side rather than filtering a fully-loaded list.
 
-    /**
-     * A test-only subclass that allows overriding the registry URL
-     * to point at MockWebServer.
-     */
-    static class TestMCPRegistryService extends MCPRegistryService {
-        private final String baseUrl;
+    @Nested
+    class PagedSearch {
 
-        TestMCPRegistryService(OkHttpClient client, Gson gson, String baseUrl) {
-            super(client, gson);
-            this.baseUrl = baseUrl;
+        private MockWebServer mockServer;
+        private MCPRegistryService service;
+
+        @BeforeEach
+        void setUp() throws IOException {
+            mockServer = new MockWebServer();
+            mockServer.start();
+            String mockUrl = mockServer.url("/v0.1/servers").toString();
+            service = new MCPRegistryService(new OkHttpClient.Builder().build(),
+                    new GsonBuilder().create(), mockUrl);
         }
 
-        @Override
-        public MCPRegistryResponse searchServers(String query, String cursor, int limit) throws IOException {
-            // Build URL against mock server instead of real registry
-            okhttp3.HttpUrl.Builder urlBuilder = java.util.Objects.requireNonNull(
-                    okhttp3.HttpUrl.parse(baseUrl)).newBuilder();
-            urlBuilder.addQueryParameter("limit", String.valueOf(limit));
-            if (query != null && !query.isBlank()) {
-                urlBuilder.addQueryParameter("q", query);
-            }
-            if (cursor != null && !cursor.isBlank()) {
-                urlBuilder.addQueryParameter("cursor", cursor);
-            }
-
-            okhttp3.Request request = new okhttp3.Request.Builder()
-                    .url(urlBuilder.build())
-                    .build();
-
-            // Access client and gson via reflection-free path: call the parent's OkHttpClient
-            try (okhttp3.Response response = getClient().newCall(request).execute()) {
-                if (!response.isSuccessful()) {
-                    throw new IOException("Registry API returned HTTP " + response.code());
-                }
-                if (response.body() == null) {
-                    throw new IOException("Registry API returned empty response");
-                }
-                MCPRegistryResponse result = getGson().fromJson(response.body().string(), MCPRegistryResponse.class);
-                return result != null ? result : new MCPRegistryResponse();
-            }
+        @AfterEach
+        void tearDown() throws IOException {
+            mockServer.shutdown();
         }
 
-        // Expose fields for the test subclass
-        private OkHttpClient getClient() {
-            try {
-                java.lang.reflect.Field f = MCPRegistryService.class.getDeclaredField("client");
-                f.setAccessible(true);
-                return (OkHttpClient) f.get(this);
-            } catch (Exception e) {
-                throw new RuntimeException(e);
-            }
+        @Test
+        void firstPageLoadsOnlyOnePageAndExposesNextCursor() throws Exception {
+            mockServer.enqueue(jsonResponse(pageJson(List.of(serverEntry("server-1"), serverEntry("server-2")),
+                    "next-cursor-123")));
+
+            MCPRegistryResponse page = service.searchServers(null, null, 100);
+
+            // Exactly one network request — no eager loop over the whole registry.
+            assertThat(mockServer.getRequestCount()).isEqualTo(1);
+            assertThat(page.getServers()).hasSize(2);
+            assertThat(page.getMetadata().getNextCursor()).isEqualTo("next-cursor-123");
+
+            RecordedRequest request = mockServer.takeRequest();
+            assertThat(request.getRequestUrl().queryParameter("limit")).isEqualTo("100");
+            assertThat(request.getRequestUrl().queryParameter("cursor")).isNull();
+            assertThat(request.getRequestUrl().queryParameter("search")).isNull();
         }
 
-        private com.google.gson.Gson getGson() {
-            try {
-                java.lang.reflect.Field f = MCPRegistryService.class.getDeclaredField("gson");
-                f.setAccessible(true);
-                return (com.google.gson.Gson) f.get(this);
-            } catch (Exception e) {
-                throw new RuntimeException(e);
+        @Test
+        void loadMoreSendsCursorForNextPage() throws Exception {
+            mockServer.enqueue(jsonResponse(pageJson(List.of(serverEntry("server-3")), null)));
+
+            MCPRegistryResponse page = service.searchServers(null, "next-cursor-123", 100);
+
+            assertThat(page.getServers()).hasSize(1);
+            // Last page: no further cursor.
+            assertThat(page.getMetadata()).isNull();
+
+            RecordedRequest request = mockServer.takeRequest();
+            assertThat(request.getRequestUrl().queryParameter("cursor")).isEqualTo("next-cursor-123");
+        }
+
+        @Test
+        void searchPushesQueryServerSideAndPagesWithinResults() throws Exception {
+            // Page 1 of search results, with a cursor for the next page of matches.
+            mockServer.enqueue(jsonResponse(pageJson(List.of(serverEntry("github-mcp")), "search-cursor-2")));
+            // Page 2 of search results (Load More), same query carried along with the cursor.
+            mockServer.enqueue(jsonResponse(pageJson(List.of(serverEntry("github-actions-mcp")), null)));
+
+            MCPRegistryResponse first = service.searchServers("github", null, 100);
+            assertThat(first.getServers()).hasSize(1);
+            assertThat(first.getMetadata().getNextCursor()).isEqualTo("search-cursor-2");
+
+            MCPRegistryResponse second = service.searchServers("github",
+                    first.getMetadata().getNextCursor(), 100);
+            assertThat(second.getServers()).hasSize(1);
+
+            RecordedRequest firstRequest = mockServer.takeRequest();
+            assertThat(firstRequest.getRequestUrl().queryParameter("search")).isEqualTo("github");
+            assertThat(firstRequest.getRequestUrl().queryParameter("cursor")).isNull();
+
+            RecordedRequest secondRequest = mockServer.takeRequest();
+            assertThat(secondRequest.getRequestUrl().queryParameter("search")).isEqualTo("github");
+            assertThat(secondRequest.getRequestUrl().queryParameter("cursor")).isEqualTo("search-cursor-2");
+        }
+
+        private MockResponse jsonResponse(String body) {
+            return new MockResponse()
+                    .addHeader("Content-Type", "application/json")
+                    .setBody(body);
+        }
+
+        private MCPRegistryServerEntry serverEntry(String name) {
+            MCPRegistryServerInfo info = new MCPRegistryServerInfo();
+            info.setName(name);
+            MCPRegistryServerEntry entry = new MCPRegistryServerEntry();
+            entry.setServer(info);
+            return entry;
+        }
+
+        private String pageJson(List<MCPRegistryServerEntry> servers, String nextCursor) {
+            MCPRegistryResponse response = new MCPRegistryResponse();
+            response.setServers(servers);
+            if (nextCursor != null) {
+                MCPRegistryMetadata metadata = new MCPRegistryMetadata();
+                metadata.setNextCursor(nextCursor);
+                response.setMetadata(metadata);
             }
+            return gson.toJson(response);
         }
     }
 

--- a/src/test/java/com/devoxx/genie/service/mcp/MCPRegistryServiceTest.java
+++ b/src/test/java/com/devoxx/genie/service/mcp/MCPRegistryServiceTest.java
@@ -353,7 +353,7 @@ class MCPRegistryServiceTest {
         }
     }
 
-    // ─── fetchAllServers tests ─────────────────────────────────
+    // ─── fetchAllMarketplaceMCPServers tests ─────────────────────────────────
 
     @Nested
     class FetchAllServers {
@@ -391,11 +391,11 @@ class MCPRegistryServiceTest {
                     .setBody(gson.toJson(responseBody)));
 
             // First call: fetches from network
-            List<MCPRegistryServerEntry> first = service.fetchAllServers(false);
+            List<MCPRegistryServerEntry> first = service.fetchAllMarketplaceMCPServers(false);
             assertThat(first).hasSize(1);
 
             // Second call: should use cache (no network request queued)
-            List<MCPRegistryServerEntry> second = service.fetchAllServers(false);
+            List<MCPRegistryServerEntry> second = service.fetchAllMarketplaceMCPServers(false);
             assertThat(second).hasSize(1);
             assertThat(mockServer.getRequestCount()).isEqualTo(1);
         }
@@ -418,8 +418,8 @@ class MCPRegistryServiceTest {
                     .addHeader("Content-Type", "application/json")
                     .setBody(gson.toJson(secondResponse)));
 
-            service.fetchAllServers(false);
-            List<MCPRegistryServerEntry> refreshed = service.fetchAllServers(true);
+            service.fetchAllMarketplaceMCPServers(false);
+            List<MCPRegistryServerEntry> refreshed = service.fetchAllMarketplaceMCPServers(true);
 
             assertThat(refreshed).hasSize(1);
             assertThat(mockServer.getRequestCount()).isEqualTo(2);
@@ -453,7 +453,7 @@ class MCPRegistryServiceTest {
                     .addHeader("Content-Type", "application/json")
                     .setBody(gson.toJson(page2)));
 
-            List<MCPRegistryServerEntry> all = service.fetchAllServers(false);
+            List<MCPRegistryServerEntry> all = service.fetchAllMarketplaceMCPServers(false);
 
             assertThat(all).hasSize(2);
             assertThat(mockServer.getRequestCount()).isEqualTo(2);
@@ -466,7 +466,7 @@ class MCPRegistryServiceTest {
                     .addHeader("Content-Type", "application/json")
                     .setBody(gson.toJson(emptyResponse)));
 
-            List<MCPRegistryServerEntry> result = service.fetchAllServers(false);
+            List<MCPRegistryServerEntry> result = service.fetchAllMarketplaceMCPServers(false);
 
             assertThat(result).isEmpty();
         }

--- a/src/test/java/com/devoxx/genie/ui/settings/mcp/dialog/MCPMarketplaceDialogPagingTest.java
+++ b/src/test/java/com/devoxx/genie/ui/settings/mcp/dialog/MCPMarketplaceDialogPagingTest.java
@@ -1,0 +1,128 @@
+package com.devoxx.genie.ui.settings.mcp.dialog;
+
+import com.devoxx.genie.model.mcp.registry.MCPRegistryMetadata;
+import com.devoxx.genie.model.mcp.registry.MCPRegistryResponse;
+import com.devoxx.genie.model.mcp.registry.MCPRegistryServerEntry;
+import com.devoxx.genie.model.mcp.registry.MCPRegistryServerInfo;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for MCPMarketplaceDialog.PagingState — the accumulate/replace/cursor logic
+ * extracted from the dialog so it can be tested without the IntelliJ platform.
+ */
+class MCPMarketplaceDialogPagingTest {
+
+    private MCPMarketplaceDialog.PagingState state;
+
+    @BeforeEach
+    void setUp() {
+        state = new MCPMarketplaceDialog.PagingState();
+    }
+
+    @Test
+    void newStateIsEmptyWithNoMorePages() {
+        assertThat(state.size()).isZero();
+        assertThat(state.getLoadedServers()).isEmpty();
+        assertThat(state.getNextCursor()).isNull();
+        assertThat(state.hasMorePages()).isFalse();
+        assertThat(state.getQuery()).isEmpty();
+    }
+
+    @Test
+    void replaceLoadsFirstPageAndTracksCursor() {
+        state.apply(page(List.of(entry("a"), entry("b")), "cursor-2"), false);
+
+        assertThat(state.size()).isEqualTo(2);
+        assertThat(state.getNextCursor()).isEqualTo("cursor-2");
+        assertThat(state.hasMorePages()).isTrue();
+    }
+
+    @Test
+    void appendAccumulatesAcrossPages() {
+        state.apply(page(List.of(entry("a"), entry("b")), "cursor-2"), false);
+        state.apply(page(List.of(entry("c")), null), true);
+
+        assertThat(state.size()).isEqualTo(3);
+        assertThat(serverNames(state)).containsExactly("a", "b", "c");
+        assertThat(state.hasMorePages()).isFalse();
+    }
+
+    @Test
+    void replaceClearsPreviouslyLoadedServers() {
+        state.apply(page(List.of(entry("old-1"), entry("old-2")), "cursor-2"), false);
+
+        // A new search replaces, rather than appends.
+        state.apply(page(List.of(entry("new-1")), null), false);
+
+        assertThat(state.size()).isEqualTo(1);
+        assertThat(serverNames(state)).containsExactly("new-1");
+        assertThat(state.getNextCursor()).isNull();
+    }
+
+    @Test
+    void blankCursorMeansNoMorePages() {
+        state.apply(page(List.of(entry("a")), "   "), false);
+        assertThat(state.hasMorePages()).isFalse();
+    }
+
+    @Test
+    void nullResponseClearsOnReplaceAndIsHandledGracefully() {
+        state.apply(page(List.of(entry("a")), "cursor-2"), false);
+
+        state.apply(null, false);
+
+        assertThat(state.size()).isZero();
+        assertThat(state.getNextCursor()).isNull();
+        assertThat(state.hasMorePages()).isFalse();
+    }
+
+    @Test
+    void responseWithNullServerListIsHandledGracefully() {
+        MCPRegistryResponse response = new MCPRegistryResponse(); // servers == null
+        state.apply(response, false);
+
+        assertThat(state.size()).isZero();
+        assertThat(state.hasMorePages()).isFalse();
+    }
+
+    @Test
+    void setQueryTrackedAndNullCoercedToEmpty() {
+        state.setQuery("github");
+        assertThat(state.getQuery()).isEqualTo("github");
+
+        state.setQuery(null);
+        assertThat(state.getQuery()).isEmpty();
+    }
+
+    // ─── Helpers ──────────────────────────────────────────────
+
+    private static MCPRegistryServerEntry entry(String name) {
+        MCPRegistryServerInfo info = new MCPRegistryServerInfo();
+        info.setName(name);
+        MCPRegistryServerEntry entry = new MCPRegistryServerEntry();
+        entry.setServer(info);
+        return entry;
+    }
+
+    private static MCPRegistryResponse page(List<MCPRegistryServerEntry> servers, String nextCursor) {
+        MCPRegistryResponse response = new MCPRegistryResponse();
+        response.setServers(servers);
+        if (nextCursor != null) {
+            MCPRegistryMetadata metadata = new MCPRegistryMetadata();
+            metadata.setNextCursor(nextCursor);
+            response.setMetadata(metadata);
+        }
+        return response;
+    }
+
+    private static List<String> serverNames(MCPMarketplaceDialog.PagingState state) {
+        return state.getLoadedServers().stream()
+                .map(e -> e.getServer().getName())
+                .toList();
+    }
+}


### PR DESCRIPTION
The MCP Marketplace fetched the *entire* registry up front by looping every
page in MCPRegistryService.fetchAllServers(), then filtered that in-memory
list client-side. As the registry grew to thousands of entries this made the
dialog hang on open, and the Cancel button did nothing because the fetch loop
never polled the progress indicator.

Switch the dialog to lazy, cursor-based paging:
- Load only the first page on open; add a "Load More" button that pages via
  the registry's nextCursor.
- Move search server-side using the registry's `search` parameter (substring
  match on server name), debounced, so typing reloads page one of matches
  across the whole registry rather than only the loaded subset.
- Run each page fetch on a pooled thread and update the table on the EDT via
  invokeLater(ModalityState.any()); a generation counter discards stale
  responses when the user keeps typing, so no modal progress dialog (and thus
  no broken Cancel) is involved.
- Location/Type filters remain client-side over the pages loaded so far.

Also fix a latent bug: searchServers sent the query as `q`, which the registry
ignores; the correct parameter is `search`. The registry base URL is now
injectable so integration tests exercise the real searchServers() against a
MockWebServer instead of a duplicated test override.

Tests:
- MCPMarketplaceDialogPagingTest covers the extracted PagingState
  append/replace/cursor-exhaustion logic.
- MCPRegistryServiceTest.PagedSearch adds MockWebServer integration tests for
  first-page-only loading, cursor paging, and server-side search.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01TQBGSzDhShEWx9RwcMqx8H