### PR TITLE
Raise agent max tool-calls cap to 500, default to 50 (#1163)

### DIFF
--- a/src/main/java/com/devoxx/genie/model/Constant.java
+++ b/src/main/java/com/devoxx/genie/model/Constant.java
@@ -61,7 +61,14 @@ public class Constant {
     public static final Integer MCP_APPROVAL_TIMEOUT = 60;
 
     // Agent mode settings
-    public static final int AGENT_MAX_TOOL_CALLS = 25;
+    public static final int AGENT_MAX_TOOL_CALLS = 50;
+    /**
+     * Upper bound for the agent max tool-calls spinner (issue #1163). Large codebases
+     * regularly need more research/implementation iterations than the previous cap of 100
+     * allowed, which interrupted work mid-task. When this limit is reached the agent is
+     * asked to wrap up with its best answer rather than being hard-stopped.
+     */
+    public static final int AGENT_MAX_TOOL_CALLS_UPPER_BOUND = 500;
     /**
      * Wall-clock cap (seconds) for a single MCP/agent prompt conversation.
      * Simple (non-agent, non-MCP) prompts use the per-request timeout instead. The agent cap is

--- a/src/main/java/com/devoxx/genie/ui/settings/agent/AgentSettingsComponent.java
+++ b/src/main/java/com/devoxx/genie/ui/settings/agent/AgentSettingsComponent.java
@@ -34,7 +34,7 @@ public class AgentSettingsComponent extends AbstractSettingsComponent {
     private final JBCheckBox enableAgentModeCheckbox =
             new JBCheckBox("Enable agent mode", stateService.getAgentModeEnabled());
     private final JBIntSpinner maxToolCallsSpinner =
-            new JBIntSpinner(stateService.getAgentMaxToolCalls() != null ? stateService.getAgentMaxToolCalls() : AGENT_MAX_TOOL_CALLS, 1, 100);
+            new JBIntSpinner(stateService.getAgentMaxToolCalls() != null ? stateService.getAgentMaxToolCalls() : AGENT_MAX_TOOL_CALLS, 1, AGENT_MAX_TOOL_CALLS_UPPER_BOUND);
     private final JBCheckBox autoApproveReadOnlyCheckbox =
             new JBCheckBox("Auto-approve read-only tools (read_file, list_files, search_files, fetch_page)", stateService.getAgentAutoApproveReadOnly());
     private final JBCheckBox writeApprovalRequiredCheckbox =


### PR DESCRIPTION
Fixes #1163.

## Problem

On larger codebases the agent's discovery and implementation phases routinely exceed the tool-call ceiling. The settings spinner capped the agent's max tool calls at **100**, and hitting it interrupted work — the reporter described "2-3 restarts" for discovery and again for implementation.

## Change

- **Spinner upper bound: 100 → 500** (`AgentSettingsComponent`) via a new `AGENT_MAX_TOOL_CALLS_UPPER_BOUND` constant.
- **Default: 25 → 50** (`AGENT_MAX_TOOL_CALLS`) for a better out-of-box experience on larger projects.

Existing users keep their stored spinner value; only the selectable ceiling and the default-for-new-installs change.

## Note on the "hard stop" perception

The limit was already a *soft* stop, not a hard kill: `AgentLoopTracker.track()` returns an `"Error: Agent loop limit reached … Provide your best answer with the information gathered so far."` string to the LLM rather than aborting execution. The model is expected to wrap up. Raising the ceiling addresses the real pain — the model being starved of further tool calls mid-research.

## Testing

- `./gradlew compileJava` — BUILD SUCCESSFUL
- `./gradlew test` — BUILD SUCCESSFUL (full suite passes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)