### PR TITLE
fix: dedupe tools by name so enabled MCP tools override built-in (read_file clash)

### DIFF
--- a/src/main/java/com/devoxx/genie/service/agent/tool/CompositeToolProvider.java
+++ b/src/main/java/com/devoxx/genie/service/agent/tool/CompositeToolProvider.java
@@ -1,15 +1,29 @@
 package com.devoxx.genie.service.agent.tool;
 
+import dev.langchain4j.service.tool.AiServiceTool;
 import dev.langchain4j.service.tool.ToolProvider;
 import dev.langchain4j.service.tool.ToolProviderRequest;
 import dev.langchain4j.service.tool.ToolProviderResult;
+import lombok.extern.slf4j.Slf4j;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Merges tools from multiple ToolProviders into a single ToolProviderResult.
+ *
+ * <p>When two providers expose a tool with the same name (e.g. the built-in
+ * {@code read_file} tool and a {@code read_file} tool from the JetBrains MCP server),
+ * langchain4j's {@code ToolProviderResult.Builder} would otherwise throw
+ * {@code IllegalConfigurationException: Duplicated definition for tool: <name>}.
+ * We deduplicate by tool name so later delegates override earlier ones: the
+ * provider order in {@code AgentToolProviderFactory} is
+ * {@code [built-in, MCP, skills]}, which means an explicitly enabled MCP tool takes
+ * precedence over the built-in tool of the same name.
  */
+@Slf4j
 public class CompositeToolProvider implements ToolProvider {
 
     private final List<ToolProvider> delegates;
@@ -20,13 +34,23 @@ public class CompositeToolProvider implements ToolProvider {
 
     @Override
     public ToolProviderResult provideTools(ToolProviderRequest request) {
-        ToolProviderResult.Builder builder = ToolProviderResult.builder();
+        // Keyed by tool name; LinkedHashMap.put keeps the first-seen ordering while
+        // letting a later delegate replace (win over) an earlier one with the same name.
+        Map<String, AiServiceTool> toolsByName = new LinkedHashMap<>();
 
         for (ToolProvider delegate : delegates) {
             ToolProviderResult result = delegate.provideTools(request);
-            builder.addAll(result.aiServiceTools());
+            for (AiServiceTool tool : result.aiServiceTools()) {
+                AiServiceTool previous = toolsByName.put(tool.name(), tool);
+                if (previous != null) {
+                    log.info("Tool name '{}' provided by multiple providers; the later provider wins (MCP overrides built-in)",
+                            tool.name());
+                }
+            }
         }
 
+        ToolProviderResult.Builder builder = ToolProviderResult.builder();
+        toolsByName.values().forEach(builder::add);
         return builder.build();
     }
 }

--- a/src/test/java/com/devoxx/genie/service/agent/tool/CompositeToolProviderTest.java
+++ b/src/test/java/com/devoxx/genie/service/agent/tool/CompositeToolProviderTest.java
@@ -2,6 +2,7 @@ package com.devoxx.genie.service.agent.tool;
 
 import dev.langchain4j.agent.tool.ToolSpecification;
 import dev.langchain4j.model.chat.request.json.JsonObjectSchema;
+import dev.langchain4j.service.tool.AiServiceTool;
 import dev.langchain4j.service.tool.ToolExecutor;
 import dev.langchain4j.service.tool.ToolProvider;
 import dev.langchain4j.service.tool.ToolProviderRequest;
@@ -45,6 +46,40 @@ class CompositeToolProviderTest {
         ToolProviderResult result = composite.provideTools(request);
 
         assertThat(result.tools()).hasSize(2);
+    }
+
+    @Test
+    void provideTools_duplicateToolName_doesNotThrow_andLaterProviderWins() throws Exception {
+        // Both providers define a tool named "read_file": the built-in one and an MCP one.
+        // Without deduplication, langchain4j's ToolProviderResult.Builder throws
+        // IllegalConfigurationException("Duplicated definition for tool: read_file").
+        ToolSpecification builtInReadFile = ToolSpecification.builder()
+                .name("read_file")
+                .description("Built-in read_file")
+                .parameters(JsonObjectSchema.builder().build())
+                .build();
+        ToolSpecification mcpReadFile = ToolSpecification.builder()
+                .name("read_file")
+                .description("JetBrains MCP read_file")
+                .parameters(JsonObjectSchema.builder().build())
+                .build();
+
+        ToolExecutor builtInExec = (req, id) -> "built-in";
+        ToolExecutor mcpExec = (req, id) -> "mcp";
+
+        // Provider order mirrors AgentToolProviderFactory: built-in first, MCP second.
+        ToolProvider builtInProvider = req -> ToolProviderResult.builder().add(builtInReadFile, builtInExec).build();
+        ToolProvider mcpProvider = req -> ToolProviderResult.builder().add(mcpReadFile, mcpExec).build();
+
+        CompositeToolProvider composite = new CompositeToolProvider(List.of(builtInProvider, mcpProvider));
+        ToolProviderResult result = composite.provideTools(request);
+
+        // Only one read_file survives, and the MCP one (later provider) wins.
+        assertThat(result.aiServiceTools()).hasSize(1);
+        AiServiceTool surviving = result.aiServiceTools().get(0);
+        assertThat(surviving.name()).isEqualTo("read_file");
+        assertThat(surviving.toolSpecification().description()).isEqualTo("JetBrains MCP read_file");
+        assertThat(surviving.toolExecutor().execute(null, null)).isEqualTo("mcp");
     }
 
     @Test


### PR DESCRIPTION
## Problem

Agent prompt execution crashed when both the **built-in `read_file`** agent tool and the **JetBrains MCP server's `read_file`** tool were enabled:

```
StreamingException - Error during streaming response
Caused by: IllegalConfigurationException - Duplicated definition for tool: read_file
```

## Root cause

`CompositeToolProvider.provideTools()` merged every delegate provider's tools via a blind `builder.addAll(...)` with **no deduplication**. langchain4j's `ToolProviderResult.Builder.buildFinalToolList()` throws `IllegalConfigurationException("Duplicated definition for tool: <name>")` on any duplicate tool name. The agent provider chain order is `[built-in, MCP, skills]`, so the built-in and MCP `read_file` collided.

## Fix

Deduplicate by tool name in `CompositeToolProvider` using a `LinkedHashMap<String, AiServiceTool>` where **a later provider wins**. Because MCP is added after the built-in provider, an explicitly enabled **MCP tool now takes precedence** over the built-in tool of the same name — the desired priority. First-seen ordering is preserved and a clash is logged at INFO.

## Testing

- Added regression test `provideTools_duplicateToolName_doesNotThrow_andLaterProviderWins` (confirmed it reproduced the exact exception before the fix; now asserts the merge succeeds and the MCP/later provider wins).
- `service.agent.*` and `service.mcp.*` suites pass with no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)