### PR TITLE
fix: use SSE transport for HTTP_SSE MCP servers (#1151)

### DIFF
--- a/src/main/java/com/devoxx/genie/service/mcp/MCPExecutionService.java
+++ b/src/main/java/com/devoxx/genie/service/mcp/MCPExecutionService.java
@@ -14,6 +14,7 @@ import dev.langchain4j.mcp.McpToolProvider;
 import dev.langchain4j.mcp.client.DefaultMcpClient;
 import dev.langchain4j.mcp.client.McpClient;
 import dev.langchain4j.mcp.client.transport.McpTransport;
+import dev.langchain4j.mcp.client.transport.http.HttpMcpTransport;
 import dev.langchain4j.mcp.client.transport.http.StreamableHttpMcpTransport;
 import dev.langchain4j.mcp.client.transport.stdio.StdioMcpTransport;
 import dev.langchain4j.service.tool.ToolProvider;
@@ -270,6 +271,7 @@ public class MCPExecutionService implements Disposable {
      * @return An initialized MCP client or null if creation fails
      */
     @Nullable
+    @SuppressWarnings({"deprecation", "removal"}) // SSE transport is required for SSE-only servers (issue #1151)
     static McpClient initHttpSseClient(@NotNull MCPServer mcpServer) {
         try {
             String sseUrl = mcpServer.getUrl();
@@ -279,11 +281,13 @@ public class MCPExecutionService implements Disposable {
                 return null;
             }
 
-            MCPService.logDebug("Initializing streamable HTTP transport for HTTP_SSE config with URL: " + sseUrl);
+            MCPService.logDebug("Initializing SSE transport for HTTP_SSE config with URL: " + sseUrl);
 
-            // Use Streamable HTTP transport as replacement for legacy HTTP/SSE transport
-            StreamableHttpMcpTransport.Builder transportBuilder = new StreamableHttpMcpTransport.Builder()
-                    .url(sseUrl)
+            // Use the SSE-based transport for HTTP_SSE servers. The streamable HTTP transport POSTs
+            // to the single URL, which SSE-only endpoints (e.g. the JetBrains MCP server) reject with
+            // HTTP 405 (see issue #1151). HttpMcpTransport opens the event stream via a GET on /sse.
+            HttpMcpTransport.Builder transportBuilder = new HttpMcpTransport.Builder()
+                    .sseUrl(sseUrl)
                     .timeout(java.time.Duration.ofSeconds(DevoxxGenieStateService.getInstance().getTimeout()))
                     .logRequests(MCPService.isDebugLogsEnabled())
                     .logResponses(MCPService.isDebugLogsEnabled())

--- a/src/main/java/com/devoxx/genie/ui/settings/mcp/dialog/transport/HttpSseTransportPanel.java
+++ b/src/main/java/com/devoxx/genie/ui/settings/mcp/dialog/transport/HttpSseTransportPanel.java
@@ -17,7 +17,7 @@ import lombok.extern.slf4j.Slf4j;
 import dev.langchain4j.mcp.client.DefaultMcpClient;
 import dev.langchain4j.mcp.client.McpClient;
 import dev.langchain4j.mcp.client.transport.McpTransport;
-import dev.langchain4j.mcp.client.transport.http.StreamableHttpMcpTransport;
+import dev.langchain4j.mcp.client.transport.http.HttpMcpTransport;
 
 /**
  * Panel for configuring HTTP SSE MCP transport
@@ -94,6 +94,29 @@ public class HttpSseTransportPanel implements TransportPanel {
 
     @Override
     public McpClient createClient(Map<String, String> headers) throws Exception {
+        McpTransport transport = createTransport(headers);
+
+        // Create and return the client
+        return new DefaultMcpClient.Builder()
+                .clientName("DevoxxGenie")
+                .protocolVersion("2024-11-05")
+                .transport(transport)
+                .build();
+    }
+
+    /**
+     * Builds the MCP transport for this panel without opening a connection.
+     * <p>
+     * This uses the SSE-based {@link HttpMcpTransport} (which opens the event stream via a GET
+     * request to the configured {@code /sse} endpoint). The legacy SSE transport must NOT be
+     * replaced by {@code StreamableHttpMcpTransport}: the streamable transport POSTs to the single
+     * URL, and an SSE-only endpoint (e.g. the JetBrains MCP server) rejects that with HTTP 405
+     * (see issue #1151).
+     * <p>
+     * Package-private for testing.
+     */
+    @SuppressWarnings({"deprecation", "removal"}) // SSE transport is required for SSE-only servers (issue #1151)
+    McpTransport createTransport(Map<String, String> headers) {
         String sseUrl = sseUrlField.getText().trim();
 
         // Validate URL
@@ -107,9 +130,8 @@ public class HttpSseTransportPanel implements TransportPanel {
 
         log.debug("Creating HTTP SSE transport with URL: {}", sseUrl);
 
-        // Use Streamable HTTP transport (recommended replacement for legacy HTTP/SSE transport)
-        StreamableHttpMcpTransport.Builder transportBuilder = new StreamableHttpMcpTransport.Builder()
-                .url(sseUrl)
+        HttpMcpTransport.Builder transportBuilder = new HttpMcpTransport.Builder()
+                .sseUrl(sseUrl)
                 .timeout(Duration.ofSeconds(60))
                 .logRequests(true)
                 .logResponses(true);
@@ -118,14 +140,7 @@ public class HttpSseTransportPanel implements TransportPanel {
             transportBuilder.customHeaders(headers);
         }
 
-        McpTransport transport = transportBuilder.build();
-
-        // Create and return the client
-        return new DefaultMcpClient.Builder()
-                .clientName("DevoxxGenie")
-                .protocolVersion("2024-11-05")
-                .transport(transport)
-                .build();
+        return transportBuilder.build();
     }
 
     @Override

--- a/src/test/java/com/devoxx/genie/ui/settings/mcp/dialog/transport/HttpSseTransportPanelTest.java
+++ b/src/test/java/com/devoxx/genie/ui/settings/mcp/dialog/transport/HttpSseTransportPanelTest.java
@@ -1,0 +1,44 @@
+package com.devoxx.genie.ui.settings.mcp.dialog.transport;
+
+import dev.langchain4j.mcp.client.transport.McpTransport;
+import dev.langchain4j.mcp.client.transport.http.HttpMcpTransport;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import javax.swing.JTextField;
+import java.lang.reflect.Field;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for issue #1151.
+ * <p>
+ * The "HTTP SSE" transport panel must build an SSE-based {@link HttpMcpTransport}
+ * (which GETs the {@code /sse} endpoint to open the event stream), NOT a
+ * {@code StreamableHttpMcpTransport} (which POSTs to the single URL). Using the
+ * streamable transport against a legacy SSE endpoint such as the JetBrains MCP
+ * server's {@code /sse} endpoint results in an HTTP 405 (Method Not Allowed).
+ */
+class HttpSseTransportPanelTest {
+
+    private HttpSseTransportPanel panel;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        panel = new HttpSseTransportPanel();
+
+        Field urlField = HttpSseTransportPanel.class.getDeclaredField("sseUrlField");
+        urlField.setAccessible(true);
+        ((JTextField) urlField.get(panel)).setText("http://127.0.0.1:64342/sse");
+    }
+
+    @Test
+    void createTransportUsesSseTransport() {
+        McpTransport transport = panel.createTransport(Map.of());
+
+        assertThat(transport)
+                .as("HTTP SSE panel must use the SSE-based HttpMcpTransport, not the streamable HTTP transport (issue #1151)")
+                .isInstanceOf(HttpMcpTransport.class);
+    }
+}


### PR DESCRIPTION
## Summary
- Fixes #1151: HTTP_SSE MCP servers (e.g. the JetBrains built-in MCP server at `http://127.0.0.1:64342/sse`) failed "Test Connection" with `Unexpected status code: 405`.
- **Root cause:** both the test-connection path (`HttpSseTransportPanel`) and the runtime path (`MCPExecutionService.initHttpSseClient`) built a `StreamableHttpMcpTransport` for the `HTTP_SSE` transport type. The streamable transport **POSTs** to the single URL, but SSE-only endpoints accept only **GET** on `/sse` and reject the POST with HTTP 405.
- **Fix:** switch the `HTTP_SSE` path to the legacy SSE transport `HttpMcpTransport` (`.sseUrl(...)` instead of `.url(...)`), which opens the event stream via GET. `HttpMcpTransport` is deprecated/marked-for-removal in langchain4j but is the correct (and only) transport for SSE-only servers, so the deprecation is suppressed with an explanatory comment.
- Extracted a non-connecting `createTransport()` in `HttpSseTransportPanel` to enable a deterministic regression test (`HttpSseTransportPanelTest`).

## Test plan
- [x] New `HttpSseTransportPanelTest.createTransportUsesSseTransport` — fails on old code (405 / `StreamableHttpMcpTransport`), passes after fix
- [x] Full MCP suite green (`service.mcp.*`, `ui.settings.mcp.*`, incl. `MCPExecutionServiceTest` SSE-routing tests)
- [ ] Manual: add the JetBrains MCP server via HTTP_SSE (`http://127.0.0.1:64342/sse`) and confirm "Test Connection" succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)