### PR TITLE
fix: prevent CustomOpenAI IDE freeze and restore model on restart

### DIFF
--- a/src/main/java/com/devoxx/genie/chatmodel/local/LocalLLMProviderUtil.java
+++ b/src/main/java/com/devoxx/genie/chatmodel/local/LocalLLMProviderUtil.java
@@ -6,6 +6,7 @@ import com.devoxx.genie.ui.settings.DevoxxGenieStateService;
 import com.devoxx.genie.util.HttpClientProvider;
 import com.google.gson.Gson;
 import com.google.gson.JsonElement;
+import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.Response;
 
@@ -29,7 +30,7 @@ public class LocalLLMProviderUtil {
         String baseUrl = ensureEndsWithSlash(Objects.requireNonNull(configValue));
         String url = endpoint == null || endpoint.isBlank() ? Objects.requireNonNull(configValue) : baseUrl + endpoint;
 
-        return fetchModels(url, responseType);
+        return fetchModels(url, responseType, HttpClientProvider.getClient());
     }
 
     /**
@@ -38,15 +39,25 @@ public class LocalLLMProviderUtil {
      * (e.g., LMStudio uses /v1/ for chat but /api/v1/models for rich metadata).
      */
     public static <T> T getModelsFromUrl(String fullUrl, Class<T> responseType) throws IOException {
-        return fetchModels(fullUrl, responseType);
+        return fetchModels(fullUrl, responseType, HttpClientProvider.getClient());
     }
 
-    private static <T> T fetchModels(String url, Class<T> responseType) throws IOException {
+    /**
+     * Fetches models from a fully-qualified URL using a caller-supplied HTTP client.
+     * Use this when the default shared client's long connect timeout and retry/backoff
+     * behaviour is undesirable (e.g. a best-effort model-list probe that must fail fast
+     * so it never blocks the UI for a slow or unreachable endpoint).
+     */
+    public static <T> T getModelsFromUrl(String fullUrl, Class<T> responseType, OkHttpClient client) throws IOException {
+        return fetchModels(fullUrl, responseType, client);
+    }
+
+    private static <T> T fetchModels(String url, Class<T> responseType, OkHttpClient client) throws IOException {
         Request request = new Request.Builder()
                 .url(url)
                 .build();
 
-        try (Response response = HttpClientProvider.getClient().newCall(request).execute()) {
+        try (Response response = client.newCall(request).execute()) {
             if (!response.isSuccessful()) {
                 throw new UnsuccessfulRequestException("Unexpected code " + response);
             }

--- a/src/main/java/com/devoxx/genie/chatmodel/local/customopenai/CustomOpenAIChatModelFactory.java
+++ b/src/main/java/com/devoxx/genie/chatmodel/local/customopenai/CustomOpenAIChatModelFactory.java
@@ -14,6 +14,7 @@ import dev.langchain4j.model.openai.OpenAiChatModel;
 import dev.langchain4j.model.openai.OpenAiStreamingChatModel;
 import dev.langchain4j.http.client.jdk.JdkHttpClient;
 import dev.langchain4j.http.client.jdk.JdkHttpClientBuilder;
+import okhttp3.OkHttpClient;
 import org.jetbrains.annotations.NotNull;
 
 import java.time.Duration;
@@ -25,6 +26,29 @@ import java.net.http.HttpClient;
 public class CustomOpenAIChatModelFactory implements ChatModelFactory {
 
     private static final Logger LOG = Logger.getInstance(CustomOpenAIChatModelFactory.class);
+
+    /**
+     * Dedicated fast-fail client for the best-effort {@code /models} probe.
+     *
+     * <p>Unlike the shared {@link com.devoxx.genie.util.HttpClientProvider} client (10s connect
+     * timeout + 3 retries with exponential backoff), this client makes a single attempt with a
+     * short connect/read timeout. A model-list probe should degrade quickly to "type the model
+     * name manually" rather than tie up the caller for tens of seconds when the endpoint is slow
+     * or unreachable (e.g. a mistyped host).</p>
+     */
+    private static final OkHttpClient MODELS_PROBE_CLIENT = new OkHttpClient.Builder()
+            .connectTimeout(Duration.ofSeconds(3))
+            .readTimeout(Duration.ofSeconds(5))
+            .writeTimeout(Duration.ofSeconds(5))
+            .retryOnConnectionFailure(false)
+            .build();
+
+    /**
+     * Cached result of the last {@link #getModels()} probe. {@code null} means "not yet fetched".
+     * Cleared by {@link #resetModels()} (the Refresh button). Caching prevents a network round-trip
+     * on every provider selection, which otherwise re-probed the endpoint each time.
+     */
+    private volatile List<LanguageModel> cachedModels = null;
 
     @Override
     public ChatModel createChatModel(@NotNull CustomChatModel customChatModel) {
@@ -105,6 +129,27 @@ public class CustomOpenAIChatModelFactory implements ChatModelFactory {
      */
     @Override
     public List<LanguageModel> getModels() {
+        List<LanguageModel> cached = cachedModels;
+        if (cached != null) {
+            return cached;
+        }
+        List<LanguageModel> models = fetchModelsFromServer();
+        // Only cache a successful, non-empty probe. An empty result usually means the endpoint
+        // was momentarily unreachable/slow (e.g. right after IDE startup); caching it would make
+        // the model list stick empty until a manual Refresh. Leaving it uncached lets the next
+        // (background, bounded) probe recover once the endpoint is available.
+        if (!models.isEmpty()) {
+            cachedModels = models;
+        }
+        return models;
+    }
+
+    @Override
+    public void resetModels() {
+        cachedModels = null;
+    }
+
+    private List<LanguageModel> fetchModelsFromServer() {
         DevoxxGenieStateService state = DevoxxGenieStateService.getInstance();
         String baseUrl = state.getCustomOpenAIUrl();
         if (baseUrl == null || baseUrl.isBlank()) {
@@ -112,7 +157,7 @@ public class CustomOpenAIChatModelFactory implements ChatModelFactory {
         }
         try {
             String modelsUrl = (baseUrl.endsWith("/") ? baseUrl : baseUrl + "/") + "models";
-            ResponseDTO response = LocalLLMProviderUtil.getModelsFromUrl(modelsUrl, ResponseDTO.class);
+            ResponseDTO response = LocalLLMProviderUtil.getModelsFromUrl(modelsUrl, ResponseDTO.class, MODELS_PROBE_CLIENT);
             if (response == null || response.getData() == null) {
                 return Collections.emptyList();
             }

--- a/src/main/java/com/devoxx/genie/ui/panel/LlmProviderPanel.java
+++ b/src/main/java/com/devoxx/genie/ui/panel/LlmProviderPanel.java
@@ -22,6 +22,7 @@ import com.intellij.ui.components.JBPanel;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.jspecify.annotations.NonNull;
 
 import javax.swing.*;
@@ -114,8 +115,10 @@ public class LlmProviderPanel extends JBPanel<LlmProviderPanel> implements LLMSe
         lastSelectedProvider = DevoxxGenieStateService.getInstance().getSelectedProvider(stateKey);
         lastSelectedLanguageModel = DevoxxGenieStateService.getInstance().getSelectedLanguageModel(stateKey);
 
+        // restoreLastSelectedProvider() triggers asynchronous model loading and restores the
+        // previously selected language model via its completion callback once the combo is
+        // populated (see updateModelNamesComboBox), so no separate restore call is needed here.
         restoreLastSelectedProvider();
-        restoreLastSelectedLanguageModel();
 
         modelProviderComboBox.addActionListener(this::handleModelProviderSelectionChange);
         modelNameComboBox.addActionListener(this::handleModelNameSelectionChange);
@@ -208,36 +211,35 @@ public class LlmProviderPanel extends JBPanel<LlmProviderPanel> implements LLMSe
                     .orElseThrow(() -> new IllegalArgumentException("No factory for provider: " + selectedProvider));
             factory.resetModels();
 
-            refreshModelComboBox(selectedProvider);
-            refreshButton.setEnabled(true);
+            // Reload asynchronously (getModels() may hit the network) and re-enable the
+            // button once the combo has been repopulated.
+            updateModelNamesComboBox(selectedProvider.getName(), () -> refreshButton.setEnabled(true));
         });
     }
 
     private void refreshCloudModels(@NonNull ModelProvider selectedProvider) {
         refreshButton.setEnabled(false);
 
-        Set<String> beforeNames = ChatModelFactoryProvider.getFactoryByProvider(selectedProvider.name())
-                .map(f -> f.getModels().stream()
-                        .map(LanguageModel::getModelName)
-                        .collect(Collectors.toSet()))
-                .orElse(Collections.emptySet());
+        // Capture the "before" model names off the EDT: getModels() may hit the network
+        // (e.g. Custom OpenAI probes its /models endpoint) and must never block the UI.
+        ApplicationManager.getApplication().executeOnPooledThread(() -> {
+            Set<String> beforeNames = ChatModelFactoryProvider.getFactoryByProvider(selectedProvider.name())
+                    .map(f -> f.getModels().stream()
+                            .map(LanguageModel::getModelName)
+                            .collect(Collectors.toSet()))
+                    .orElse(Collections.emptySet());
 
-        ModelConfigService.getInstance().forceRefresh(() -> {
-            ChatModelFactoryProvider.getFactoryByProvider(selectedProvider.name())
-                    .ifPresent(ChatModelFactory::resetModels);
-            refreshModelComboBox(selectedProvider);
-            refreshButton.setEnabled(true);
-
-            notifyModelChanges(selectedProvider, beforeNames);
+            ModelConfigService.getInstance().forceRefresh(() -> {
+                ChatModelFactoryProvider.getFactoryByProvider(selectedProvider.name())
+                        .ifPresent(ChatModelFactory::resetModels);
+                // Reload the combo asynchronously; re-enable the button and report the
+                // diff once the (now-cached) models have been populated.
+                updateModelNamesComboBox(selectedProvider.getName(), () -> {
+                    refreshButton.setEnabled(true);
+                    notifyModelChanges(selectedProvider, beforeNames);
+                });
+            });
         });
-    }
-
-    private void refreshModelComboBox(@NonNull ModelProvider selectedProvider) {
-        updateModelNamesComboBox(selectedProvider.getName());
-        modelNameComboBox.setRenderer(new ModelInfoRenderer());
-        modelNameComboBox.setFont(DevoxxGenieFontsUtil.getDropdownFont());
-        modelNameComboBox.revalidate();
-        modelNameComboBox.repaint();
     }
 
     private void notifyModelChanges(@NonNull ModelProvider selectedProvider,
@@ -267,51 +269,78 @@ public class LlmProviderPanel extends JBPanel<LlmProviderPanel> implements LLMSe
      * Update the model names combobox.
      */
     public void updateModelNamesComboBox(String modelProvider) {
-        Optional.ofNullable(modelProvider).ifPresent(provider -> {
+        updateModelNamesComboBox(modelProvider, null);
+    }
+
+    /**
+     * Update the model names combobox, invoking {@code onComplete} on the EDT once the combo
+     * has been repopulated.
+     * <p>
+     * The actual {@link ChatModelFactory#getModels()} call is dispatched to a background thread
+     * because it can perform blocking network I/O (e.g. the Custom OpenAI provider probes its
+     * {@code /models} endpoint). Running it on the EDT froze the IDE when the endpoint was slow
+     * or unreachable. Results are applied back to the combo on the EDT.
+     *
+     * @param modelProvider the provider name; when {@code null} nothing happens
+     * @param onComplete    optional callback run on the EDT after the combo is updated
+     */
+    public void updateModelNamesComboBox(String modelProvider, @Nullable Runnable onComplete) {
+        if (modelProvider == null) {
+            return;
+        }
+
+        Optional<ChatModelFactory> factoryOpt = ChatModelFactoryProvider.getFactoryByProvider(modelProvider);
+        if (factoryOpt.isEmpty()) {
+            applyModelsOnEdt(Collections.emptyList(), onComplete);
+            return;
+        }
+
+        ChatModelFactory factory = factoryOpt.get();
+        ApplicationManager.getApplication().executeOnPooledThread(() -> {
+            List<LanguageModel> models;
+            try {
+                models = new ArrayList<>(factory.getModels());
+            } catch (Exception e) {
+                log.error("Error fetching models for provider {}", modelProvider, e);
+                models = Collections.emptyList();
+            }
+            applyModelsOnEdt(models, onComplete);
+        });
+    }
+
+    /**
+     * Apply the fetched models to the combo on the EDT. Keeps {@link #isUpdatingModelNames}
+     * {@code true} while the combo is repopulated so the selection listener can distinguish
+     * programmatic updates from user actions.
+     */
+    private void applyModelsOnEdt(@NotNull List<LanguageModel> models, @Nullable Runnable onComplete) {
+        ApplicationManager.getApplication().invokeLater(() -> {
             boolean wasUpdating = isUpdatingModelNames;
             isUpdatingModelNames = true;
             try {
                 modelNameComboBox.removeAllItems();
-                modelNameComboBox.setVisible(true);
-                // Ensure font consistency is maintained when updating
                 modelNameComboBox.setFont(DevoxxGenieFontsUtil.getDropdownFont());
-
-                ChatModelFactoryProvider
-                        .getFactoryByProvider(provider)
-                        .ifPresentOrElse(
-                                factory -> {
-                                    List<LanguageModel> models = factory.getModels();
-                                    if (models.isEmpty()) {
-                                        hideModelNameComboBox();
-                                    } else {
-                                        populateModelNames(factory);
-                                    }
-                                },
-                                this::hideModelNameComboBox
-                        );
+                if (models.isEmpty()) {
+                    hideModelNameComboBox();
+                } else {
+                    modelNameComboBox.setVisible(true);
+                    List<LanguageModel> sorted = new ArrayList<>(models);
+                    sorted.sort(Comparator.naturalOrder());
+                    sorted.forEach(modelNameComboBox::addItem);
+                }
+                modelNameComboBox.setRenderer(new ModelInfoRenderer());
+                modelNameComboBox.revalidate();
+                modelNameComboBox.repaint();
             } catch (Exception e) {
                 log.error("Error updating model names", e);
                 Messages.showErrorDialog(project, "Failed to update model names: " + e.getMessage(), "Error");
             } finally {
                 isUpdatingModelNames = wasUpdating;
             }
+            if (onComplete != null) {
+                onComplete.run();
+            }
         });
-    }
-
-    /**
-     * Populate the model names.
-     *
-     * @param chatModelFactory the chat model factory
-     */
-    private void populateModelNames(@NotNull ChatModelFactory chatModelFactory) {
-        modelNameComboBox.removeAllItems();
-        List<LanguageModel> modelNames = new ArrayList<>(chatModelFactory.getModels());
-        if (modelNames.isEmpty()) {
-            hideModelNameComboBox();
-        } else {
-            modelNames.sort(Comparator.naturalOrder());
-            modelNames.forEach(modelNameComboBox::addItem);
-        }
     }
 
     /**
@@ -330,7 +359,9 @@ public class LlmProviderPanel extends JBPanel<LlmProviderPanel> implements LLMSe
                 ModelProvider provider = modelProviderComboBox.getItemAt(i);
                 if (provider.getName().equals(lastSelectedProvider)) {
                     modelProviderComboBox.setSelectedIndex(i);
-                    updateModelNamesComboBox(lastSelectedProvider);
+                    // Model loading is asynchronous, so restore the previously selected
+                    // language model only once the combo has been repopulated.
+                    updateModelNamesComboBox(lastSelectedProvider, this::restoreLastSelectedLanguageModel);
                     break;
                 }
             }
@@ -343,21 +374,47 @@ public class LlmProviderPanel extends JBPanel<LlmProviderPanel> implements LLMSe
      * Restore the last selected language model from persistent storage
      */
     public void restoreLastSelectedLanguageModel() {
-        if (lastSelectedLanguageModel != null) {
-            boolean wasUpdating = isUpdatingModelNames;
-            isUpdatingModelNames = true;
-            try {
-                for (int i = 0; i < modelNameComboBox.getItemCount(); i++) {
-                    LanguageModel model = modelNameComboBox.getItemAt(i);
-                    if (model.getModelName().equals(lastSelectedLanguageModel)) {
-                        modelNameComboBox.setSelectedIndex(i);
-                        break;
-                    }
-                }
-            } finally {
-                isUpdatingModelNames = wasUpdating;
-            }
+        if (lastSelectedLanguageModel == null) {
+            return;
         }
+        boolean wasUpdating = isUpdatingModelNames;
+        isUpdatingModelNames = true;
+        try {
+            for (int i = 0; i < modelNameComboBox.getItemCount(); i++) {
+                LanguageModel model = modelNameComboBox.getItemAt(i);
+                if (model.getModelName().equals(lastSelectedLanguageModel)) {
+                    modelNameComboBox.setSelectedIndex(i);
+                    return;
+                }
+            }
+            // The persisted model is not in the freshly fetched list. This is common for the
+            // Custom OpenAI provider whose /models endpoint may be slow, unavailable at startup,
+            // or simply not enumerate the chosen model. Re-add it so the user's selection still
+            // survives an IDE restart rather than silently resetting.
+            restorePersistedModelNotInList();
+        } finally {
+            isUpdatingModelNames = wasUpdating;
+        }
+    }
+
+    /**
+     * Re-add the persisted language model to the combo when the provider did not return it,
+     * so the previous selection is preserved across restarts. A minimal {@link LanguageModel}
+     * is synthesised from the persisted name and current provider.
+     */
+    private void restorePersistedModelNotInList() {
+        ModelProvider provider = (ModelProvider) modelProviderComboBox.getSelectedItem();
+        if (provider == null) {
+            return;
+        }
+        LanguageModel restored = LanguageModel.builder()
+                .provider(provider)
+                .modelName(lastSelectedLanguageModel)
+                .displayName(lastSelectedLanguageModel)
+                .build();
+        modelNameComboBox.addItem(restored);
+        modelNameComboBox.setSelectedItem(restored);
+        modelNameComboBox.setVisible(true);
     }
 
     /**
@@ -403,24 +460,15 @@ public class LlmProviderPanel extends JBPanel<LlmProviderPanel> implements LLMSe
             isUpdatingModelNames)
             return;
 
-        isUpdatingModelNames = true;
-
-        try {
-            DevoxxGenieStateService stateInstance = DevoxxGenieStateService.getInstance();
-            JComboBox<?> comboBox = (JComboBox<?>) e.getSource();
-            ModelProvider modelProvider = (ModelProvider) comboBox.getSelectedItem();
-            if (modelProvider != null) {
-                stateInstance.setSelectedProvider(stateKey, modelProvider.getName());
-
-                updateModelNamesComboBox(modelProvider.getName());
-
-                modelNameComboBox.setRenderer(new ModelInfoRenderer());
-                modelNameComboBox.setFont(DevoxxGenieFontsUtil.getDropdownFont());
-                modelNameComboBox.revalidate();
-                modelNameComboBox.repaint();
-            }
-        } finally {
-            isUpdatingModelNames = false;
+        DevoxxGenieStateService stateInstance = DevoxxGenieStateService.getInstance();
+        JComboBox<?> comboBox = (JComboBox<?>) e.getSource();
+        ModelProvider modelProvider = (ModelProvider) comboBox.getSelectedItem();
+        if (modelProvider != null) {
+            stateInstance.setSelectedProvider(stateKey, modelProvider.getName());
+            // Models are fetched off the EDT and applied back asynchronously (see
+            // updateModelNamesComboBox), which also manages isUpdatingModelNames while it
+            // repopulates the combo. This keeps the UI responsive for slow/unreachable endpoints.
+            updateModelNamesComboBox(modelProvider.getName());
         }
     }
 }

--- a/src/main/java/com/devoxx/genie/ui/window/DevoxxGenieToolWindowContent.java
+++ b/src/main/java/com/devoxx/genie/ui/window/DevoxxGenieToolWindowContent.java
@@ -241,22 +241,23 @@ public class DevoxxGenieToolWindowContent implements SettingsChangeListener, Glo
         LanguageModel currentModel = (LanguageModel) llmProviderPanel.getModelNameComboBox().getSelectedItem();
 
         suppressModelSelectionTracking = true;
-        try {
-            llmProviderPanel.getModelProviderComboBox().removeAllItems();
-            llmProviderPanel.getModelNameComboBox().removeAllItems();
-            llmProviderPanel.addModelProvidersToComboBox();
 
-            if (currentProvider != null) {
-                llmProviderPanel.getModelProviderComboBox().setSelectedItem(currentProvider);
-                llmProviderPanel.updateModelNamesComboBox(currentProvider.getName());
+        llmProviderPanel.getModelProviderComboBox().removeAllItems();
+        llmProviderPanel.getModelNameComboBox().removeAllItems();
+        llmProviderPanel.addModelProvidersToComboBox();
 
+        if (currentProvider != null) {
+            llmProviderPanel.getModelProviderComboBox().setSelectedItem(currentProvider);
+            // Model loading is asynchronous, so re-select the current model and lift the
+            // tracking suppression only once the combo has actually been repopulated.
+            llmProviderPanel.updateModelNamesComboBox(currentProvider.getName(), () -> {
                 if (currentModel != null) {
                     llmProviderPanel.getModelNameComboBox().setSelectedItem(currentModel);
                 }
-            } else {
-                llmProviderPanel.setLastSelectedProvider();
-            }
-        } finally {
+                suppressModelSelectionTracking = false;
+            });
+        } else {
+            llmProviderPanel.setLastSelectedProvider();
             suppressModelSelectionTracking = false;
         }
     }

--- a/src/test/java/com/devoxx/genie/chatmodel/local/customopenai/CustomOpenAIChatModelFactoryTest.java
+++ b/src/test/java/com/devoxx/genie/chatmodel/local/customopenai/CustomOpenAIChatModelFactoryTest.java
@@ -1,11 +1,14 @@
 package com.devoxx.genie.chatmodel.local.customopenai;
 
+import com.devoxx.genie.chatmodel.local.LocalLLMProviderUtil;
 import com.devoxx.genie.model.CustomChatModel;
 import com.devoxx.genie.model.LanguageModel;
+import com.devoxx.genie.model.gpt4all.ResponseDTO;
 import com.devoxx.genie.service.mcp.MCPService;
 import com.devoxx.genie.ui.settings.DevoxxGenieStateService;
 import dev.langchain4j.model.chat.ChatModel;
 import dev.langchain4j.model.chat.StreamingChatModel;
+import okhttp3.OkHttpClient;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -19,7 +22,10 @@ import org.mockito.quality.Strictness;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -180,5 +186,63 @@ class CustomOpenAIChatModelFactoryTest {
         when(mockState.getCustomOpenAIUrl()).thenReturn("http://127.0.0.1:1/v1/");
         CustomOpenAIChatModelFactory factory = new CustomOpenAIChatModelFactory();
         assertThat(factory.getModels()).isEmpty();
+    }
+
+    @Test
+    void getModelsCachesResultAndProbesEndpointOnlyOnce() {
+        // Regression for the freeze: repeated provider selections must not re-probe the
+        // /models endpoint every time. The network call is cached after the first fetch.
+        when(mockState.getCustomOpenAIUrl()).thenReturn("http://localhost:8080/v1/");
+
+        ResponseDTO response = buildResponse("model-a", "model-b");
+
+        try (MockedStatic<LocalLLMProviderUtil> util = Mockito.mockStatic(LocalLLMProviderUtil.class)) {
+            util.when(() -> LocalLLMProviderUtil.getModelsFromUrl(
+                            eq("http://localhost:8080/v1/models"), eq(ResponseDTO.class), any(OkHttpClient.class)))
+                    .thenReturn(response);
+
+            CustomOpenAIChatModelFactory factory = new CustomOpenAIChatModelFactory();
+
+            List<LanguageModel> first = factory.getModels();
+            List<LanguageModel> second = factory.getModels();
+
+            assertThat(first).extracting(LanguageModel::getModelName).containsExactly("model-a", "model-b");
+            assertThat(second).extracting(LanguageModel::getModelName).containsExactly("model-a", "model-b");
+
+            // The endpoint is probed exactly once despite two getModels() calls.
+            util.verify(() -> LocalLLMProviderUtil.getModelsFromUrl(
+                    eq("http://localhost:8080/v1/models"), eq(ResponseDTO.class), any(OkHttpClient.class)), times(1));
+        }
+    }
+
+    @Test
+    void resetModelsClearsCacheSoNextGetModelsReprobes() {
+        when(mockState.getCustomOpenAIUrl()).thenReturn("http://localhost:8080/v1/");
+
+        try (MockedStatic<LocalLLMProviderUtil> util = Mockito.mockStatic(LocalLLMProviderUtil.class)) {
+            util.when(() -> LocalLLMProviderUtil.getModelsFromUrl(
+                            eq("http://localhost:8080/v1/models"), eq(ResponseDTO.class), any(OkHttpClient.class)))
+                    .thenReturn(buildResponse("model-a"));
+
+            CustomOpenAIChatModelFactory factory = new CustomOpenAIChatModelFactory();
+
+            factory.getModels();
+            factory.resetModels();
+            factory.getModels();
+
+            // After reset the endpoint is probed again: two probes for two uncached calls.
+            util.verify(() -> LocalLLMProviderUtil.getModelsFromUrl(
+                    eq("http://localhost:8080/v1/models"), eq(ResponseDTO.class), any(OkHttpClient.class)), times(2));
+        }
+    }
+
+    private static ResponseDTO buildResponse(String... modelIds) {
+        ResponseDTO dto = new ResponseDTO();
+        dto.setData(java.util.Arrays.stream(modelIds).map(id -> {
+            com.devoxx.genie.model.gpt4all.Model m = new com.devoxx.genie.model.gpt4all.Model();
+            m.setId(id);
+            return m;
+        }).toList());
+        return dto;
     }
 }

--- a/src/test/java/com/devoxx/genie/ui/panel/LlmProviderPanelTest.java
+++ b/src/test/java/com/devoxx/genie/ui/panel/LlmProviderPanelTest.java
@@ -24,6 +24,7 @@ import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.*;
 
@@ -62,6 +63,18 @@ class LlmProviderPanelTest {
         appManagerMockedStatic = Mockito.mockStatic(ApplicationManager.class);
         appManagerMockedStatic.when(ApplicationManager::getApplication).thenReturn(application);
         lenient().when(application.getService(DevoxxGenieStateService.class)).thenReturn(stateService);
+
+        // Model loading is now dispatched off the EDT via executeOnPooledThread and applied back
+        // via invokeLater. In tests we run both inline so the (otherwise asynchronous) combo
+        // population completes synchronously and the assertions below remain deterministic.
+        lenient().when(application.executeOnPooledThread(any(Runnable.class))).thenAnswer(invocation -> {
+            invocation.getArgument(0, Runnable.class).run();
+            return java.util.concurrent.CompletableFuture.completedFuture(null);
+        });
+        lenient().doAnswer(invocation -> {
+            invocation.getArgument(0, Runnable.class).run();
+            return null;
+        }).when(application).invokeLater(any(Runnable.class));
 
         stateServiceMockedStatic = Mockito.mockStatic(DevoxxGenieStateService.class);
         stateServiceMockedStatic.when(DevoxxGenieStateService::getInstance).thenReturn(stateService);
@@ -122,17 +135,9 @@ class LlmProviderPanelTest {
         when(llmProviderService.getAvailableModelProviders()).thenReturn(providers);
 
         ChatModelFactory factory = mock(ChatModelFactory.class);
-        boolean[] flagSnapshotDuringPopulate = new boolean[]{false};
-        // Capture the flag value at the moment the factory is asked for models — that runs
-        // inside updateModelNamesComboBox after isUpdatingModelNames was set true.
-        LlmProviderPanel[] panelHolder = new LlmProviderPanel[1];
-        when(factory.getModels()).thenAnswer(invocation -> {
-            flagSnapshotDuringPopulate[0] = panelHolder[0].isUpdatingModelNames();
-            return List.of(
-                    LanguageModel.builder().provider(ModelProvider.OpenAI)
-                            .modelName("gpt-4").displayName("GPT-4").build()
-            );
-        });
+        when(factory.getModels()).thenReturn(List.of(
+                LanguageModel.builder().provider(ModelProvider.OpenAI)
+                        .modelName("gpt-4").displayName("GPT-4").build()));
 
         factoryProviderMockedStatic.when(() -> ChatModelFactoryProvider.getFactoryByProvider("OpenAI"))
                 .thenReturn(Optional.of(factory));
@@ -140,7 +145,13 @@ class LlmProviderPanelTest {
                 .thenReturn(Optional.empty());
 
         LlmProviderPanel panel = new LlmProviderPanel(project);
-        panelHolder[0] = panel;
+
+        // The network fetch now runs off the EDT (without the flag); the flag must be true while
+        // the combo items are added on the EDT — that is when the selection ActionEvents (which
+        // drive model_selected analytics) fire and must be suppressed. Capture the flag at that point.
+        boolean[] flagDuringPopulate = new boolean[]{false};
+        panel.getModelNameComboBox().addActionListener(e ->
+                flagDuringPopulate[0] = flagDuringPopulate[0] || panel.isUpdatingModelNames());
 
         assertThat(panel.isUpdatingModelNames())
                 .as("Flag is false before any programmatic update")
@@ -148,12 +159,46 @@ class LlmProviderPanelTest {
 
         panel.updateModelNamesComboBox("OpenAI");
 
-        assertThat(flagSnapshotDuringPopulate[0])
+        assertThat(flagDuringPopulate[0])
                 .as("Flag must be true while combo is being repopulated")
                 .isTrue();
         assertThat(panel.isUpdatingModelNames())
                 .as("Flag must reset to false after updateModelNamesComboBox completes")
                 .isFalse();
+    }
+
+    @Test
+    void updateModelNamesComboBox_fetchesModelsOffTheEdt() {
+        // Regression for the CustomOpenAI freeze: getModels() can perform blocking network I/O,
+        // so it must be dispatched to a background thread (executeOnPooledThread) rather than
+        // called directly on the EDT while the provider combo selection is being handled.
+        List<ModelProvider> providers = List.of(ModelProvider.OpenAI);
+        when(llmProviderService.getAvailableModelProviders()).thenReturn(providers);
+
+        ChatModelFactory factory = mock(ChatModelFactory.class);
+        boolean[] fetchedViaPool = new boolean[]{false};
+        // The pooled-thread stub records that the fetch runnable actually ran through it.
+        when(application.executeOnPooledThread(any(Runnable.class))).thenAnswer(invocation -> {
+            fetchedViaPool[0] = true;
+            invocation.getArgument(0, Runnable.class).run();
+            return java.util.concurrent.CompletableFuture.completedFuture(null);
+        });
+        when(factory.getModels()).thenReturn(List.of(
+                LanguageModel.builder().provider(ModelProvider.OpenAI)
+                        .modelName("gpt-4").displayName("GPT-4").build()));
+
+        factoryProviderMockedStatic.when(() -> ChatModelFactoryProvider.getFactoryByProvider("OpenAI"))
+                .thenReturn(Optional.of(factory));
+
+        LlmProviderPanel panel = new LlmProviderPanel(project);
+        fetchedViaPool[0] = false; // ignore any construction-time loading
+
+        panel.updateModelNamesComboBox("OpenAI");
+
+        assertThat(fetchedViaPool[0])
+                .as("Model fetch must be dispatched off the EDT")
+                .isTrue();
+        verify(factory, atLeastOnce()).getModels();
     }
 
     @Test
@@ -326,6 +371,61 @@ class LlmProviderPanelTest {
         LanguageModel selected = (LanguageModel) panel.getModelNameComboBox().getSelectedItem();
         assertThat(selected).isNotNull();
         assertThat(selected.getModelName()).isEqualTo("gpt-4");
+    }
+
+    @Test
+    void restoresCustomOpenAiModelAfterRestart() {
+        // Reproduction for "CustomOpenAI selected model not restored after restart":
+        // when the provider and model were persisted and the /models probe returns the
+        // saved model, it must be re-selected on construction.
+        when(stateService.isCustomOpenAIUrlEnabled()).thenReturn(true);
+        when(stateService.getSelectedProvider("test-hash")).thenReturn("CustomOpenAI");
+        when(stateService.getSelectedLanguageModel("test-hash")).thenReturn("meta/llama-3.1-70b");
+
+        List<ModelProvider> providers = List.of(ModelProvider.CustomOpenAI);
+        when(llmProviderService.getAvailableModelProviders()).thenReturn(providers);
+
+        ChatModelFactory factory = mock(ChatModelFactory.class);
+        when(factory.getModels()).thenReturn(List.of(
+                LanguageModel.builder().provider(ModelProvider.CustomOpenAI)
+                        .modelName("meta/llama-3.1-8b").displayName("meta/llama-3.1-8b").build(),
+                LanguageModel.builder().provider(ModelProvider.CustomOpenAI)
+                        .modelName("meta/llama-3.1-70b").displayName("meta/llama-3.1-70b").build()));
+
+        factoryProviderMockedStatic.when(() -> ChatModelFactoryProvider.getFactoryByProvider("CustomOpenAI"))
+                .thenReturn(Optional.of(factory));
+
+        LlmProviderPanel panel = new LlmProviderPanel(project);
+
+        LanguageModel selected = (LanguageModel) panel.getModelNameComboBox().getSelectedItem();
+        assertThat(selected).isNotNull();
+        assertThat(selected.getModelName()).isEqualTo("meta/llama-3.1-70b");
+    }
+
+    @Test
+    void restoresCustomOpenAiModelEvenWhenNotInFetchedList() {
+        // The /models endpoint may be slow/unavailable at startup or may not enumerate the
+        // chosen model. The persisted selection must still be restored (re-added and selected).
+        when(stateService.isCustomOpenAIUrlEnabled()).thenReturn(true);
+        when(stateService.getSelectedProvider("test-hash")).thenReturn("CustomOpenAI");
+        when(stateService.getSelectedLanguageModel("test-hash")).thenReturn("meta/llama-3.1-70b");
+
+        List<ModelProvider> providers = List.of(ModelProvider.CustomOpenAI);
+        when(llmProviderService.getAvailableModelProviders()).thenReturn(providers);
+
+        ChatModelFactory factory = mock(ChatModelFactory.class);
+        // Endpoint returns nothing (cold start / unreachable).
+        when(factory.getModels()).thenReturn(Collections.emptyList());
+
+        factoryProviderMockedStatic.when(() -> ChatModelFactoryProvider.getFactoryByProvider("CustomOpenAI"))
+                .thenReturn(Optional.of(factory));
+
+        LlmProviderPanel panel = new LlmProviderPanel(project);
+
+        LanguageModel selected = (LanguageModel) panel.getModelNameComboBox().getSelectedItem();
+        assertThat(selected).isNotNull();
+        assertThat(selected.getModelName()).isEqualTo("meta/llama-3.1-70b");
+        assertThat(selected.getProvider()).isEqualTo(ModelProvider.CustomOpenAI);
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Selecting the **CustomOpenAI** provider froze the IDE when its URL was slow/unreachable (e.g. a mistyped host): the provider-selection handler called `getModels()` on the EDT, doing a blocking HTTP GET to `/models` via the shared client (10s connect timeout + 3 retries with backoff).
- **Load models off the EDT:** `updateModelNamesComboBox` now fetches on a pooled thread and applies results via `invokeLater` with an optional completion callback; all callers updated. `CustomOpenAIChatModelFactory` caches results and probes with a dedicated fast-fail `OkHttpClient` (3s/5s, no retries); empty probes aren't cached so a cold-start failure isn't sticky.
- **Restore on restart:** the persisted model is now re-selected even when the `/models` endpoint doesn't return it, and a `settingsChanged()` regression (re-selecting before the async combo repopulated) is fixed.

## Test plan
- [x] Full suite green: `./gradlew test` (verified locally, BUILD SUCCESSFUL)
- [x] Select CustomOpenAI with an unreachable URL (e.g. `http://itegrate.api.nvidia.com/v1`) → IDE stays responsive, model dropdown degrades gracefully
- [x] Select CustomOpenAI with a working endpoint, pick a model, restart IDE → previously selected model is restored

🤖 Generated with [Claude Code](https://claude.com/claude-code)