### PR TITLE
fix: guard null token counts in cost calculation (#1149)

### DIFF
--- a/src/main/java/com/devoxx/genie/model/request/ChatMessageContext.java
+++ b/src/main/java/com/devoxx/genie/model/request/ChatMessageContext.java
@@ -81,9 +81,13 @@ public class ChatMessageContext {
 
     public void setTokenUsageAndCost(TokenUsage tokenUsage) {
         this.tokenUsage = tokenUsage;
-        if (this.tokenUsage != null) {
-            this.cost = (tokenUsage.inputTokenCount() * languageModel.getInputCost() +
-                tokenUsage.outputTokenCount() * languageModel.getOutputCost()) / 1_000_000.0;
+        if (this.tokenUsage != null && languageModel != null) {
+            // Some providers (e.g. cloud models in agent mode) return a non-null TokenUsage
+            // whose input/output counts are null. Guard against unboxing null Integers (#1149).
+            int inputTokens = tokenUsage.inputTokenCount() != null ? tokenUsage.inputTokenCount() : 0;
+            int outputTokens = tokenUsage.outputTokenCount() != null ? tokenUsage.outputTokenCount() : 0;
+            this.cost = (inputTokens * languageModel.getInputCost() +
+                outputTokens * languageModel.getOutputCost()) / 1_000_000.0;
         }
     }
 }

--- a/src/test/java/com/devoxx/genie/model/request/ChatMessageContextTest.java
+++ b/src/test/java/com/devoxx/genie/model/request/ChatMessageContextTest.java
@@ -1,0 +1,64 @@
+package com.devoxx.genie.model.request;
+
+import com.devoxx.genie.model.LanguageModel;
+import dev.langchain4j.model.output.TokenUsage;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+class ChatMessageContextTest {
+
+    private static LanguageModel model() {
+        return LanguageModel.builder()
+                .inputCost(3.0)
+                .outputCost(15.0)
+                .build();
+    }
+
+    @Test
+    void setTokenUsageAndCost_computesCostWhenCountsPresent() {
+        ChatMessageContext context = ChatMessageContext.builder()
+                .languageModel(model())
+                .build();
+
+        context.setTokenUsageAndCost(new TokenUsage(1_000_000, 1_000_000));
+
+        // (1_000_000 * 3 + 1_000_000 * 15) / 1_000_000 = 18.0
+        assertThat(context.getCost()).isEqualTo(18.0);
+    }
+
+    /**
+     * Reproduces issue #1149: some providers (e.g. when running a cloud model in agent
+     * mode) return a non-null TokenUsage whose inputTokenCount()/outputTokenCount() are
+     * null. Auto-unboxing those nulls during cost calculation threw a NullPointerException.
+     */
+    @Test
+    void setTokenUsageAndCost_doesNotThrowWhenTokenCountsAreNull() {
+        ChatMessageContext context = ChatMessageContext.builder()
+                .languageModel(model())
+                .build();
+
+        TokenUsage nullCounts = new TokenUsage(null, null, null);
+
+        assertThatCode(() -> context.setTokenUsageAndCost(nullCounts))
+                .doesNotThrowAnyException();
+
+        assertThat(context.getTokenUsage()).isSameAs(nullCounts);
+        assertThat(context.getCost()).isZero();
+    }
+
+    @Test
+    void setTokenUsageAndCost_handlesPartialNullCounts() {
+        ChatMessageContext context = ChatMessageContext.builder()
+                .languageModel(model())
+                .build();
+
+        // input present, output null
+        assertThatCode(() -> context.setTokenUsageAndCost(new TokenUsage(1_000_000, null)))
+                .doesNotThrowAnyException();
+
+        // (1_000_000 * 3 + 0 * 15) / 1_000_000 = 3.0
+        assertThat(context.getCost()).isEqualTo(3.0);
+    }
+}


### PR DESCRIPTION
## Summary
- Fixes #1149: agent runs aborted with `NullPointerException - Cannot invoke "java.lang.Integer.intValue()" because the return value of "TokenUsage.inputTokenCount()" is null`.
- Root cause: `ChatMessageContext.setTokenUsageAndCost` only null-checked the `TokenUsage` object, then multiplied its counts by the model cost. Some providers (e.g. a cloud model in agent mode with Ollama configured) return a non-null `TokenUsage` whose `inputTokenCount()`/`outputTokenCount()` are null `Integer`s — auto-unboxing them threw the NPE. Since this runs on the prompt-execution path, it aborted the whole turn.
- Fix: coalesce each null token count to `0` (and null-guard `languageModel`) before computing cost, matching the existing guard in `ActionButtonsPanel`.

## Test plan
- [x] New `ChatMessageContextTest` reproduces the NPE before the fix (all-null and partial-null counts) and passes after
- [x] Full `./gradlew test` suite green