### PR TITLE
mcp test now uses user-entered environment variables

### DIFF
--- a/src/main/java/com/devoxx/genie/ui/settings/mcp/dialog/MCPServerDialog.java
+++ b/src/main/java/com/devoxx/genie/ui/settings/mcp/dialog/MCPServerDialog.java
@@ -283,6 +283,10 @@ public class MCPServerDialog extends DialogWrapper {
 
         // Capture field values on EDT before background work
         String serverName = nameField.getText().trim();
+        // Capture the user-entered environment variables on the EDT so they can be
+        // passed to STDIO transports during the connection test (fixes MCP creation
+        // failing when env vars such as API tokens are required).
+        final Map<String, String> envForConnection = envVarTableModel.getEnvVars();
 
         // Use single-element arrays to pass results out of the background runnable
         final MCPServer[] result = {null};
@@ -300,7 +304,7 @@ public class MCPServerDialog extends DialogWrapper {
                     indicator.setText("Connecting to MCP server...");
                     indicator.setIndeterminate(true);
                     Map<String, String> headers = existingServerSupport.headersForConnection(existingServer);
-                    mcpClient = panel.createClient(headers);
+                    mcpClient = panel.createClient(headers, envForConnection);
 
                     indicator.checkCanceled();
 

--- a/src/main/java/com/devoxx/genie/ui/settings/mcp/dialog/transport/StdioTransportPanel.java
+++ b/src/main/java/com/devoxx/genie/ui/settings/mcp/dialog/transport/StdioTransportPanel.java
@@ -146,6 +146,17 @@ public class StdioTransportPanel implements TransportPanel {
 
     @Override
     public McpClient createClient() throws Exception {
+        return createClient(java.util.Collections.emptyMap(), java.util.Collections.emptyMap());
+    }
+
+    @Override
+    public McpClient createClient(Map<String, String> headers) throws Exception {
+        // STDIO transport ignores HTTP headers; keep behaviour but without custom env.
+        return createClient(headers, java.util.Collections.emptyMap());
+    }
+
+    @Override
+    public McpClient createClient(Map<String, String> headers, Map<String, String> customEnv) throws Exception {
         // Parse arguments and create command list
         List<String> args = parseArguments();
         List<String> mcpCommand = buildCommand(args);
@@ -158,8 +169,11 @@ public class StdioTransportPanel implements TransportPanel {
             throw new Exception("Command not found: " + commandField.getText().trim());
         }
         
-        // Create the transport and connect to the server
-        Map<String, String> env = createEnvironmentMap();
+        // Create the transport and connect to the server.
+        // Merge the user-supplied environment variables (e.g. API tokens) on
+        // top of the inherited system environment so the connection test runs
+        // with the same environment as the configured server would at runtime.
+        Map<String, String> env = createEnvironmentMap(customEnv);
         StdioMcpTransport transport = new StdioMcpTransport.Builder()
                 .command(mcpCommand)
                 .environment(env)
@@ -212,7 +226,7 @@ public class StdioTransportPanel implements TransportPanel {
      * Creates environment map with PATH updated to include command directory
      * @return Environment variables map
      */
-    private @NotNull Map<String, String> createEnvironmentMap() {
+    private @NotNull Map<String, String> createEnvironmentMap(Map<String, String> customEnv) {
         Map<String, String> env = new HashMap<>(System.getenv());
         String command = commandField.getText().trim();
         int lastSeparatorIndex = command.lastIndexOf(File.separator);
@@ -220,6 +234,13 @@ public class StdioTransportPanel implements TransportPanel {
         if (lastSeparatorIndex > 0) {
             String directoryPath = command.substring(0, lastSeparatorIndex);
             env.put("PATH", directoryPath + File.pathSeparator + env.getOrDefault("PATH", ""));
+        }
+
+        // Apply user-supplied environment variables last so they take
+        // precedence, mirroring MCPExecutionService#initStdioClient.
+        if (customEnv != null && !customEnv.isEmpty()) {
+            env.putAll(customEnv);
+            log.debug("Added {} custom environment variable(s) for connection test", customEnv.size());
         }
         
         return env;

--- a/src/main/java/com/devoxx/genie/ui/settings/mcp/dialog/transport/TransportPanel.java
+++ b/src/main/java/com/devoxx/genie/ui/settings/mcp/dialog/transport/TransportPanel.java
@@ -68,6 +68,26 @@ public interface TransportPanel {
     default McpClient createClient(Map<String, String> headers) throws Exception {
         return createClient();
     }
+
+    /**
+     * Create an MCP client for testing the connection, with custom headers
+     * (for HTTP-based transports) and custom environment variables
+     * (for STDIO-based transports).
+     * <p>
+     * The default implementation ignores the environment variables and
+     * delegates to {@link #createClient(Map)}. STDIO transports should
+     * override this method so that user-supplied environment variables
+     * (e.g. API tokens) are passed to the spawned process during the
+     * connection test, mirroring runtime behaviour.
+     *
+     * @param headers custom headers to include in HTTP requests
+     * @param env     custom environment variables to expose to the process
+     * @return The created MCP client
+     * @throws Exception If client creation fails
+     */
+    default McpClient createClient(Map<String, String> headers, Map<String, String> env) throws Exception {
+        return createClient(headers);
+    }
     
     /**
      * Apply settings to a server builder


### PR DESCRIPTION
# Pull Request

## 📚 Documentation

Before submitting, please review our [Contributing Guide](https://genie.devoxx.com/docs/contributing).

## Description

When adding a new MCP server that uses the **STDIO** transport, the connection test performed in the *Add MCP Server* dialog did not pass the user-entered environment variables (e.g. API tokens) to the spawned process. As a result, MCP servers that require such environment variables to authenticate or initialize would fail the connection test, preventing the server from being created.

This PR threads the environment variables captured in the dialog's env-var table through to the STDIO transport when the connection test client is created, so the test runs with the same environment the configured server would have at runtime.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test addition/improvement

## Related Issue

<!-- Link to the issue this PR addresses -->
Fixes #
Closes #
Related to #

## Changes Made

- **`TransportPanel`**: Added a new default method `createClient(Map<String, String> headers, Map<String, String> env)` so transports can receive both custom HTTP headers and custom environment variables when testing a connection. The default implementation delegates to `createClient(headers)`, preserving backward compatibility.
- **`StdioTransportPanel`**: Overrode the new method (and the headers-only variant) to merge the user-supplied environment variables on top of the inherited system environment. `createEnvironmentMap` now accepts a `customEnv` map and applies it last so user values take precedence, mirroring `MCPExecutionService#initStdioClient`.
- **`MCPServerDialog`**: Captured the env-var table values on the EDT (`envVarTableModel.getEnvVars()`) before background work and passed them into `panel.createClient(headers, envForConnection)` during the connection test.

## Testing

**How has this been tested?**

- [ ] Unit tests
- [ ] Integration tests
- [x] Manual testing in IntelliJ IDEA
- [ ] Tested with local LLM (Ollama/LMStudio/GPT4All)
- [ ] Tested with cloud LLM (OpenAI/Anthropic/Gemini)
- [x] Tested with MCP servers
- [ ] Tested with RAG enabled

**Test Configuration:**
- IntelliJ IDEA version:
- JDK version:
- OS: macOS

## Documentation

- [ ] I have updated the documentation at [genie.devoxx.com](https://genie.devoxx.com) if needed
- [ ] I have updated CLAUDE.md if architecture/patterns changed
- [x] I have added/updated code comments for complex logic
- [ ] I have updated the README.md if needed

## Checklist

- [x] My code follows the existing code style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Screenshots/Videos (if applicable)

<!-- Add screenshots or videos demonstrating the changes, especially for UI changes -->

## Additional Notes

The new `createClient(headers, env)` method is added as a `default` interface method, so existing `TransportPanel` implementations (e.g. HTTP/SSE transports) continue to work without changes — they simply ignore the environment variables. Only the STDIO transport overrides it. The merge order intentionally mirrors `MCPExecutionService#initStdioClient` to keep the connection-test environment consistent with the runtime environment.

## Breaking Changes

None. The change is fully backward compatible: the new interface method has a default implementation that delegates to the existing `createClient(Map)` method.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the project's license.