### PR TITLE
fix: match multiline old_string across CRLF/LF endings (#1144)

### DIFF
--- a/src/main/java/com/devoxx/genie/service/agent/AgentLoopTracker.java
+++ b/src/main/java/com/devoxx/genie/service/agent/AgentLoopTracker.java
@@ -144,8 +144,21 @@ public class AgentLoopTracker implements ToolProvider {
             return errorResult;
         }
 
-        publishLogEvent(AgentType.TOOL_RESPONSE, toolRequest.name(), null, toolResult, count);
+        // Tool executors signal failure by returning an "Error: ..." string rather than
+        // throwing (e.g. EditFileToolExecutor when old_string is not found). Classify
+        // those as TOOL_ERROR so the activity view shows a failure icon instead of a
+        // green "valid" check (issue #1144).
+        AgentType type = isErrorResult(toolResult) ? AgentType.TOOL_ERROR : AgentType.TOOL_RESPONSE;
+        publishLogEvent(type, toolRequest.name(), null, toolResult, count);
         return toolResult;
+    }
+
+    /**
+     * Returns {@code true} when a tool result string represents an error by convention —
+     * i.e. it starts with the "Error:" prefix used across the built-in tool executors.
+     */
+    static boolean isErrorResult(@Nullable String result) {
+        return result != null && result.stripLeading().startsWith("Error:");
     }
 
     /**

--- a/src/main/java/com/devoxx/genie/service/agent/tool/EditFileToolExecutor.java
+++ b/src/main/java/com/devoxx/genie/service/agent/tool/EditFileToolExecutor.java
@@ -88,10 +88,20 @@ public class EditFileToolExecutor implements ToolExecutor {
                 return "Error: Access denied - path is outside the project root.";
             }
 
-            String content = new String(file.contentsToByteArray(), StandardCharsets.UTF_8);
+            String rawContent = new String(file.contentsToByteArray(), StandardCharsets.UTF_8);
+
+            // Normalize line endings to LF before matching. LLMs emit old_string with LF
+            // even when the file on disk uses CRLF (typical on Windows), which would
+            // otherwise make any multi-line old_string impossible to match (issue #1144).
+            // We detect the file's original separator so we can restore it on write and
+            // avoid silently rewriting the whole file's line endings.
+            String lineSeparator = detectLineSeparator(rawContent);
+            String content = normalizeLineEndings(rawContent);
+            String normalizedOld = normalizeLineEndings(oldString);
+            String normalizedNew = normalizeLineEndings(newString);
 
             // Count occurrences
-            int count = countOccurrences(content, oldString);
+            int count = countOccurrences(content, normalizedOld);
             if (count == 0) {
                 return "Error: The specified old_string was not found in " + path;
             }
@@ -101,17 +111,22 @@ public class EditFileToolExecutor implements ToolExecutor {
                         "or set replace_all to true.";
             }
 
-            // Perform replacement
+            // Perform replacement (in LF space)
             String newContent;
             if (replaceAll) {
-                newContent = content.replace(oldString, newString);
+                newContent = content.replace(normalizedOld, normalizedNew);
             } else {
-                int idx = content.indexOf(oldString);
-                newContent = content.substring(0, idx) + newString +
-                        content.substring(idx + oldString.length());
+                int idx = content.indexOf(normalizedOld);
+                newContent = content.substring(0, idx) + normalizedNew +
+                        content.substring(idx + normalizedOld.length());
             }
 
-            file.setBinaryContent(newContent.getBytes(StandardCharsets.UTF_8));
+            // Restore the file's original line separator before writing.
+            String outContent = "\n".equals(lineSeparator)
+                    ? newContent
+                    : newContent.replace("\n", lineSeparator);
+
+            file.setBinaryContent(outContent.getBytes(StandardCharsets.UTF_8));
 
             if (replaceAll && count > 1) {
                 return "Successfully replaced " + count + " occurrences in " + path;
@@ -134,6 +149,26 @@ public class EditFileToolExecutor implements ToolExecutor {
 
     boolean isAncestor(VirtualFile ancestor, VirtualFile descendant) {
         return VfsUtilCore.isAncestor(ancestor, descendant, false);
+    }
+
+    /** Converts CRLF and lone CR line endings to LF so matching is line-ending agnostic. */
+    static @NotNull String normalizeLineEndings(@NotNull String s) {
+        return s.replace("\r\n", "\n").replace('\r', '\n');
+    }
+
+    /**
+     * Detects the dominant line separator used by the file content so it can be preserved
+     * on write. Returns "\r\n" if any CRLF is present, "\r" for lone CR (classic Mac),
+     * otherwise "\n".
+     */
+    static @NotNull String detectLineSeparator(@NotNull String content) {
+        if (content.contains("\r\n")) {
+            return "\r\n";
+        }
+        if (content.indexOf('\r') != -1) {
+            return "\r";
+        }
+        return "\n";
     }
 
     static int countOccurrences(@NotNull String content, @NotNull String search) {

--- a/src/test/java/com/devoxx/genie/service/agent/AgentLoopTrackerTest.java
+++ b/src/test/java/com/devoxx/genie/service/agent/AgentLoopTrackerTest.java
@@ -192,6 +192,36 @@ class AgentLoopTrackerTest {
         assertThat(overLimit.resultText()).contains("Agent loop limit reached");
     }
 
+    // --- isErrorResult() tests (issue #1144: error result strings must be flagged
+    //     as TOOL_ERROR, not shown with a green "valid" icon) ---
+
+    @Test
+    void isErrorResult_errorPrefixedString_isError() {
+        assertThat(AgentLoopTracker.isErrorResult(
+                "Error: The specified old_string was not found in Foo.java")).isTrue();
+    }
+
+    @Test
+    void isErrorResult_leadingWhitespaceBeforeError_isError() {
+        assertThat(AgentLoopTracker.isErrorResult("  Error: something went wrong")).isTrue();
+    }
+
+    @Test
+    void isErrorResult_successString_isNotError() {
+        assertThat(AgentLoopTracker.isErrorResult("Successfully edited Foo.java")).isFalse();
+    }
+
+    @Test
+    void isErrorResult_nullResult_isNotError() {
+        assertThat(AgentLoopTracker.isErrorResult(null)).isFalse();
+    }
+
+    @Test
+    void isErrorResult_textMentioningErrorMidSentence_isNotError() {
+        assertThat(AgentLoopTracker.isErrorResult(
+                "The build produced no error and finished cleanly")).isFalse();
+    }
+
     private ToolSpecification createSpec(String name) {
         return ToolSpecification.builder()
                 .name(name)

--- a/src/test/java/com/devoxx/genie/service/agent/tool/EditFileToolExecutorTest.java
+++ b/src/test/java/com/devoxx/genie/service/agent/tool/EditFileToolExecutorTest.java
@@ -361,6 +361,60 @@ class EditFileToolExecutorTest {
     }
 
     @Test
+    void editFile_crlfFileContent_lfMultilineOldString_matchesAndPreservesCrlf() throws IOException {
+        // Issue #1144: file saved with Windows CRLF line endings, but the LLM emits the
+        // multi-line old_string with LF only. The match must still succeed, and the write
+        // must preserve the file's original CRLF line endings.
+        VirtualFile projectBase = mock(VirtualFile.class);
+        VirtualFile file = createMockFileWithContent("import a.A\r\nimport a.B\r\nclass Foo {}\r\n");
+
+        EditFileToolExecutor testExecutor = createTestableExecutor(projectBase, file);
+
+        String result = testExecutor.editFile("Foo.java",
+                "import a.A\nimport a.B", "import a.B\nimport a.A", false);
+        assertThat(result).contains("Successfully edited");
+
+        ArgumentCaptor<byte[]> captor = ArgumentCaptor.forClass(byte[].class);
+        verify(file).setBinaryContent(captor.capture());
+        assertThat(new String(captor.getValue(), StandardCharsets.UTF_8))
+                .isEqualTo("import a.B\r\nimport a.A\r\nclass Foo {}\r\n");
+    }
+
+    @Test
+    void editFile_crlfFileContent_lfSingleLineOldString_stillWorks() throws IOException {
+        VirtualFile projectBase = mock(VirtualFile.class);
+        VirtualFile file = createMockFileWithContent("line1\r\nline2\r\nline3\r\n");
+
+        EditFileToolExecutor testExecutor = createTestableExecutor(projectBase, file);
+
+        String result = testExecutor.editFile("test.txt", "line2", "replaced", false);
+        assertThat(result).contains("Successfully edited");
+
+        ArgumentCaptor<byte[]> captor = ArgumentCaptor.forClass(byte[].class);
+        verify(file).setBinaryContent(captor.capture());
+        assertThat(new String(captor.getValue(), StandardCharsets.UTF_8))
+                .isEqualTo("line1\r\nreplaced\r\nline3\r\n");
+    }
+
+    @Test
+    void editFile_lfFileContent_lfMultilineOldString_preservesLf() throws IOException {
+        // Guard against the CRLF normalization accidentally rewriting an LF file to CRLF.
+        VirtualFile projectBase = mock(VirtualFile.class);
+        VirtualFile file = createMockFileWithContent("import a.A\nimport a.B\nclass Foo {}\n");
+
+        EditFileToolExecutor testExecutor = createTestableExecutor(projectBase, file);
+
+        String result = testExecutor.editFile("Foo.java",
+                "import a.A\nimport a.B", "import a.B\nimport a.A", false);
+        assertThat(result).contains("Successfully edited");
+
+        ArgumentCaptor<byte[]> captor = ArgumentCaptor.forClass(byte[].class);
+        verify(file).setBinaryContent(captor.capture());
+        assertThat(new String(captor.getValue(), StandardCharsets.UTF_8))
+                .isEqualTo("import a.B\nimport a.A\nclass Foo {}\n");
+    }
+
+    @Test
     void editFile_setBinaryContentThrows_returnsError() throws IOException {
         VirtualFile projectBase = mock(VirtualFile.class);
         VirtualFile file = createMockFileWithContent("hello world");


### PR DESCRIPTION
## Summary
Fixes #1144 — two independent root causes behind "The specified old_string was not found" on multiline edits.

- **CRLF/LF mismatch (the "not found" bug):** `EditFileToolExecutor` matched `old_string` against the file's raw on-disk bytes with exact `indexOf`. On Windows files use CRLF while the LLM emits `old_string` with LF, so any multi-line `old_string` (e.g. several imports) could never match. Single-line edits were unaffected — matching the reported symptom. Fixed by normalizing line endings to LF for matching/replacing and restoring the file's detected original separator on write (CRLF stays CRLF, LF stays LF).
- **Misleading green "valid" icon:** `AgentLoopTracker` only flagged `TOOL_ERROR` on thrown exceptions, but executors report failures by *returning* an `"Error: ..."` string — so failed edits showed a green check. Now result strings starting with `Error:` are classified as `TOOL_ERROR`.

Note: JSON `\n` decoding in `ToolArgumentParser` was verified correct, so parsing was never the issue.

## Test plan
- [x] `editFile_crlfFileContent_lfMultilineOldString_matchesAndPreservesCrlf` — CRLF file + LF multiline old_string matches and round-trips CRLF
- [x] `editFile_crlfFileContent_lfSingleLineOldString_stillWorks`
- [x] `editFile_lfFileContent_lfMultilineOldString_preservesLf` — LF files are not rewritten to CRLF
- [x] `AgentLoopTracker.isErrorResult` cases (error prefix, leading whitespace, success string, null, mid-sentence "error")
- [x] Full suite: `./gradlew test` → BUILD SUCCESSFUL, no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)