### PR TITLE
fix: classify non-zero run_command exit as agent tool error

### DIFF
--- a/src/main/java/com/devoxx/genie/service/agent/AgentLoopTracker.java
+++ b/src/main/java/com/devoxx/genie/service/agent/AgentLoopTracker.java
@@ -157,7 +157,7 @@ public class AgentLoopTracker implements ToolProvider {
      * Returns {@code true} when a tool result string represents an error by convention —
      * i.e. it starts with the "Error:" prefix used across the built-in tool executors.
      */
-    static boolean isErrorResult(@Nullable String result) {
+    public static boolean isErrorResult(@Nullable String result) {
         return result != null && result.stripLeading().startsWith("Error:");
     }
 

--- a/src/main/java/com/devoxx/genie/service/agent/tool/RunCommandToolExecutor.java
+++ b/src/main/java/com/devoxx/genie/service/agent/tool/RunCommandToolExecutor.java
@@ -189,7 +189,10 @@ public class RunCommandToolExecutor implements ToolExecutor {
         if (exitCode == 0) {
             return result.isEmpty() ? "(command completed successfully with no output)" : result;
         } else {
-            return "Exit code: " + exitCode + "\n" + result;
+            // Prefix with "Error:" so AgentLoopTracker.isErrorResult() classifies a non-zero
+            // exit as TOOL_ERROR (red icon) instead of a green "success" check in the Activity
+            // panel. The exit code is kept in the message for the LLM's benefit.
+            return "Error: Command exited with code " + exitCode + "\n" + result;
         }
     }
 

--- a/src/test/java/com/devoxx/genie/service/agent/tool/RunCommandToolExecutorTest.java
+++ b/src/test/java/com/devoxx/genie/service/agent/tool/RunCommandToolExecutorTest.java
@@ -1,5 +1,6 @@
 package com.devoxx.genie.service.agent.tool;
 
+import com.devoxx.genie.service.agent.AgentLoopTracker;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.SystemInfo;
 import dev.langchain4j.agent.tool.ToolExecutionRequest;
@@ -142,7 +143,7 @@ class RunCommandToolExecutorTest {
                 .build();
 
         String result = executor.execute(request, null);
-        assertThat(result).contains("Exit code: 2").contains("failing");
+        assertThat(result).contains("exited with code 2").contains("failing");
     }
 
     @Test
@@ -247,7 +248,40 @@ class RunCommandToolExecutorTest {
                 .build();
 
         String result = executor.execute(request, null);
-        assertThat(result).contains("Exit code: 1");
+        assertThat(result).contains("exited with code 1");
+    }
+
+    /**
+     * Reproduces the bug where a command exiting with a non-zero code was rendered
+     * with the green "success" icon in the agent Activity panel. The icon is decided
+     * by {@link AgentLoopTracker#isErrorResult(String)}, which only flags strings
+     * beginning with "Error:". A non-zero exit must therefore produce an
+     * "Error:"-prefixed result so it is classified as TOOL_ERROR (red icon).
+     */
+    @Test
+    void execute_nonZeroExitCode_isClassifiedAsError() {
+        ToolExecutionRequest request = ToolExecutionRequest.builder()
+                .name("run_command")
+                .arguments("{\"command\": \"exit 1\"}")
+                .build();
+
+        String result = executor.execute(request, null);
+        assertThat(AgentLoopTracker.isErrorResult(result))
+                .as("Non-zero exit code must be classified as an error result")
+                .isTrue();
+    }
+
+    @Test
+    void execute_zeroExitCode_isNotClassifiedAsError() {
+        ToolExecutionRequest request = ToolExecutionRequest.builder()
+                .name("run_command")
+                .arguments("{\"command\": \"echo ok\"}")
+                .build();
+
+        String result = executor.execute(request, null);
+        assertThat(AgentLoopTracker.isErrorResult(result))
+                .as("Successful command must not be classified as an error result")
+                .isFalse();
     }
 
     @Test


### PR DESCRIPTION
## Summary
- A `run_command` agent tool call that exited with a non-zero code (e.g. `exit 1`) was rendered with the green ✓ "success" icon in the Activity panel instead of a red ✗.
- Root cause: the icon is decided solely by `AgentLoopTracker.isErrorResult()`, which flags results starting with `"Error:"` (the convention from #1144). `RunCommandToolExecutor` returned non-zero results as `"Exit code: N"` and didn't throw, so they were published as `TOOL_RESPONSE` (green).
- Fix: prefix the non-zero result with `"Error: Command exited with code N"` so it participates in the existing convention and renders red; the exit code is preserved for the LLM. `isErrorResult()` made public for the cross-class regression test.

## Test plan
- [x] Added reproducing test `execute_nonZeroExitCode_isClassifiedAsError` (failed before the fix, passes after)
- [x] Added `execute_zeroExitCode_isNotClassifiedAsError`
- [x] Updated existing tests asserting the old `"Exit code: N"` wording
- [x] Full test suite green (`./gradlew test`, JDK 21)

🤖 Generated with [Claude Code](https://claude.com/claude-code)