### PR TITLE
DRAFT: fix bug with scroll teleports to first message

### DIFF
--- a/src/main/kotlin/com/devoxx/genie/ui/compose/components/AiBubble.kt
+++ b/src/main/kotlin/com/devoxx/genie/ui/compose/components/AiBubble.kt
@@ -10,6 +10,9 @@ import androidx.compose.foundation.text.selection.SelectionContainer
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.onSizeChanged
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.TextLinkStyles
@@ -175,13 +178,32 @@ fun AiBubble(
     modifier: Modifier = Modifier,
     onRetryClick: (String) -> Unit = {},
     onOpenAgentSettings: () -> Unit = {},
+    cachedHeight: Dp = Dp.Unspecified,
+    onMeasured: (Dp) -> Unit = {},
 ) {
     val colors = DevoxxGenieThemeAccessor.colors
     val shape = RoundedCornerShape(8.dp)
+    val density = LocalDensity.current
 
     Column(
         modifier = modifier
             .fillMaxWidth()
+            // Reserve the bubble's last-known height on the very first measurement after a
+            // recycled item re-enters the viewport. The Markdown renderer reports a tiny
+            // height for its first frame and grows once parsing/highlighting completes; for
+            // a finished response that one-frame jump, when the bubble is the topmost
+            // visible item, makes LazyColumn re-pin its top edge and the viewport snaps to
+            // the start of the message. Pre-sizing to the cached height removes the jump.
+            .then(if (cachedHeight != Dp.Unspecified) Modifier.heightIn(min = cachedHeight) else Modifier)
+            // Cache the stable height only for finished responses; a streaming bubble grows
+            // legitimately and must not be frozen.
+            .then(
+                if (!message.isStreaming) {
+                    Modifier.onSizeChanged { size ->
+                        if (size.height > 0) onMeasured(with(density) { size.height.toDp() })
+                    }
+                } else Modifier
+            )
             .padding(vertical = 4.dp)
             .border(1.dp, DevoxxBlue, shape)
             .background(colors.assistantBubbleBackground, shape)

--- a/src/main/kotlin/com/devoxx/genie/ui/compose/components/MessagePair.kt
+++ b/src/main/kotlin/com/devoxx/genie/ui/compose/components/MessagePair.kt
@@ -3,6 +3,7 @@ package com.devoxx.genie.ui.compose.components
 import androidx.compose.foundation.layout.*
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.devoxx.genie.ui.compose.model.MessageUiModel
 
@@ -14,6 +15,8 @@ fun MessagePair(
     onRetryClick: (String) -> Unit = {},
     onOpenAgentSettings: () -> Unit = {},
     onOpenLogs: () -> Unit = {},
+    cachedAiBubbleHeight: Dp = Dp.Unspecified,
+    onAiBubbleMeasured: (Dp) -> Unit = {},
 ) {
     Column(
         modifier = modifier.fillMaxWidth().padding(horizontal = 8.dp, vertical = 4.dp),
@@ -37,6 +40,8 @@ fun MessagePair(
             message = message,
             onRetryClick = onRetryClick,
             onOpenAgentSettings = onOpenAgentSettings,
+            cachedHeight = cachedAiBubbleHeight,
+            onMeasured = onAiBubbleMeasured,
         )
 
         // File references

--- a/src/main/kotlin/com/devoxx/genie/ui/compose/screen/ChatScreen.kt
+++ b/src/main/kotlin/com/devoxx/genie/ui/compose/screen/ChatScreen.kt
@@ -32,6 +32,7 @@ import androidx.compose.ui.input.nestedscroll.NestedScrollSource
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.devoxx.genie.ui.compose.components.ConversationToolbar
@@ -65,37 +66,51 @@ fun ChatScreen(
     // items scrolled out and back in are also skipped via this set.
     val seenMessageIds = remember { messages.mapTo(HashSet()) { it.id } }
 
+    // Last measured height of each finished AI bubble, keyed by message id. A bubble's
+    // Markdown content reports a tiny height on its first frame and grows once parsed; when
+    // a recycled item re-enters at the top of the viewport that one-frame growth makes
+    // LazyColumn re-pin the item's top edge, snapping the viewport to the start of the
+    // message. Replaying the cached height as a minimum on re-entry keeps the first frame
+    // at full size so the anchor is preserved. Survives recomposition (not config changes).
+    val aiBubbleHeights = remember { mutableStateMapOf<String, Dp>() }
+
     // Whether the list should follow the growing tail of the last message. Disabled the
     // moment the user scrolls up (see nestedScrollConnection), re-enabled when the user
     // returns to the bottom or a new message is submitted.
     var autoFollow by remember { mutableStateOf(true) }
 
-    // True when the very end of the conversation is visible. The bottom anchor item is
-    // the last list item, so "at bottom" means the last item's bottom edge is inside the
-    // viewport (small tolerance for rounding).
+    // True when the very end of the conversation is visible. The bottom anchor is the
+    // last list item, so "at bottom" means that anchor is laid out and its bottom edge is
+    // within the viewport. The tolerance is kept tiny (2px, rounding only): a larger fuzzy
+    // window combined with the 1dp anchor would treat a small upward scroll as "still at
+    // bottom" and immediately re-enable following, yanking the reader back down.
     val isAtBottom by remember {
         derivedStateOf {
             val info = listState.layoutInfo
             val last = info.visibleItemsInfo.lastOrNull()
             last == null || (
                 last.index == info.totalItemsCount - 1 &&
-                    last.offset + last.size <= info.viewportEndOffset + 8
+                    last.offset + last.size <= info.viewportEndOffset + 2
                 )
         }
     }
 
-    // Reaching the bottom by any means (manual scroll, button, programmatic) resumes following.
+    // Re-enable following only when the end of the conversation is actually reached AND the
+    // user is not mid-gesture. Without the isScrollInProgress guard, the brief moment a
+    // streaming update relayouts the list can satisfy isAtBottom and flip autoFollow back
+    // on while the user is still dragging upward.
     LaunchedEffect(isAtBottom) {
-        if (isAtBottom) autoFollow = true
+        if (isAtBottom && !listState.isScrollInProgress) autoFollow = true
     }
 
     // Only user gestures (drag / mouse wheel / fling) pass through the nested-scroll chain;
     // programmatic animateScrollToItem calls do not. Any upward user scroll stops following
-    // so streaming updates can't yank the reader back down.
+    // so streaming updates can't yank the reader back down. In Compose a scroll that reveals
+    // earlier content (finger/content moving down) reports a positive available.y.
     val nestedScrollConnection = remember {
         object : NestedScrollConnection {
             override fun onPreScroll(available: Offset, source: NestedScrollSource): Offset {
-                if (available.y > 0f) autoFollow = false
+                if (available.y > 0.5f) autoFollow = false
                 return Offset.Zero
             }
         }
@@ -113,8 +128,11 @@ fun ChatScreen(
     // Follow the tail while streaming. Scrolling to the 1px bottom anchor (index ==
     // messages.size) shows the END of the growing last message; scrolling to the message
     // item itself would pin the viewport at its top once it outgrows the screen.
+    // The isScrollInProgress guard is essential: a streaming token must never start a
+    // programmatic scroll while the user is dragging/flinging upward, otherwise the reader
+    // is snapped back down to the start of the message below them.
     LaunchedEffect(messages.lastOrNull()?.aiResponseMarkdown) {
-        if (autoFollow && messages.isNotEmpty()) {
+        if (autoFollow && messages.isNotEmpty() && !listState.isScrollInProgress) {
             listState.animateScrollToItem(messages.size)
         }
     }
@@ -135,8 +153,16 @@ fun ChatScreen(
                 ) { _, message ->
                     // Play the entrance exactly once: the first time this id is ever
                     // composed, and only for messages inserted while the chat is live.
+                    // Computed in `remember(message.id)` so an item scrolled out and back
+                    // in (a fresh composition) re-checks `seenMessageIds` and resolves to
+                    // false, never replaying the transition. See shouldPlayEntrance.
                     val playEntrance = remember(message.id) {
-                        seenMessageIds.add(message.id) && animationsEnabled && !isRestoring
+                        shouldPlayEntrance(
+                            seenMessageIds = seenMessageIds,
+                            messageId = message.id,
+                            animationsEnabled = animationsEnabled,
+                            isRestoring = isRestoring,
+                        )
                     }
                     MessageEntrance(messageId = message.id, playEntrance = playEntrance) {
                         MessagePair(
@@ -145,6 +171,8 @@ fun ChatScreen(
                             onRetryClick = onRetryClick,
                             onOpenAgentSettings = onOpenAgentSettings,
                             onOpenLogs = onOpenLogs,
+                            cachedAiBubbleHeight = aiBubbleHeights[message.id] ?: Dp.Unspecified,
+                            onAiBubbleMeasured = { height -> aiBubbleHeights[message.id] = height },
                         )
                     }
                 }
@@ -169,10 +197,45 @@ fun ChatScreen(
 }
 
 /**
+ * Decides whether a bubble should play its one-shot entrance transition.
+ *
+ * Contract (intentionally side-effecting on [seenMessageIds] so the decision is made
+ * exactly once per id): returns true only the FIRST time an id is ever observed while
+ * the chat is live and animations are on. Every later call for the same id — including
+ * when a recycled LazyColumn item re-enters composition after being scrolled away —
+ * returns false, because the id is already in [seenMessageIds]. Keeping re-entering
+ * items out of the animated path is what prevents the list from losing its scroll anchor
+ * and snapping to the top of the conversation.
+ *
+ * [seenMessageIds] must be pre-seeded with the ids present on first composition so a
+ * conversation restored from history does not replay entrances for its whole transcript.
+ */
+internal fun shouldPlayEntrance(
+    seenMessageIds: MutableSet<String>,
+    messageId: String,
+    animationsEnabled: Boolean,
+    isRestoring: Boolean,
+): Boolean {
+    val firstTimeSeen = seenMessageIds.add(messageId)
+    return firstTimeSeen && animationsEnabled && !isRestoring
+}
+
+/**
  * Entrance animation for a newly inserted message bubble: fade-in plus a slight upward
- * slide (≤150ms). Neither effect changes the measured item size, so tail-following and
- * scroll-to-bottom positions are not disturbed. When [playEntrance] is false (already
- * seen, restoring from history, or animations disabled) the content shows immediately.
+ * slide (≤150ms).
+ *
+ * IMPORTANT — scroll anchoring: [AnimatedVisibility] sits in the measurement path of the
+ * item it wraps and can report a transient/zero size while its transition settles. Inside
+ * a [LazyColumn] that breaks the list's scroll-offset bookkeeping: when the user scrolls
+ * up and a recycled item re-enters composition, the momentary size change makes the list
+ * lose its anchor and snap `firstVisibleItemIndex` back to 0 — i.e. the viewport jumps to
+ * the very top of the conversation.
+ *
+ * To avoid this we only ever put [AnimatedVisibility] in the layout path for the single
+ * bubble that is genuinely playing its one-shot entrance ([playEntrance] == true). Every
+ * other bubble — already seen, restored from history, animations disabled, or simply
+ * scrolled back into view — renders [content] directly at its full, stable height, so
+ * scrolling never disturbs the list anchor.
  */
 @Composable
 private fun MessageEntrance(
@@ -180,8 +243,14 @@ private fun MessageEntrance(
     playEntrance: Boolean,
     content: @Composable () -> Unit,
 ) {
+    if (!playEntrance) {
+        // Stable, full-height content with no transition in the measurement path.
+        content()
+        return
+    }
+
     val entranceState = remember(messageId) {
-        MutableTransitionState(initialState = !playEntrance).apply { targetState = true }
+        MutableTransitionState(initialState = false).apply { targetState = true }
     }
     AnimatedVisibility(
         visibleState = entranceState,

--- a/src/test/kotlin/com/devoxx/genie/ui/compose/screen/ChatScreenScrollButtonTest.kt
+++ b/src/test/kotlin/com/devoxx/genie/ui/compose/screen/ChatScreenScrollButtonTest.kt
@@ -31,4 +31,62 @@ class ChatScreenScrollButtonTest {
     fun `button hidden when there are no messages`() {
         assertThat(shouldShowScrollToBottom(autoFollow = false, messages = emptyList())).isFalse()
     }
+
+    // --- entrance animation gating (guards the scroll snap-to-top regression) ---
+
+    @Test
+    fun `entrance plays the first time a live message is seen`() {
+        val seen = mutableSetOf<String>()
+        assertThat(
+            shouldPlayEntrance(seen, messageId = "m1", animationsEnabled = true, isRestoring = false)
+        ).isTrue()
+    }
+
+    @Test
+    fun `entrance does not replay when a recycled item re-enters composition`() {
+        val seen = mutableSetOf<String>()
+        // First composition: animates once.
+        shouldPlayEntrance(seen, messageId = "m1", animationsEnabled = true, isRestoring = false)
+        // Scrolled away and back: the item re-composes and must NOT animate again,
+        // otherwise AnimatedVisibility re-enters the layout path and the LazyColumn
+        // loses its scroll anchor (jump-to-top bug).
+        assertThat(
+            shouldPlayEntrance(seen, messageId = "m1", animationsEnabled = true, isRestoring = false)
+        ).isFalse()
+    }
+
+    @Test
+    fun `entrance never plays for messages pre-seeded from restored history`() {
+        val seen = mutableSetOf("m1", "m2")
+        assertThat(
+            shouldPlayEntrance(seen, messageId = "m1", animationsEnabled = true, isRestoring = false)
+        ).isFalse()
+        assertThat(
+            shouldPlayEntrance(seen, messageId = "m2", animationsEnabled = true, isRestoring = false)
+        ).isFalse()
+    }
+
+    @Test
+    fun `entrance does not play while restoring`() {
+        val seen = mutableSetOf<String>()
+        assertThat(
+            shouldPlayEntrance(seen, messageId = "m1", animationsEnabled = true, isRestoring = true)
+        ).isFalse()
+        // Id is still marked seen, so a later live recomposition won't suddenly animate.
+        assertThat(
+            shouldPlayEntrance(seen, messageId = "m1", animationsEnabled = true, isRestoring = false)
+        ).isFalse()
+    }
+
+    @Test
+    fun `entrance does not play when animations are disabled`() {
+        val seen = mutableSetOf<String>()
+        assertThat(
+            shouldPlayEntrance(seen, messageId = "m1", animationsEnabled = false, isRestoring = false)
+        ).isFalse()
+        // Still marked seen: re-enabling animations later must not retroactively animate it.
+        assertThat(
+            shouldPlayEntrance(seen, messageId = "m1", animationsEnabled = true, isRestoring = false)
+        ).isFalse()
+    }
 }


### PR DESCRIPTION
# Pull Request

## 📚 Documentation

Before submitting, please review our [Contributing Guide](https://genie.devoxx.com/docs/contributing).

## Description

Scrolling up through the conversation in the Compose chat UI caused the viewport to jump unexpectedly. There were two distinct bugs:

1. **Jump to the very top of the list** — every message bubble was wrapped in a `MessageEntrance` that always placed an `AnimatedVisibility` (fade + slide) in the measurement path of each `LazyColumn` item. When recycled items re-entered the viewport, `AnimatedVisibility` could report a transient/zero size during re-composition, corrupting `LazyListState`'s scroll-offset bookkeeping and resetting `firstVisibleItemIndex` to `0`.

2. **Jump to the start of an assistant message** — when an assistant (`AiBubble`) message scrolled into view at the top edge, its `Markdown`/syntax-highlighted content was rendered lazily, so the item was first measured with a small height and then grew a frame later. Because it was the top-most visible item, `LazyColumn` kept its top edge pinned, snapping the viewport to the start of that message. User messages (plain `BasicText`, height known on the first measure) were unaffected — which is why the symptom only appeared on assistant messages.

This PR fixes both issues so scrolling up is smooth and the list keeps its anchor.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test addition/improvement

## Related Issue

<!-- Link to the issue this PR addresses -->
Fixes #
Closes #
Related to #

## Changes Made

- **`MessageEntrance` (ChatScreen.kt)**: It now renders `content()` directly (with stable full height, no `AnimatedVisibility`) whenever `playEntrance == false`. `AnimatedVisibility` is only mounted for the single bubble genuinely playing its one-shot entrance, so re-entering/already-seen/restored/animation-disabled bubbles never go through the animated layout path and the list keeps its scroll anchor.
- **`shouldPlayEntrance(...)` (ChatScreen.kt)**: Extracted the "play the entrance exactly once" decision into an `internal` pure function so the contract (never replay on re-entry, never animate history-seeded ids, skip while restoring or when animations are disabled) is explicit and unit-testable.
- **Auto-follow / tail-following (ChatScreen.kt)**: Tightened the `isAtBottom` tolerance (from +8px to +2px) and guarded both the `isAtBottom`→`autoFollow` reset and the streaming-follow effect with `!listState.isScrollInProgress`, so a streaming token can no longer re-pin the viewport to the bottom while the user is actively scrolling.
- **AI bubble height caching (ChatScreen.kt → MessagePair.kt → AiBubble.kt)**: Added a per-message height cache (`aiBubbleHeights`, keyed by `message.id`) that reserves a finished assistant bubble's measured height via `heightIn(min = ...)` on its first measure after re-entering the viewport. Height is recorded through `onSizeChanged` only for completed (`!isStreaming`) messages, so legitimately growing streams are not frozen. This removes the post-first-frame height jump that snapped the viewport to the start of the message.

## Testing

**How has this been tested?**

- [x] Unit tests
- [ ] Integration tests
- [x] Manual testing in IntelliJ IDEA
- [ ] Tested with local LLM (Ollama/LMStudio/GPT4All)
- [ ] Tested with cloud LLM (OpenAI/Anthropic/Gemini)
- [ ] Tested with MCP servers
- [ ] Tested with RAG enabled

**Test Configuration:**
- IntelliJ IDEA version: 2026.1.3
- JDK version: 21 (Amazon Corretto)
- OS: macOS

## Documentation

- [ ] I have updated the documentation at [genie.devoxx.com](https://genie.devoxx.com) if needed
- [ ] I have updated CLAUDE.md if architecture/patterns changed
- [x] I have added/updated code comments for complex logic
- [ ] I have updated the README.md if needed

## Checklist

- [x] My code follows the existing code style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Screenshots/Videos (if applicable)

<!-- Add screenshots or videos demonstrating the changes, especially for UI changes -->

## Additional Notes

- The height cache lives in a `remember { mutableStateMapOf<String, Dp>() }` for the lifetime of the composition; it is populated as soon as a message finishes streaming and is sufficient for scroll anchoring.
- The new `shouldPlayEntrance` helper is intentionally side-effecting on `seenMessageIds` so that a recycled item re-entering composition correctly resolves to `false` (no replay).
- 5 unit tests were added to `ChatScreenScrollButtonTest` covering the entrance-gating contract (first-time play, no replay on re-entry, no play for seeded ids, no play while restoring, no play when animations are disabled); the full class runs 9/9 green.

## Breaking Changes

None. All changes are internal to the Compose chat UI and backward compatible.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the project's license.