### PR TITLE
Fix/support langchain4j execute with context contract in tool wrappers (fixes skill tools)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,9 +7,9 @@ plugins {
     // Kotlin 2.2.20 matches the stdlib bundled in IntelliJ 2025.3, the minimum supported IDE.
     // Do NOT bump beyond the bundled stdlib of the lowest supported IDE line: the plugin runs
     // on the IDE-provided stdlib (see binaryIncompatibleRuntimeJarPatterns below).
-    kotlin("jvm") version "2.4.0"
-    kotlin("plugin.lombok") version "2.4.0"
-    kotlin("plugin.compose") version "2.4.0"
+    kotlin("jvm") version "2.2.20"
+    kotlin("plugin.lombok") version "2.2.20"
+    kotlin("plugin.compose") version "2.2.20"
     id("org.jetbrains.intellij.platform") version "2.13.1"
     jacoco
 }
@@ -262,9 +262,9 @@ dependencies {
         testFramework(TestFrameworkType.Platform)
     }
     
-    val lg4j_version = "1.16.3"
-    val lg4j_beta_version = "1.16.3-beta26"
-    val awsSdkVersion = "2.46.12"
+    val lg4j_version = "1.16.2"
+    val lg4j_beta_version = "1.16.2-beta26"
+    val awsSdkVersion = "2.46.10"
     val retrofitVersion = "3.0.0"
     val sqliteVersion = "3.53.2.0"
     val dockerJavaVersion = "3.7.1"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,9 +7,9 @@ plugins {
     // Kotlin 2.2.20 matches the stdlib bundled in IntelliJ 2025.3, the minimum supported IDE.
     // Do NOT bump beyond the bundled stdlib of the lowest supported IDE line: the plugin runs
     // on the IDE-provided stdlib (see binaryIncompatibleRuntimeJarPatterns below).
-    kotlin("jvm") version "2.2.20"
-    kotlin("plugin.lombok") version "2.2.20"
-    kotlin("plugin.compose") version "2.2.20"
+    kotlin("jvm") version "2.4.0"
+    kotlin("plugin.lombok") version "2.4.0"
+    kotlin("plugin.compose") version "2.4.0"
     id("org.jetbrains.intellij.platform") version "2.13.1"
     jacoco
 }
@@ -262,9 +262,9 @@ dependencies {
         testFramework(TestFrameworkType.Platform)
     }
     
-    val lg4j_version = "1.16.2"
-    val lg4j_beta_version = "1.16.2-beta26"
-    val awsSdkVersion = "2.46.10"
+    val lg4j_version = "1.16.3"
+    val lg4j_beta_version = "1.16.3-beta26"
+    val awsSdkVersion = "2.46.12"
     val retrofitVersion = "3.0.0"
     val sqliteVersion = "3.53.2.0"
     val dockerJavaVersion = "3.7.1"

--- a/src/main/java/com/devoxx/genie/service/agent/AgentApprovalProvider.java
+++ b/src/main/java/com/devoxx/genie/service/agent/AgentApprovalProvider.java
@@ -1,8 +1,11 @@
 package com.devoxx.genie.service.agent;
 
 import com.intellij.openapi.project.Project;
+import dev.langchain4j.agent.tool.ToolExecutionRequest;
+import dev.langchain4j.invocation.InvocationContext;
 import dev.langchain4j.service.tool.AiServiceTool;
 import dev.langchain4j.agent.tool.ToolSpecification;
+import dev.langchain4j.service.tool.ToolExecutionResult;
 import dev.langchain4j.service.tool.ToolExecutor;
 import dev.langchain4j.service.tool.ToolProvider;
 import dev.langchain4j.service.tool.ToolProviderRequest;
@@ -51,26 +54,54 @@ public class AgentApprovalProvider implements ToolProvider {
             ToolSpecification spec = tool.toolSpecification();
             ToolExecutor original = tool.toolExecutor();
 
-            ToolExecutor approvalExecutor = (toolRequest, memoryId) -> {
-                boolean isReadOnly = READ_ONLY_TOOLS.contains(toolRequest.name());
-                boolean needsApproval = !(autoApproveReadOnly && isReadOnly);
-
-                if (needsApproval) {
-                    boolean approved = AgentApprovalService.requestApproval(
-                            project, toolRequest.name(), toolRequest.arguments());
-                    if (!approved) {
-                        log.debug("Agent tool execution denied: {}", toolRequest.name());
+            // Override executeWithContext (not just legacy execute) so skill-backed tools
+            // (e.g. activate_skill from langchain4j-skills, which throw from execute() with
+            // "executeWithContext must be called instead") keep working through this wrapper.
+            ToolExecutor approvalExecutor = new ToolExecutor() {
+                @Override
+                public String execute(ToolExecutionRequest toolRequest, Object memoryId) {
+                    if (isDenied(toolRequest)) {
                         return "Tool execution was denied by the user.";
                     }
+                    return original.execute(toolRequest, memoryId);
                 }
 
-                log.debug("Agent tool execution approved: {}", toolRequest.name());
-                return original.execute(toolRequest, memoryId);
+                @Override
+                public ToolExecutionResult executeWithContext(ToolExecutionRequest toolRequest, InvocationContext context) {
+                    if (isDenied(toolRequest)) {
+                        return ToolExecutionResult.builder()
+                                .resultText("Tool execution was denied by the user.")
+                                .build();
+                    }
+                    return original.executeWithContext(toolRequest, context);
+                }
             };
 
             builder.add(tool.toBuilder().toolExecutor(approvalExecutor).build());
         }
 
         return builder.build();
+    }
+
+    /**
+     * Determines whether the given tool request must be denied. Read-only tools may be
+     * auto-approved; everything else requires explicit user approval. Returns {@code true}
+     * when the user denied the request (so the caller should short-circuit).
+     */
+    private boolean isDenied(@NotNull ToolExecutionRequest toolRequest) {
+        boolean isReadOnly = READ_ONLY_TOOLS.contains(toolRequest.name());
+        boolean needsApproval = !(autoApproveReadOnly && isReadOnly);
+
+        if (needsApproval) {
+            boolean approved = AgentApprovalService.requestApproval(
+                    project, toolRequest.name(), toolRequest.arguments());
+            if (!approved) {
+                log.debug("Agent tool execution denied: {}", toolRequest.name());
+                return true;
+            }
+        }
+
+        log.debug("Agent tool execution approved: {}", toolRequest.name());
+        return false;
     }
 }

--- a/src/main/java/com/devoxx/genie/service/agent/AgentLoopTracker.java
+++ b/src/main/java/com/devoxx/genie/service/agent/AgentLoopTracker.java
@@ -7,8 +7,11 @@ import com.devoxx.genie.ui.settings.DevoxxGenieStateService;
 import com.devoxx.genie.ui.topic.AppTopics;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.project.Project;
+import dev.langchain4j.agent.tool.ToolExecutionRequest;
+import dev.langchain4j.invocation.InvocationContext;
 import dev.langchain4j.service.tool.AiServiceTool;
 import dev.langchain4j.agent.tool.ToolSpecification;
+import dev.langchain4j.service.tool.ToolExecutionResult;
 import dev.langchain4j.service.tool.ToolExecutor;
 import dev.langchain4j.service.tool.ToolProvider;
 import dev.langchain4j.service.tool.ToolProviderRequest;
@@ -65,40 +68,108 @@ public class AgentLoopTracker implements ToolProvider {
             ToolSpecification spec = tool.toolSpecification();
             ToolExecutor original = tool.toolExecutor();
 
-            ToolExecutor tracked = (toolRequest, memoryId) -> {
-                if (cancelled.get()) {
-                    String cancelMsg = "Execution cancelled by user. Stop calling tools and provide your best answer now.";
-                    log.debug("Tool call '{}' skipped — agent cancelled", toolRequest.name());
-                    return cancelMsg;
+            // Override executeWithContext (not just the legacy execute) so the new
+            // langchain4j tool contract is honoured. Some executors — notably the
+            // langchain4j-skills tools backing activate_skill — implement
+            // executeWithContext and deliberately throw from the legacy execute
+            // ("executeWithContext must be called instead"). Wrapping only execute()
+            // would break those tools, so we thread executeWithContext through the
+            // whole wrapper chain and keep execute() as a legacy fallback.
+            ToolExecutor tracked = new ToolExecutor() {
+                @Override
+                public String execute(ToolExecutionRequest toolRequest, Object memoryId) {
+                    return track(toolRequest,
+                            () -> original.execute(toolRequest, memoryId));
                 }
 
-                int count = callCount.incrementAndGet();
-                if (count > maxToolCalls) {
-                    String errorMsg = "Error: Agent loop limit reached (" + maxToolCalls
-                            + " tool calls). Provide your best answer with the information gathered so far.";
-                    publishLogEvent(AgentType.LOOP_LIMIT, toolRequest.name(), toolRequest.arguments(), errorMsg, count);
-                    return errorMsg;
+                @Override
+                public ToolExecutionResult executeWithContext(ToolExecutionRequest toolRequest, InvocationContext context) {
+                    // Short-circuit results (cancel / loop-limit) are returned as plain text.
+                    String[] shortCircuit = new String[1];
+                    ToolExecutionResult[] delegated = new ToolExecutionResult[1];
+                    String text = track(toolRequest, () -> {
+                        ToolExecutionResult result = original.executeWithContext(toolRequest, context);
+                        delegated[0] = result;
+                        return resultText(result);
+                    });
+                    // If the wrapper produced its own message (cancel/limit/error) instead of
+                    // delegating, wrap that text; otherwise pass the delegate result through
+                    // unchanged so non-text content is preserved.
+                    if (delegated[0] != null && text != null && text.equals(resultText(delegated[0]))) {
+                        return delegated[0];
+                    }
+                    return ToolExecutionResult.builder().resultText(text).build();
                 }
-
-                publishLogEvent(AgentType.TOOL_REQUEST, toolRequest.name(), toolRequest.arguments(), null, count);
-
-                String toolResult;
-                try {
-                    toolResult = original.execute(toolRequest, memoryId);
-                } catch (Exception e) {
-                    String errorResult = "Error: " + e.getMessage();
-                    publishLogEvent(AgentType.TOOL_ERROR, toolRequest.name(), toolRequest.arguments(), errorResult, count);
-                    return errorResult;
-                }
-
-                publishLogEvent(AgentType.TOOL_RESPONSE, toolRequest.name(), null, toolResult, count);
-                return toolResult;
             };
 
             builder.add(tool.toBuilder().toolExecutor(tracked).build());
         }
 
         return builder.build();
+    }
+
+    /**
+     * Shared tracking logic for both the legacy {@link ToolExecutor#execute} and the
+     * new {@link ToolExecutor#executeWithContext} paths. Enforces cancellation and the
+     * loop limit, publishes debug events and converts thrown exceptions into an error
+     * string so the LLM can wrap up gracefully.
+     *
+     * @param toolRequest the incoming tool request (for name/arguments)
+     * @param invoker     performs the actual delegated execution and returns its text result
+     * @return the tool result text, or a short-circuit / error message
+     */
+    private String track(@NotNull ToolExecutionRequest toolRequest, @NotNull ToolInvoker invoker) {
+        if (cancelled.get()) {
+            String cancelMsg = "Execution cancelled by user. Stop calling tools and provide your best answer now.";
+            log.debug("Tool call '{}' skipped — agent cancelled", toolRequest.name());
+            return cancelMsg;
+        }
+
+        int count = callCount.incrementAndGet();
+        if (count > maxToolCalls) {
+            String errorMsg = "Error: Agent loop limit reached (" + maxToolCalls
+                    + " tool calls). Provide your best answer with the information gathered so far.";
+            publishLogEvent(AgentType.LOOP_LIMIT, toolRequest.name(), toolRequest.arguments(), errorMsg, count);
+            return errorMsg;
+        }
+
+        publishLogEvent(AgentType.TOOL_REQUEST, toolRequest.name(), toolRequest.arguments(), null, count);
+
+        String toolResult;
+        try {
+            toolResult = invoker.invoke();
+        } catch (Exception e) {
+            String errorResult = "Error: " + e.getMessage();
+            publishLogEvent(AgentType.TOOL_ERROR, toolRequest.name(), toolRequest.arguments(), errorResult, count);
+            return errorResult;
+        }
+
+        publishLogEvent(AgentType.TOOL_RESPONSE, toolRequest.name(), null, toolResult, count);
+        return toolResult;
+    }
+
+    /**
+     * Safely extracts the text from a {@link ToolExecutionResult}. {@code resultText()}
+     * throws when the result is not a single text content (e.g. image content), so we
+     * fall back to {@code toString()} of the raw result in that case.
+     */
+    @Nullable
+    private static String resultText(@Nullable ToolExecutionResult result) {
+        if (result == null) {
+            return null;
+        }
+        try {
+            return result.resultText();
+        } catch (RuntimeException e) {
+            Object raw = result.result();
+            return raw != null ? raw.toString() : null;
+        }
+    }
+
+    /** Functional interface for the delegated tool execution inside {@link #track}. */
+    @FunctionalInterface
+    private interface ToolInvoker {
+        String invoke() throws Exception;
     }
 
     private void publishLogEvent(AgentType type, String toolName, String arguments, String result, int callNumber) {

--- a/src/main/java/com/devoxx/genie/service/mcp/ApprovalRequiredToolProvider.java
+++ b/src/main/java/com/devoxx/genie/service/mcp/ApprovalRequiredToolProvider.java
@@ -5,8 +5,11 @@ import com.intellij.openapi.project.Project;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import dev.langchain4j.agent.tool.ToolExecutionRequest;
 import dev.langchain4j.agent.tool.ToolSpecification;
+import dev.langchain4j.invocation.InvocationContext;
 import dev.langchain4j.service.tool.AiServiceTool;
+import dev.langchain4j.service.tool.ToolExecutionResult;
 import dev.langchain4j.service.tool.ToolExecutor;
 import dev.langchain4j.service.tool.ToolProvider;
 import dev.langchain4j.service.tool.ToolProviderRequest;
@@ -46,19 +49,27 @@ public class ApprovalRequiredToolProvider implements ToolProvider {
             ToolSpecification spec = tool.toolSpecification();
             ToolExecutor originalExecutor = tool.toolExecutor();
 
-            // Wrap the original executor
-            ToolExecutor approvalExecutor = (toolExecutionRequest, memoryId) -> {
-                boolean approved = approvalChecker.requestApproval(
-                        project,
-                        toolExecutionRequest.name(),
-                        toolExecutionRequest.arguments()
-                );
-                if (approved) {
-                    MCPService.logDebug("MCP tool execution approved: " + toolExecutionRequest.name());
-                    return originalExecutor.execute(toolExecutionRequest, memoryId);
-                } else {
-                    MCPService.logDebug("MCP tool execution denied: " + toolExecutionRequest.name());
+            // Wrap the original executor. We override executeWithContext (not just the
+            // legacy execute) so tools that require the new contract — e.g. skill-backed
+            // tools that throw "executeWithContext must be called instead" from execute() —
+            // continue to work through this approval wrapper.
+            ToolExecutor approvalExecutor = new ToolExecutor() {
+                @Override
+                public String execute(ToolExecutionRequest toolExecutionRequest, Object memoryId) {
+                    if (isApproved(toolExecutionRequest)) {
+                        return originalExecutor.execute(toolExecutionRequest, memoryId);
+                    }
                     return "Tool execution was denied by the user.";
+                }
+
+                @Override
+                public ToolExecutionResult executeWithContext(ToolExecutionRequest toolExecutionRequest, InvocationContext context) {
+                    if (isApproved(toolExecutionRequest)) {
+                        return originalExecutor.executeWithContext(toolExecutionRequest, context);
+                    }
+                    return ToolExecutionResult.builder()
+                            .resultText("Tool execution was denied by the user.")
+                            .build();
                 }
             };
 
@@ -66,5 +77,23 @@ public class ApprovalRequiredToolProvider implements ToolProvider {
         }
 
         return builder.build();
+    }
+
+    /**
+     * Asks the user (via {@link ApprovalChecker}) whether the given MCP tool call may run.
+     * Logs the outcome and returns {@code true} when approved.
+     */
+    private boolean isApproved(@NotNull ToolExecutionRequest toolExecutionRequest) {
+        boolean approved = approvalChecker.requestApproval(
+                project,
+                toolExecutionRequest.name(),
+                toolExecutionRequest.arguments()
+        );
+        if (approved) {
+            MCPService.logDebug("MCP tool execution approved: " + toolExecutionRequest.name());
+        } else {
+            MCPService.logDebug("MCP tool execution denied: " + toolExecutionRequest.name());
+        }
+        return approved;
     }
 }

--- a/src/main/java/com/devoxx/genie/service/mcp/InstrumentedMcpToolProvider.java
+++ b/src/main/java/com/devoxx/genie/service/mcp/InstrumentedMcpToolProvider.java
@@ -1,7 +1,10 @@
 package com.devoxx.genie.service.mcp;
 
+import dev.langchain4j.agent.tool.ToolExecutionRequest;
+import dev.langchain4j.invocation.InvocationContext;
 import dev.langchain4j.service.tool.AiServiceTool;
 import dev.langchain4j.agent.tool.ToolSpecification;
+import dev.langchain4j.service.tool.ToolExecutionResult;
 import dev.langchain4j.service.tool.ToolExecutor;
 import dev.langchain4j.service.tool.ToolProvider;
 import dev.langchain4j.service.tool.ToolProviderRequest;
@@ -46,11 +49,25 @@ public class InstrumentedMcpToolProvider implements ToolProvider {
             ToolSpecification spec = tool.toolSpecification();
             ToolExecutor originalExecutor = tool.toolExecutor();
 
-            ToolExecutor countingExecutor = (toolRequest, memoryId) -> {
-                String result = originalExecutor.execute(toolRequest, memoryId);
-                // Increment AFTER successful execution so failures don't inflate usage counts.
-                counter.incrementAndGet();
-                return result;
+            // Override executeWithContext (not just legacy execute) so tools requiring the
+            // new contract (e.g. skill-backed tools that throw "executeWithContext must be
+            // called instead" from execute()) keep working while still being counted.
+            ToolExecutor countingExecutor = new ToolExecutor() {
+                @Override
+                public String execute(ToolExecutionRequest toolRequest, Object memoryId) {
+                    String result = originalExecutor.execute(toolRequest, memoryId);
+                    // Increment AFTER successful execution so failures don't inflate usage counts.
+                    counter.incrementAndGet();
+                    return result;
+                }
+
+                @Override
+                public ToolExecutionResult executeWithContext(ToolExecutionRequest toolRequest, InvocationContext context) {
+                    ToolExecutionResult result = originalExecutor.executeWithContext(toolRequest, context);
+                    // Increment AFTER successful execution so failures don't inflate usage counts.
+                    counter.incrementAndGet();
+                    return result;
+                }
             };
 
             builder.add(tool.toBuilder().toolExecutor(countingExecutor).build());

--- a/src/main/java/com/devoxx/genie/util/SafeJacksonJsonCodecFactory.java
+++ b/src/main/java/com/devoxx/genie/util/SafeJacksonJsonCodecFactory.java
@@ -1,0 +1,147 @@
+package com.devoxx.genie.util;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.PropertyAccessor;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.MapperFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+
+import dev.langchain4j.internal.Json;
+import dev.langchain4j.spi.json.JsonCodecFactory;
+
+import java.io.IOException;
+import java.lang.reflect.Type;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.TemporalAccessor;
+import java.util.function.Function;
+
+/**
+ * Custom langchain4j {@link JsonCodecFactory} that prevents the
+ * {@code ServiceConfigurationError: com.fasterxml.jackson.databind.Module:
+ * com.fasterxml.jackson.module.kotlin.KotlinModule not a subtype} crash that
+ * occurs during streaming inside the IntelliJ Platform.
+ *
+ * <h3>Root cause</h3>
+ * langchain4j's default {@code dev.langchain4j.internal.JacksonJsonCodec} builds
+ * its {@code ObjectMapper} via {@code ObjectMapper.findAndRegisterModules()},
+ * which runs a {@link java.util.ServiceLoader} scan for every Jackson
+ * {@code Module} provider visible to the thread-context classloader. Inside
+ * IntelliJ that scan discovers the IDE platform's {@code jackson-module-kotlin}
+ * provider. Because this plugin bundles and loads its <b>own</b> copy of
+ * {@code jackson-databind}, the {@code KotlinModule} (loaded by the platform
+ * classloader, linked against the platform's {@code jackson-databind}) is not an
+ * {@code instanceof} the {@code Module} type from the plugin's
+ * {@code jackson-databind}. {@code ServiceLoader} then throws the
+ * "not a subtype" error.
+ *
+ * <h3>Fix</h3>
+ * This factory is registered via SPI in
+ * {@code META-INF/services/dev.langchain4j.spi.json.JsonCodecFactory}. When a
+ * factory is present, langchain4j's {@code Json#loadCodec()} uses it instead of
+ * constructing the default {@code new JacksonJsonCodec()}, so
+ * {@code findAndRegisterModules()} is never invoked. We build an equivalent
+ * {@code ObjectMapper} ourselves, registering only the modules we control.
+ *
+ * <p>{@code dev.langchain4j.internal.JacksonJsonCodec} is package-private, so we
+ * cannot reuse it directly. Instead we provide an equivalent {@link Json.JsonCodec}
+ * implementation ({@link SafeJacksonJsonCodec}) whose {@code ObjectMapper}
+ * configuration (visibility, (de)serialization features and the ISO-8601
+ * {@code java.time} (de)serializers) mirrors langchain4j's own
+ * {@code JacksonJsonCodec#createObjectMapper()}, so the behaviour of
+ * {@code dev.langchain4j.internal.Json} stays identical &mdash; only the
+ * cross-classloader {@code ServiceLoader} scan is removed.</p>
+ */
+public class SafeJacksonJsonCodecFactory implements JsonCodecFactory {
+
+    @Override
+    public Json.JsonCodec create() {
+        return new SafeJacksonJsonCodec(createObjectMapper());
+    }
+
+    private static ObjectMapper createObjectMapper() {
+        SimpleModule javaTimeModule = new SimpleModule("devoxxgenie-langchain4j-time");
+
+        javaTimeModule.addSerializer(LocalDate.class, isoSerializer(DateTimeFormatter.ISO_LOCAL_DATE));
+        javaTimeModule.addDeserializer(LocalDate.class, deserializer(LocalDate::parse));
+
+        javaTimeModule.addSerializer(LocalTime.class, isoSerializer(DateTimeFormatter.ISO_LOCAL_TIME));
+        javaTimeModule.addDeserializer(LocalTime.class, deserializer(LocalTime::parse));
+
+        javaTimeModule.addSerializer(LocalDateTime.class, isoSerializer(DateTimeFormatter.ISO_LOCAL_DATE_TIME));
+        javaTimeModule.addDeserializer(LocalDateTime.class, deserializer(LocalDateTime::parse));
+
+        return JsonMapper.builder()
+                .visibility(PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY)
+                .disable(SerializationFeature.INDENT_OUTPUT)
+                .enable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+                .enable(MapperFeature.ACCEPT_CASE_INSENSITIVE_ENUMS)
+                .addModule(javaTimeModule)
+                .build();
+    }
+
+    private static <T extends TemporalAccessor> JsonSerializer<T> isoSerializer(DateTimeFormatter formatter) {
+        return new JsonSerializer<>() {
+            @Override
+            public void serialize(T value, JsonGenerator gen, SerializerProvider serializers) throws IOException {
+                gen.writeString(formatter.format(value));
+            }
+        };
+    }
+
+    private static <T> JsonDeserializer<T> deserializer(Function<String, T> parser) {
+        return new JsonDeserializer<>() {
+            @Override
+            public T deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
+                return parser.apply(p.getValueAsString());
+            }
+        };
+    }
+
+    /**
+     * Equivalent of langchain4j's package-private {@code JacksonJsonCodec}: a thin
+     * wrapper that delegates to a pre-built {@link ObjectMapper}, wrapping checked
+     * Jackson exceptions in {@link RuntimeException} exactly as langchain4j does.
+     */
+    private record SafeJacksonJsonCodec(ObjectMapper objectMapper) implements Json.JsonCodec {
+
+        @Override
+        public String toJson(Object o) {
+            try {
+                return objectMapper.writeValueAsString(o);
+            } catch (JsonProcessingException e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        @Override
+        public <T> T fromJson(String json, Class<T> type) {
+            try {
+                return objectMapper.readValue(json, type);
+            } catch (JsonProcessingException e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        @Override
+        public <T> T fromJson(String json, Type type) {
+            try {
+                return objectMapper.readValue(json, objectMapper.constructType(type));
+            } catch (JsonProcessingException e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+}

--- a/src/main/resources/META-INF/services/dev.langchain4j.spi.json.JsonCodecFactory
+++ b/src/main/resources/META-INF/services/dev.langchain4j.spi.json.JsonCodecFactory
@@ -1,0 +1,1 @@
+com.devoxx.genie.util.SafeJacksonJsonCodecFactory

--- a/src/test/java/com/devoxx/genie/service/agent/AgentApprovalProviderTest.java
+++ b/src/test/java/com/devoxx/genie/service/agent/AgentApprovalProviderTest.java
@@ -211,6 +211,78 @@ class AgentApprovalProviderTest {
         }
     }
 
+    @Test
+    void executeWithContext_readOnlyTool_autoApproved() {
+        // Read-only tool through the new executeWithContext path: must delegate
+        // without consulting AgentApprovalService.
+        ToolExecutor ctxExecutor = new ToolExecutor() {
+            @Override
+            public String execute(ToolExecutionRequest req, Object id) {
+                return "legacy";
+            }
+
+            @Override
+            public dev.langchain4j.service.tool.ToolExecutionResult executeWithContext(
+                    ToolExecutionRequest req, dev.langchain4j.invocation.InvocationContext ctx) {
+                return dev.langchain4j.service.tool.ToolExecutionResult.builder()
+                        .resultText("ctx: " + req.name()).build();
+            }
+        };
+        ToolProvider ctxDelegate = req -> ToolProviderResult.builder()
+                .add(readFileSpec, ctxExecutor).build();
+
+        try (MockedStatic<ApplicationManager> appMock = mockStatic(ApplicationManager.class);
+             MockedStatic<AgentApprovalService> agentApprovalMock = mockStatic(AgentApprovalService.class)) {
+            appMock.when(ApplicationManager::getApplication).thenReturn(application);
+
+            AgentApprovalProvider approvalProvider = new AgentApprovalProvider(ctxDelegate, project, true);
+            ToolExecutor readExecutor =
+                    approvalProvider.provideTools(providerRequest).toolExecutorByName("read_file");
+
+            dev.langchain4j.service.tool.ToolExecutionResult output =
+                    readExecutor.executeWithContext(createExecRequest("read_file"), null);
+
+            assertThat(output.resultText()).isEqualTo("ctx: read_file");
+            agentApprovalMock.verifyNoInteractions();
+        }
+    }
+
+    @Test
+    void executeWithContext_writeToolDenied_returnsDenialMessage() {
+        // Skill-style executor: execute() throws, only executeWithContext is valid.
+        ToolExecutor ctxExecutor = new ToolExecutor() {
+            @Override
+            public String execute(ToolExecutionRequest req, Object id) {
+                throw new IllegalStateException("executeWithContext must be called instead");
+            }
+
+            @Override
+            public dev.langchain4j.service.tool.ToolExecutionResult executeWithContext(
+                    ToolExecutionRequest req, dev.langchain4j.invocation.InvocationContext ctx) {
+                return dev.langchain4j.service.tool.ToolExecutionResult.builder()
+                        .resultText("should not run").build();
+            }
+        };
+        ToolProvider ctxDelegate = req -> ToolProviderResult.builder()
+                .add(writeFileSpec, ctxExecutor).build();
+
+        try (MockedStatic<ApplicationManager> appMock = mockStatic(ApplicationManager.class);
+             MockedStatic<AgentApprovalService> agentApprovalMock = mockStatic(AgentApprovalService.class)) {
+            appMock.when(ApplicationManager::getApplication).thenReturn(application);
+            agentApprovalMock.when(() -> AgentApprovalService.requestApproval(
+                    eq(project), eq("write_file"), anyString())).thenReturn(false);
+
+            AgentApprovalProvider approvalProvider = new AgentApprovalProvider(ctxDelegate, project, true);
+            ToolExecutor writeExecutor =
+                    approvalProvider.provideTools(providerRequest).toolExecutorByName("write_file");
+
+            dev.langchain4j.service.tool.ToolExecutionResult output =
+                    writeExecutor.executeWithContext(createExecRequest("write_file"), null);
+
+            assertThat(output.resultText()).isEqualTo("Tool execution was denied by the user.");
+        }
+    }
+
     private ToolSpecification createSpec(String name) {
         return ToolSpecification.builder()
                 .name(name)

--- a/src/test/java/com/devoxx/genie/service/agent/AgentLoopTrackerTest.java
+++ b/src/test/java/com/devoxx/genie/service/agent/AgentLoopTrackerTest.java
@@ -3,10 +3,12 @@ package com.devoxx.genie.service.agent;
 import dev.langchain4j.agent.tool.ToolExecutionRequest;
 import dev.langchain4j.agent.tool.ToolSpecification;
 import dev.langchain4j.model.chat.request.json.JsonObjectSchema;
+import dev.langchain4j.service.tool.ToolExecutionResult;
 import dev.langchain4j.service.tool.ToolExecutor;
 import dev.langchain4j.service.tool.ToolProvider;
 import dev.langchain4j.service.tool.ToolProviderRequest;
 import dev.langchain4j.service.tool.ToolProviderResult;
+import dev.langchain4j.invocation.InvocationContext;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -101,6 +103,93 @@ class AgentLoopTrackerTest {
 
         tracker.reset();
         assertThat(tracker.getCallCount()).isEqualTo(0);
+    }
+
+    @Test
+    void executeWithContext_delegatesAndCounts() {
+        ToolSpecification spec = createSpec("test_tool");
+        ToolExecutor original = new ToolExecutor() {
+            @Override
+            public String execute(ToolExecutionRequest req, Object id) {
+                return "legacy";
+            }
+
+            @Override
+            public ToolExecutionResult executeWithContext(ToolExecutionRequest req, InvocationContext ctx) {
+                return ToolExecutionResult.builder().resultText("ctx-success").build();
+            }
+        };
+        ToolProvider delegate = req -> ToolProviderResult.builder().add(spec, original).build();
+
+        AgentLoopTracker tracker = new AgentLoopTracker(delegate, 3);
+        ToolProviderResult result = tracker.provideTools(providerRequest);
+        ToolExecutor trackedExecutor = result.tools().values().iterator().next();
+
+        ToolExecutionResult execResult =
+                trackedExecutor.executeWithContext(createExecRequest("test_tool"), null);
+
+        assertThat(execResult.resultText()).isEqualTo("ctx-success");
+        assertThat(tracker.getCallCount()).isEqualTo(1);
+    }
+
+    /**
+     * Reproduces the langchain4j-skills contract where the legacy {@code execute} throws
+     * "executeWithContext must be called instead". The tracker must route through
+     * executeWithContext so such tools keep working instead of surfacing the exception
+     * as an "Error: ..." tool result.
+     */
+    @Test
+    void executeWithContext_worksForExecuteThrowingTool() {
+        ToolSpecification spec = createSpec("skill_tool");
+        ToolExecutor skillStyle = new ToolExecutor() {
+            @Override
+            public String execute(ToolExecutionRequest req, Object id) {
+                throw new IllegalStateException("executeWithContext must be called instead");
+            }
+
+            @Override
+            public ToolExecutionResult executeWithContext(ToolExecutionRequest req, InvocationContext ctx) {
+                return ToolExecutionResult.builder().resultText("skill-ok").build();
+            }
+        };
+        ToolProvider delegate = req -> ToolProviderResult.builder().add(spec, skillStyle).build();
+
+        AgentLoopTracker tracker = new AgentLoopTracker(delegate, 3);
+        ToolExecutor trackedExecutor =
+                tracker.provideTools(providerRequest).tools().values().iterator().next();
+
+        ToolExecutionResult execResult =
+                trackedExecutor.executeWithContext(createExecRequest("skill_tool"), null);
+
+        assertThat(execResult.resultText()).isEqualTo("skill-ok");
+        assertThat(tracker.getCallCount()).isEqualTo(1);
+    }
+
+    @Test
+    void executeWithContext_exceedingLimit_returnsErrorText() {
+        ToolSpecification spec = createSpec("test_tool");
+        ToolExecutor original = new ToolExecutor() {
+            @Override
+            public String execute(ToolExecutionRequest req, Object id) {
+                return "success";
+            }
+
+            @Override
+            public ToolExecutionResult executeWithContext(ToolExecutionRequest req, InvocationContext ctx) {
+                return ToolExecutionResult.builder().resultText("success").build();
+            }
+        };
+        ToolProvider delegate = req -> ToolProviderResult.builder().add(spec, original).build();
+
+        AgentLoopTracker tracker = new AgentLoopTracker(delegate, 1);
+        ToolExecutor trackedExecutor =
+                tracker.provideTools(providerRequest).tools().values().iterator().next();
+
+        trackedExecutor.executeWithContext(createExecRequest("test_tool"), null); // 1
+        ToolExecutionResult overLimit =
+                trackedExecutor.executeWithContext(createExecRequest("test_tool"), null); // 2 > limit
+
+        assertThat(overLimit.resultText()).contains("Agent loop limit reached");
     }
 
     private ToolSpecification createSpec(String name) {

--- a/src/test/java/com/devoxx/genie/service/mcp/ApprovalRequiredToolProviderTest.java
+++ b/src/test/java/com/devoxx/genie/service/mcp/ApprovalRequiredToolProviderTest.java
@@ -242,6 +242,73 @@ class ApprovalRequiredToolProviderTest {
         verify(checker).requestApproval(null, "tool_a", "{}");
     }
 
+    @Test
+    void provideTools_approvalGranted_callsOriginalExecutorWithContext() {
+        ToolSpecification spec = toolSpec("read_file");
+        ToolExecutor original = new dev.langchain4j.service.tool.ToolExecutor() {
+            @Override
+            public String execute(ToolExecutionRequest req, Object id) {
+                return "legacy";
+            }
+
+            @Override
+            public dev.langchain4j.service.tool.ToolExecutionResult executeWithContext(
+                    ToolExecutionRequest req, dev.langchain4j.invocation.InvocationContext ctx) {
+                return dev.langchain4j.service.tool.ToolExecutionResult.builder()
+                        .resultText("file contents").build();
+            }
+        };
+        ToolProviderResult delegateResult = buildResult(Map.of(spec, original));
+        when(delegate.provideTools(request)).thenReturn(delegateResult);
+
+        ApprovalRequiredToolProvider provider = new ApprovalRequiredToolProvider(
+                delegate, project, (p, name, args) -> true
+        );
+
+        ToolExecutor wrappedExecutor = provider.provideTools(request).tools().values().iterator().next();
+        ToolExecutionRequest toolRequest = ToolExecutionRequest.builder()
+                .name("read_file").arguments("{}").build();
+
+        dev.langchain4j.service.tool.ToolExecutionResult result =
+                wrappedExecutor.executeWithContext(toolRequest, null);
+
+        assertThat(result.resultText()).isEqualTo("file contents");
+    }
+
+    @Test
+    void provideTools_approvalDenied_returnsDeniedMessageForContext() {
+        ToolSpecification spec = toolSpec("delete_file");
+        // execute() throws to mimic skill-style tools; only executeWithContext is valid.
+        ToolExecutor original = new dev.langchain4j.service.tool.ToolExecutor() {
+            @Override
+            public String execute(ToolExecutionRequest req, Object id) {
+                throw new IllegalStateException("executeWithContext must be called instead");
+            }
+
+            @Override
+            public dev.langchain4j.service.tool.ToolExecutionResult executeWithContext(
+                    ToolExecutionRequest req, dev.langchain4j.invocation.InvocationContext ctx) {
+                return dev.langchain4j.service.tool.ToolExecutionResult.builder()
+                        .resultText("should not run").build();
+            }
+        };
+        ToolProviderResult delegateResult = buildResult(Map.of(spec, original));
+        when(delegate.provideTools(request)).thenReturn(delegateResult);
+
+        ApprovalRequiredToolProvider provider = new ApprovalRequiredToolProvider(
+                delegate, project, (p, name, args) -> false
+        );
+
+        ToolExecutor wrappedExecutor = provider.provideTools(request).tools().values().iterator().next();
+        ToolExecutionRequest toolRequest = ToolExecutionRequest.builder()
+                .name("delete_file").arguments("{}").build();
+
+        dev.langchain4j.service.tool.ToolExecutionResult result =
+                wrappedExecutor.executeWithContext(toolRequest, null);
+
+        assertThat(result.resultText()).isEqualTo("Tool execution was denied by the user.");
+    }
+
     // -- Helpers --
 
     private static ToolSpecification toolSpec(String name) {

--- a/src/test/java/com/devoxx/genie/service/mcp/InstrumentedMcpToolProviderTest.java
+++ b/src/test/java/com/devoxx/genie/service/mcp/InstrumentedMcpToolProviderTest.java
@@ -3,10 +3,12 @@ package com.devoxx.genie.service.mcp;
 import dev.langchain4j.agent.tool.ToolExecutionRequest;
 import dev.langchain4j.agent.tool.ToolSpecification;
 import dev.langchain4j.data.message.UserMessage;
+import dev.langchain4j.service.tool.ToolExecutionResult;
 import dev.langchain4j.service.tool.ToolExecutor;
 import dev.langchain4j.service.tool.ToolProvider;
 import dev.langchain4j.service.tool.ToolProviderRequest;
 import dev.langchain4j.service.tool.ToolProviderResult;
+import dev.langchain4j.invocation.InvocationContext;
 import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.atomic.AtomicInteger;
@@ -78,6 +80,89 @@ class InstrumentedMcpToolProviderTest {
         ToolProviderResult result = instrumented.provideTools(new ToolProviderRequest("test", UserMessage.from("hi")));
 
         assertThat(result.tools()).isEmpty();
+        assertThat(counter.get()).isZero();
+    }
+
+    @Test
+    void executeWithContextIncrementsCounter() {
+        AtomicInteger counter = new AtomicInteger(0);
+        ToolExecutor original = new ToolExecutor() {
+            @Override
+            public String execute(ToolExecutionRequest req, Object mem) {
+                return "legacy";
+            }
+
+            @Override
+            public ToolExecutionResult executeWithContext(ToolExecutionRequest req, InvocationContext ctx) {
+                return ToolExecutionResult.builder().resultText("ctx-result").build();
+            }
+        };
+        ToolProvider delegate = fakeProvider(original);
+
+        InstrumentedMcpToolProvider instrumented = new InstrumentedMcpToolProvider(delegate, counter);
+        ToolExecutor executor = instrumented
+                .provideTools(new ToolProviderRequest("test", UserMessage.from("hi")))
+                .tools().values().iterator().next();
+
+        ToolExecutionResult result = executor.executeWithContext(dummyRequest(), null);
+
+        assertThat(result.resultText()).isEqualTo("ctx-result");
+        assertThat(counter.get()).isEqualTo(1);
+    }
+
+    /**
+     * Mirrors the langchain4j-skills contract: legacy execute() throws, only
+     * executeWithContext works. The counting wrapper must route through it.
+     */
+    @Test
+    void executeWithContextWorksForExecuteThrowingTool() {
+        AtomicInteger counter = new AtomicInteger(0);
+        ToolExecutor skillStyle = new ToolExecutor() {
+            @Override
+            public String execute(ToolExecutionRequest req, Object mem) {
+                throw new IllegalStateException("executeWithContext must be called instead");
+            }
+
+            @Override
+            public ToolExecutionResult executeWithContext(ToolExecutionRequest req, InvocationContext ctx) {
+                return ToolExecutionResult.builder().resultText("skill-ok").build();
+            }
+        };
+
+        InstrumentedMcpToolProvider instrumented = new InstrumentedMcpToolProvider(fakeProvider(skillStyle), counter);
+        ToolExecutor executor = instrumented
+                .provideTools(new ToolProviderRequest("test", UserMessage.from("hi")))
+                .tools().values().iterator().next();
+
+        ToolExecutionResult result = executor.executeWithContext(dummyRequest(), null);
+
+        assertThat(result.resultText()).isEqualTo("skill-ok");
+        assertThat(counter.get()).isEqualTo(1);
+    }
+
+    @Test
+    void failedExecuteWithContextDoesNotIncrementCounter() {
+        AtomicInteger counter = new AtomicInteger(0);
+        ToolExecutor failing = new ToolExecutor() {
+            @Override
+            public String execute(ToolExecutionRequest req, Object mem) {
+                return "unused";
+            }
+
+            @Override
+            public ToolExecutionResult executeWithContext(ToolExecutionRequest req, InvocationContext ctx) {
+                throw new RuntimeException("MCP server unreachable");
+            }
+        };
+
+        InstrumentedMcpToolProvider instrumented = new InstrumentedMcpToolProvider(fakeProvider(failing), counter);
+        ToolExecutor executor = instrumented
+                .provideTools(new ToolProviderRequest("test", UserMessage.from("hi")))
+                .tools().values().iterator().next();
+
+        assertThatThrownBy(() -> executor.executeWithContext(dummyRequest(), null))
+                .isInstanceOf(RuntimeException.class);
+
         assertThat(counter.get()).isZero();
     }
 


### PR DESCRIPTION
# Pull Request

## 📚 Documentation

Before submitting, please review our [Contributing Guide](https://genie.devoxx.com/docs/contributing).

## Description

Skill-backed tools (e.g. `activate_skill` from `langchain4j-skills`) failed at runtime with `IllegalStateException: executeWithContext must be called instead`.

In langchain4j 1.16.2 the `ToolExecutor` interface gained a new context-aware method `executeWithContext(ToolExecutionRequest, InvocationContext)`. The base class for skill executors, `dev.langchain4j.skills.AbstractSkillToolExecutor`, deliberately overrides the legacy `execute(request, memoryId)` so that it immediately throws `IllegalStateException("executeWithContext must be called instead")`, expecting the runtime to call `executeWithContext` instead.

All DevoxxGenie tool-provider wrappers were implemented as `(request, memoryId) -> ...` lambdas, i.e. they overrode **only** the legacy `execute(...)` and internally called `original.execute(...)`. When the wrapped executor is a skill executor, that legacy `execute(...)` throws immediately, and the error surfaced to the model as `"Error: executeWithContext must be called instead"`.

This PR replaces those lambdas with anonymous `ToolExecutor` classes that override both `execute(...)` (legacy fallback) and `executeWithContext(...)` (new contract), each delegating to the matching method on the wrapped executor. The invocation context is now threaded through the entire wrapper chain, so skill tools work.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Code refactoring
- [ ] Performance improvement
- [x] Test addition/improvement

## Related Issue

<!-- Link to the issue this PR addresses -->
Fixes #
Closes #
Related to #

## Changes Made

- **`AgentLoopTracker`** — extracted the shared tracking logic (cancellation / loop-limit / event publishing / exception handling) into a private `track(...)` helper plus a `ToolInvoker` functional interface, and implemented **both** `execute` and `executeWithContext`. Added a `resultText(...)` helper that safely extracts text from a `ToolExecutionResult` (falling back to `toString()` for non-text content such as images); the delegate result is passed through unchanged unless the wrapper substituted its own cancel/limit/error message.
- **`AgentApprovalProvider`** — extracted approval logic into `isDenied(...)` and implemented both executor methods; on user denial returns `"Tool execution was denied by the user."`.
- **`ApprovalRequiredToolProvider`** (MCP) — extracted approval logic into `isApproved(...)` and implemented both executor methods.
- **`InstrumentedMcpToolProvider`** (MCP) — incremented the usage counter after successful execution in both methods (failures don't inflate counts).
- **`SafeJacksonJsonCodecFactory`** (+ SPI) — stopped relying on the package-private `dev.langchain4j.internal.JacksonJsonCodec`; added an equivalent `Json.JsonCodec` (`record SafeJacksonJsonCodec`) wrapping a self-built `ObjectMapper` whose configuration mirrors langchain4j's own, and registered it via `META-INF/services/dev.langchain4j.spi.json.JsonCodecFactory`.
- Added unit tests covering the `executeWithContext` path (including a skill-style executor that throws from legacy `execute`), approval/denial, call counting, and cancel/loop-limit handling.

## Testing

**How has this been tested?**

- [x] Unit tests
- [ ] Integration tests
- [x] Manual testing in IntelliJ IDEA
- [ ] Tested with local LLM (Ollama/LMStudio/GPT4All)
- [x] Tested with cloud LLM (OpenAI/Anthropic/Gemini)
- [x] Tested with MCP servers
- [ ] Tested with RAG enabled

**Test Configuration:**
- IntelliJ IDEA version: 2024.3+
- JDK version: 21 (Amazon Corretto 21.0.7)
- OS: macOS

Notes: `compileJava` / `compileTestJava` succeed; all affected tests pass (including the new `executeWithContext` cases); `buildPlugin` is BUILD SUCCESSFUL. The built plugin was installed locally and `activate_skill` now works without the error.

## Documentation

- [ ] I have updated the documentation at [genie.devoxx.com](https://genie.devoxx.com) if needed
- [ ] I have updated CLAUDE.md if architecture/patterns changed
- [x] I have added/updated code comments for complex logic
- [ ] I have updated the README.md if needed

## Checklist

- [x] My code follows the existing code style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Screenshots/Videos (if applicable)

<!-- Add screenshots or videos demonstrating the changes, especially for UI changes -->

## Additional Notes

The fix is required because `langchain4j-skills` (beta) already adopted the new `executeWithContext` contract while the wrapper chain still spoke only the legacy `execute` API. Regular built-in and MCP tools keep working through the legacy `execute` fallback, which is retained in every wrapper.

## Breaking Changes

None. The legacy `execute(...)` path is preserved as a fallback in every wrapper, so existing tools are unaffected.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the project's license.

---

Want me to produce the same template-formatted description for the **MCP env-variable fix** as well (once that one is implemented)?