### PR TITLE
chore: fix dead JDK 21 path and silence buildSearchableOptions noise

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,7 +45,7 @@ message, and show me a summary of what you changed and why.
 **IMPORTANT**: This project requires **JDK 21** for building. JDK 25 causes Gradle build script failures. Always set `JAVA_HOME` before running Gradle commands:
 
 ```bash
-export JAVA_HOME=/Users/stephan/Library/Java/JavaVirtualMachines/azul-21.0.5/Contents/Home
+export JAVA_HOME=~/.sdkman/candidates/java/21-zulu
 ```
 
 ### Building

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -442,6 +442,14 @@ tasks {
         duplicatesStrategy = DuplicatesStrategy.EXCLUDE
     }
 
+    // Skip building the searchable-options index. It boots a headless IDE whose
+    // Grazie/PluginManager subsystem spews kotlinx.coroutines cancellation stack
+    // traces (network/SSL calls cancelled at shutdown) — harmless noise that the
+    // build does not need. Disabling it also speeds up buildPlugin.
+    buildSearchableOptions {
+        enabled = false
+    }
+
     test {
         doFirst {
             val tmpDir = File("/tmp/test")


### PR DESCRIPTION
## Summary

Investigating reported "Kotlin exceptions" during `./gradlew clean buildPlugin` revealed the build was never actually failing (`BUILD SUCCESSFUL` every run). Two unrelated issues were behind the noise:

1. **Dead JDK 21 path** — `CLAUDE.md` documented `JAVA_HOME=.../azul-21.0.5/...`, a JDK that no longer exists. With it unset, Gradle silently fell back to JDK 25. Repointed to the available SDKMAN `21-zulu` JDK.

2. **`buildSearchableOptions` noise** — this task boots a headless IntelliJ instance (`TraverseUIStarter`) to index searchable settings. During shutdown its Grazie/PluginManager subsystem cancels in-flight network/SSL calls and logs them as `WARN` with large `kotlinx.coroutines.JobCancellationException` / `SSLException` stack traces. Harmless, but looks alarming. The plugin provides no custom searchable settings, so the task is disabled — removing the noise and speeding up `buildPlugin`.

## Changes
- `CLAUDE.md`: `JAVA_HOME` → `~/.sdkman/candidates/java/21-zulu`
- `build.gradle.kts`: `buildSearchableOptions { enabled = false }`

## Verification
`./gradlew clean buildPlugin --rerun-tasks` under JDK 21 → `:buildSearchableOptions SKIPPED`, zero coroutine stack traces, `BUILD SUCCESSFUL`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)