### PR TITLE
Bump langchain4j from 1.16.2 to 1.16.3

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -262,8 +262,8 @@ dependencies {
         testFramework(TestFrameworkType.Platform)
     }
     
-    val lg4j_version = "1.16.2"
-    val lg4j_beta_version = "1.16.2-beta26"
+    val lg4j_version = "1.16.3"
+    val lg4j_beta_version = "1.16.3-beta26"
     val awsSdkVersion = "2.46.10"
     val retrofitVersion = "3.0.0"
     val sqliteVersion = "3.53.2.0"


### PR DESCRIPTION
## What

Routine dependency update of all langchain4j artifacts:

- `1.16.2` → `1.16.3` (stable artifacts)
- `1.16.2-beta26` → `1.16.3-beta26` (beta artifacts: web-search, chroma, mcp, reactor, skills)

All artifacts are driven by the `lg4j_version` / `lg4j_beta_version` variables in `build.gradle.kts`, so the change is limited to the two version constants.

## Verification

- `dependencies --configuration runtimeClasspath` resolves cleanly to 1.16.3 across the tree.
- `compileJava` / `compileTestJava` succeed.
- Agent and chat-model test suites pass.

## Note

This is a **maintenance bump only**. It does **not** fix the streaming `ServiceConfigurationError: KotlinModule not a subtype` — `langchain4j-core`'s `JacksonJsonCodec` calls `findAndRegisterModules()` identically in 1.16.2 and 1.16.3. That issue is addressed separately on `claude/skill-illegal-state-exception-3ygexl` (PR #1132).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TRWhqjR76e1B6fw7zYuBXU)_