### PR TITLE
Add NVIDIA as a cloud LLM provider

### DIFF
--- a/src/main/java/com/devoxx/genie/chatmodel/ChatModelFactoryProvider.java
+++ b/src/main/java/com/devoxx/genie/chatmodel/ChatModelFactoryProvider.java
@@ -11,6 +11,7 @@ import com.devoxx.genie.chatmodel.cloud.grok.GrokChatModelFactory;
 import com.devoxx.genie.chatmodel.cloud.groq.GroqChatModelFactory;
 import com.devoxx.genie.chatmodel.cloud.kimi.KimiChatModelFactory;
 import com.devoxx.genie.chatmodel.cloud.mistral.MistralChatModelFactory;
+import com.devoxx.genie.chatmodel.cloud.nvidia.NvidiaChatModelFactory;
 import com.devoxx.genie.chatmodel.cloud.openai.OpenAIChatModelFactory;
 import com.devoxx.genie.chatmodel.cloud.openrouter.OpenRouterChatModelFactory;
 import com.devoxx.genie.chatmodel.local.acprunners.AcpRunnersChatModelFactory;
@@ -80,6 +81,7 @@ public final class ChatModelFactoryProvider {
         FACTORY_SUPPLIERS.put(ModelProvider.Grok, GrokChatModelFactory::new);
         FACTORY_SUPPLIERS.put(ModelProvider.Kimi, KimiChatModelFactory::new);
         FACTORY_SUPPLIERS.put(ModelProvider.GLM, GLMChatModelFactory::new);
+        FACTORY_SUPPLIERS.put(ModelProvider.Nvidia, NvidiaChatModelFactory::new);
         FACTORY_SUPPLIERS.put(ModelProvider.CLIRunners, CliRunnersChatModelFactory::new);
         FACTORY_SUPPLIERS.put(ModelProvider.ACPRunners, AcpRunnersChatModelFactory::new);
     }

--- a/src/main/java/com/devoxx/genie/chatmodel/cloud/nvidia/NvidiaChatModelFactory.java
+++ b/src/main/java/com/devoxx/genie/chatmodel/cloud/nvidia/NvidiaChatModelFactory.java
@@ -1,0 +1,234 @@
+package com.devoxx.genie.chatmodel.cloud.nvidia;
+
+import com.devoxx.genie.chatmodel.ChatModelFactory;
+import com.devoxx.genie.chatmodel.local.LocalLLMProviderUtil;
+import com.devoxx.genie.model.CustomChatModel;
+import com.devoxx.genie.model.LanguageModel;
+import com.devoxx.genie.model.enumarations.ModelProvider;
+import com.devoxx.genie.model.gpt4all.ResponseDTO;
+import com.intellij.openapi.diagnostic.Logger;
+import dev.langchain4j.model.chat.ChatModel;
+import dev.langchain4j.model.chat.StreamingChatModel;
+import dev.langchain4j.model.openai.OpenAiChatModel;
+import dev.langchain4j.model.openai.OpenAiStreamingChatModel;
+import okhttp3.OkHttpClient;
+import org.jetbrains.annotations.NotNull;
+
+import java.time.Duration;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * NVIDIA NIM (build.nvidia.com) chat model factory. NVIDIA exposes an
+ * OpenAI-compatible endpoint at {@code https://integrate.api.nvidia.com/v1},
+ * so we reuse the langchain4j OpenAI client and only swap the base URL + API key.
+ */
+public class NvidiaChatModelFactory implements ChatModelFactory {
+
+    private static final Logger LOG = Logger.getInstance(NvidiaChatModelFactory.class);
+
+    private static final String BASE_URL = "https://integrate.api.nvidia.com/v1";
+    private static final String MODELS_URL = BASE_URL + "/models";
+
+    /**
+     * NVIDIA's OpenAI-compatible {@code /v1/models} endpoint returns only model ids
+     * (standard OpenAI {@code {"data":[{"id":...}]}} shape) with no context length, so
+     * every dynamically-listed model is given a heuristic window instead of the
+     * primitive-int default of 0 (the zero-context symptom seen through the generic
+     * "Custom OpenAI URL" path). This value only feeds the token-usage bar and the
+     * "add project to context" budget — it never truncates a conversation — so a
+     * best-effort approximation is fine. 128K covers the bulk of NVIDIA's instruct
+     * LLMs (Llama 3.x, Nemotron, Qwen3, DeepSeek, GPT-OSS, GLM, Kimi, Mistral 2/3, …).
+     */
+    private static final int DEFAULT_CONTEXT_WINDOW = 128_000;
+
+    /**
+     * Heuristic context-window overrides for the model families whose window is NOT 128K,
+     * keyed by a lowercase substring of the model id and checked in insertion order
+     * (first match wins). Values are derived from published NIM/model specs. Auxiliary /
+     * non-chat models (embeddings, rerankers, safety-guards, OCR/parse, translation,
+     * vision-only) are listed FIRST and given a modest window so a base-model name in
+     * their id (e.g. {@code nv-embedqa-mistral-7b}) cannot mis-bucket them. Anything not
+     * matched here falls back to {@link #DEFAULT_CONTEXT_WINDOW}. Verified against the
+     * full live {@code /v1/models} catalogue (121 models).
+     */
+    private static final Map<String, Integer> CONTEXT_WINDOW_BY_SUBSTRING = new LinkedHashMap<>();
+    static {
+        Map<String, Integer> m = CONTEXT_WINDOW_BY_SUBSTRING;
+        // --- Auxiliary / non-chat (embeddings, rerankers, moderation, OCR/parse, translation, vision-only) ---
+        m.put("embed", 8_192);
+        m.put("bge-", 8_192);
+        m.put("nvclip", 8_192);
+        m.put("nemoretriever", 8_192);
+        m.put("-parse", 8_192);
+        m.put("guard", 8_192);
+        m.put("safety", 8_192);
+        m.put("topic-control", 8_192);
+        m.put("reward", 8_192);
+        m.put("gliner", 8_192);
+        m.put("translate", 8_192);
+        m.put("detector", 8_192);
+        m.put("deplot", 8_192);
+        m.put("kosmos", 8_192);
+        m.put("diffusiongemma", 8_192);
+        // --- 4K-context models ---
+        m.put("nemotron-4-340b", 4_096);
+        m.put("nemotron-mini", 4_096);
+        m.put("llama2-70b", 4_096);
+        m.put("solar-10.7b", 4_096);
+        m.put("neva", 4_096);
+        m.put("fuyu", 4_096);
+        m.put("vila", 4_096);
+        // --- Code models ---
+        m.put("codellama", 16_384);
+        m.put("starcoder2", 16_384);
+        m.put("deepseek-coder", 16_384);
+        m.put("granite-34b-code", 8_192);
+        m.put("granite-8b-code", 8_192);
+        m.put("codestral", 32_768);
+        // --- 8K-context models ---
+        m.put("minitron-8b-8k", 8_192);
+        m.put("chatqa", 8_192);
+        m.put("sea-lion", 8_192);
+        m.put("gemma-2b", 8_192);
+        m.put("gemma-2-", 8_192);
+        m.put("codegemma", 8_192);
+        m.put("recurrentgemma", 8_192);
+        // --- 16K-context models ---
+        m.put("zamba2", 16_384);
+        // --- 32K-context models ---
+        m.put("gemma-3n", 32_768);
+        m.put("yi-large", 32_768);
+        m.put("mixtral-8x7b", 32_768);
+        m.put("mistral-7b", 32_768);
+        m.put("dbrx", 32_768);
+        m.put("sarvam", 32_768);
+        m.put("palmyra-fin", 32_768);
+        m.put("palmyra-med", 32_768);
+        // Mistral Large: v2/v3 keep 128K; plain v1 is 32K (more specific keys first).
+        m.put("mistral-large-2", 128_000);
+        m.put("mistral-large-3", 128_000);
+        m.put("mistral-large", 32_768);
+        // --- 64K-context models ---
+        m.put("mixtral-8x22b", 65_536);
+        // --- 256K-context models ---
+        m.put("jamba", 256_000);
+        // --- 1M-context models ---
+        m.put("llama-4", 1_000_000);
+        m.put("maverick", 1_000_000);
+    }
+
+    /**
+     * Best-effort context window for a NVIDIA model id, using {@link #CONTEXT_WINDOW_BY_SUBSTRING}
+     * (first substring match wins) and falling back to {@link #DEFAULT_CONTEXT_WINDOW}.
+     */
+    static int contextWindowFor(@NotNull String modelId) {
+        String id = modelId.toLowerCase(Locale.ROOT);
+        for (Map.Entry<String, Integer> entry : CONTEXT_WINDOW_BY_SUBSTRING.entrySet()) {
+            if (id.contains(entry.getKey())) {
+                return entry.getValue();
+            }
+        }
+        return DEFAULT_CONTEXT_WINDOW;
+    }
+
+    /**
+     * Dedicated fast-fail client for the best-effort {@code /models} probe: a single
+     * attempt with short timeouts so the model-list fetch degrades quickly to the
+     * curated fallback rather than tying up the caller when the endpoint is slow.
+     */
+    private static final OkHttpClient MODELS_PROBE_CLIENT = new OkHttpClient.Builder()
+            .connectTimeout(Duration.ofSeconds(3))
+            .readTimeout(Duration.ofSeconds(5))
+            .writeTimeout(Duration.ofSeconds(5))
+            .retryOnConnectionFailure(false)
+            .build();
+
+    /** Cached result of the last {@link #getModels()} probe. Cleared by {@link #resetModels()} (Refresh). */
+    private volatile List<LanguageModel> cachedModels = null;
+
+    private final ModelProvider MODEL_PROVIDER = ModelProvider.Nvidia;
+
+    @Override
+    public ChatModel createChatModel(@NotNull CustomChatModel customChatModel) {
+        return OpenAiChatModel.builder()
+            .baseUrl(BASE_URL)
+            .apiKey(getApiKey(MODEL_PROVIDER))
+            .modelName(customChatModel.getModelName())
+            .maxRetries(customChatModel.getMaxRetries())
+            .temperature(customChatModel.getTemperature())
+            .maxTokens(customChatModel.getMaxTokens())
+            .timeout(Duration.ofSeconds(customChatModel.getTimeout()))
+            .topP(customChatModel.getTopP())
+            .listeners(getListener())
+            .build();
+    }
+
+    @Override
+    public StreamingChatModel createStreamingChatModel(@NotNull CustomChatModel customChatModel) {
+        return OpenAiStreamingChatModel.builder()
+            .baseUrl(BASE_URL)
+            .apiKey(getApiKey(MODEL_PROVIDER))
+            .modelName(customChatModel.getModelName())
+            .temperature(customChatModel.getTemperature())
+            .topP(customChatModel.getTopP())
+            .timeout(Duration.ofSeconds(customChatModel.getTimeout()))
+            .listeners(getListener())
+            .build();
+    }
+
+    /**
+     * Returns the full catalogue of NVIDIA models by probing the OpenAI-compatible
+     * {@code /v1/models} endpoint. On any failure (unreachable/empty/unparseable) this
+     * falls back to the curated hardcoded list from the model registry so the provider
+     * still offers models offline. Successful probes are cached until {@link #resetModels()}.
+     */
+    @Override
+    public List<LanguageModel> getModels() {
+        List<LanguageModel> cached = cachedModels;
+        if (cached != null) {
+            return cached;
+        }
+        List<LanguageModel> models = fetchModelsFromServer();
+        if (models.isEmpty()) {
+            // Degrade gracefully to the curated registry list; do not cache the fallback so
+            // the next probe can recover once the endpoint is reachable.
+            return getModels(MODEL_PROVIDER);
+        }
+        cachedModels = models;
+        return models;
+    }
+
+    @Override
+    public void resetModels() {
+        cachedModels = null;
+    }
+
+    private List<LanguageModel> fetchModelsFromServer() {
+        try {
+            ResponseDTO response = LocalLLMProviderUtil.getModelsFromUrl(MODELS_URL, ResponseDTO.class, MODELS_PROBE_CLIENT);
+            if (response == null || response.getData() == null) {
+                return Collections.emptyList();
+            }
+            return response.getData().stream()
+                    .filter(model -> model != null && model.getId() != null && !model.getId().isBlank())
+                    .map(model -> LanguageModel.builder()
+                            .provider(MODEL_PROVIDER)
+                            .modelName(model.getId())
+                            .displayName(model.getId())
+                            .inputCost(0)
+                            .outputCost(0)
+                            .inputMaxTokens(contextWindowFor(model.getId()))
+                            .apiKeyUsed(true)
+                            .build())
+                    .collect(Collectors.toList());
+        } catch (Exception e) {
+            LOG.warn("Could not fetch NVIDIA models from '" + MODELS_URL + "': " + e.getMessage());
+            return Collections.emptyList();
+        }
+    }
+}

--- a/src/main/java/com/devoxx/genie/model/enumarations/ModelProvider.java
+++ b/src/main/java/com/devoxx/genie/model/enumarations/ModelProvider.java
@@ -29,6 +29,7 @@ public enum ModelProvider {
     Grok("Grok", Type.CLOUD),
     Kimi("Kimi", Type.CLOUD),
     GLM("GLM", Type.CLOUD),
+    Nvidia("NVIDIA", Type.CLOUD),
 
     AzureOpenAI("AzureOpenAI", Type.OPTIONAL),
     Bedrock("Bedrock", Type.OPTIONAL);

--- a/src/main/java/com/devoxx/genie/service/DevoxxGenieSettingsService.java
+++ b/src/main/java/com/devoxx/genie/service/DevoxxGenieSettingsService.java
@@ -63,6 +63,8 @@ public interface DevoxxGenieSettingsService {
 
     String getGlmKey();
 
+    String getNvidiaKey();
+
     String getCustomOpenAIApiKey();
 
     Boolean getIsWebSearchEnabled();
@@ -166,6 +168,8 @@ public interface DevoxxGenieSettingsService {
     void setKimiKey(String key);
 
     void setGlmKey(String key);
+
+    void setNvidiaKey(String key);
 
     void setCustomOpenAIApiKey(String key);
 

--- a/src/main/java/com/devoxx/genie/service/LLMProviderService.java
+++ b/src/main/java/com/devoxx/genie/service/LLMProviderService.java
@@ -34,6 +34,7 @@ public class LLMProviderService {
         providerKeyMap.put(Grok, () -> DevoxxGenieStateService.getInstance().getGrokKey());
         providerKeyMap.put(Kimi, () -> DevoxxGenieStateService.getInstance().getKimiKey());
         providerKeyMap.put(GLM, () -> DevoxxGenieStateService.getInstance().getGlmKey());
+        providerKeyMap.put(Nvidia, () -> DevoxxGenieStateService.getInstance().getNvidiaKey());
         providerKeyMap.put(AzureOpenAI, () -> DevoxxGenieStateService.getInstance().getAzureOpenAIKey());
         providerKeyMap.put(Bedrock, () -> switch (Optional.ofNullable(DevoxxGenieStateService.getInstance().getAwsBedrockAuthMode())
                 .orElse(AwsBedrockAuthMode.defaultMode())) {
@@ -92,6 +93,7 @@ public class LLMProviderService {
                 case Grok -> stateService.isGrokEnabled();
                 case Kimi -> stateService.isKimiEnabled();
                 case GLM -> stateService.isGlmEnabled();
+                case Nvidia -> stateService.isNvidiaEnabled();
                 case AzureOpenAI -> stateService.isAzureOpenAIEnabled();
                 case Bedrock -> stateService.isAwsEnabled();
                 default -> false;

--- a/src/main/java/com/devoxx/genie/service/credentials/CredentialKey.java
+++ b/src/main/java/com/devoxx/genie/service/credentials/CredentialKey.java
@@ -24,6 +24,7 @@ public enum CredentialKey {
     GROK_KEY             ("grokKey"),
     KIMI_KEY             ("kimiKey"),
     GLM_KEY              ("glmKey"),
+    NVIDIA_KEY           ("nvidiaKey"),
     AZURE_OPEN_AI_KEY    ("azureOpenAIKey"),
     AWS_ACCESS_KEY_ID    ("awsAccessKeyId"),
     AWS_SECRET_KEY       ("awsSecretKey"),

--- a/src/main/java/com/devoxx/genie/service/models/LLMModelRegistryService.java
+++ b/src/main/java/com/devoxx/genie/service/models/LLMModelRegistryService.java
@@ -50,6 +50,7 @@ public final class LLMModelRegistryService {
         addGrokModels();
         addKimiModels();
         addGLMModels();
+        addNvidiaModels();
     }
 
     /**
@@ -1206,6 +1207,39 @@ public final class LLMModelRegistryService {
                         .inputCost(0.55)
                         .outputCost(2.19)
                         .inputMaxTokens(131_072)
+                        .apiKeyUsed(true)
+                        .build());
+    }
+
+    /**
+     * NVIDIA NIM models exposed through the OpenAI-compatible endpoint at
+     * {@code https://integrate.api.nvidia.com/v1}. Each model declares an explicit
+     * {@code inputMaxTokens} (context window) so it is never left at the primitive
+     * default of 0 — the zero-context symptom seen when NVIDIA is used through the
+     * generic "Custom OpenAI URL" path (whose {@code /v1/models} probe carries no
+     * context length). NVIDIA's build.nvidia.com endpoints are credit-based rather
+     * than per-token priced, so costs are left at 0.
+     */
+    private void addNvidiaModels() {
+        addNvidiaModel("deepseek-ai/deepseek-r1", "DeepSeek R1", 128_000);
+        addNvidiaModel("meta/llama-3.3-70b-instruct", "Llama 3.3 70B Instruct", 128_000);
+        addNvidiaModel("meta/llama-3.1-405b-instruct", "Llama 3.1 405B Instruct", 128_000);
+        addNvidiaModel("meta/llama-3.1-70b-instruct", "Llama 3.1 70B Instruct", 128_000);
+        addNvidiaModel("meta/llama-3.1-8b-instruct", "Llama 3.1 8B Instruct", 128_000);
+        addNvidiaModel("nvidia/llama-3.1-nemotron-70b-instruct", "Llama 3.1 Nemotron 70B", 128_000);
+        addNvidiaModel("mistralai/mistral-large-2-instruct", "Mistral Large 2", 128_000);
+        addNvidiaModel("qwen/qwen2.5-coder-32b-instruct", "Qwen2.5 Coder 32B", 32_768);
+    }
+
+    private void addNvidiaModel(@NotNull String modelName, @NotNull String displayName, int inputMaxTokens) {
+        models.put(ModelProvider.Nvidia.getName() + ":" + modelName,
+                LanguageModel.builder()
+                        .provider(ModelProvider.Nvidia)
+                        .modelName(modelName)
+                        .displayName(displayName)
+                        .inputCost(0)
+                        .outputCost(0)
+                        .inputMaxTokens(inputMaxTokens)
                         .apiKeyUsed(true)
                         .build());
     }

--- a/src/main/java/com/devoxx/genie/ui/panel/LlmProviderPanel.java
+++ b/src/main/java/com/devoxx/genie/ui/panel/LlmProviderPanel.java
@@ -168,6 +168,7 @@ public class LlmProviderPanel extends JBPanel<LlmProviderPanel> implements LLMSe
                     case Grok -> stateService.isGrokEnabled();
                     case Kimi -> stateService.isKimiEnabled();
                     case GLM -> stateService.isGlmEnabled();
+                    case Nvidia -> stateService.isNvidiaEnabled();
                     case AzureOpenAI -> stateService.isAzureOpenAIEnabled();
                     case Bedrock -> stateService.isAwsEnabled();
                     case CLIRunners -> true;

--- a/src/main/java/com/devoxx/genie/ui/settings/DevoxxGenieStateService.java
+++ b/src/main/java/com/devoxx/genie/ui/settings/DevoxxGenieStateService.java
@@ -155,6 +155,7 @@ public final class DevoxxGenieStateService implements PersistentStateComponent<D
     private boolean isGrokEnabled = false;
     private boolean isKimiEnabled = false;
     private boolean isGlmEnabled = false;
+    private boolean isNvidiaEnabled = false;
 
     // ============================================================================
     // LEGACY-XML CREDENTIAL LANDING PADS
@@ -217,6 +218,8 @@ public final class DevoxxGenieStateService implements PersistentStateComponent<D
     private String kimiKey = "";
     @Getter(AccessLevel.NONE) @Setter(AccessLevel.NONE) @OptionTag("glmKey")
     private String glmKey = "";
+    @Getter(AccessLevel.NONE) @Setter(AccessLevel.NONE) @OptionTag("nvidiaKey")
+    private String nvidiaKey = "";
     private String azureOpenAIEndpoint = "";
     private String azureOpenAIDeployment = "";
     @Getter(AccessLevel.NONE) @Setter(AccessLevel.NONE) @OptionTag("azureOpenAIKey")
@@ -862,6 +865,9 @@ public final class DevoxxGenieStateService implements PersistentStateComponent<D
 
     @Transient @Override public @NotNull String getGlmKey()       { return creds().getCredential(CredentialKey.GLM_KEY); }
     @Transient @Override public void          setGlmKey(String v) { creds().setCredential(CredentialKey.GLM_KEY, v); }
+
+    @Transient @Override public @NotNull String getNvidiaKey()       { return creds().getCredential(CredentialKey.NVIDIA_KEY); }
+    @Transient @Override public void          setNvidiaKey(String v) { creds().setCredential(CredentialKey.NVIDIA_KEY, v); }
 
     @Transient @Override public @NotNull String getAzureOpenAIKey()       { return creds().getCredential(CredentialKey.AZURE_OPEN_AI_KEY); }
     @Transient @Override public void          setAzureOpenAIKey(String v) { creds().setCredential(CredentialKey.AZURE_OPEN_AI_KEY, v); }

--- a/src/main/java/com/devoxx/genie/ui/settings/agent/AgentSettingsComponent.java
+++ b/src/main/java/com/devoxx/genie/ui/settings/agent/AgentSettingsComponent.java
@@ -359,6 +359,7 @@ public class AgentSettingsComponent extends AbstractSettingsComponent {
                     case Grok -> state.isGrokEnabled();
                     case Kimi -> state.isKimiEnabled();
                     case GLM -> state.isGlmEnabled();
+                    case Nvidia -> state.isNvidiaEnabled();
                     case AzureOpenAI -> state.isAzureOpenAIEnabled();
                     case Bedrock -> state.isAwsEnabled();
                     case CLIRunners -> false;
@@ -588,6 +589,7 @@ public class AgentSettingsComponent extends AbstractSettingsComponent {
                         case Grok -> state.isGrokEnabled();
                         case Kimi -> state.isKimiEnabled();
                         case GLM -> state.isGlmEnabled();
+                        case Nvidia -> state.isNvidiaEnabled();
                         case AzureOpenAI -> state.isAzureOpenAIEnabled();
                         case Bedrock -> state.isAwsEnabled();
                         case CLIRunners -> false;

--- a/src/main/java/com/devoxx/genie/ui/settings/llm/LLMProvidersComponent.java
+++ b/src/main/java/com/devoxx/genie/ui/settings/llm/LLMProvidersComponent.java
@@ -91,6 +91,8 @@ public class LLMProvidersComponent extends AbstractSettingsComponent {
     @Getter
     private final JPasswordField glmApiKeyField = new JPasswordField(stateService.getGlmKey());
     @Getter
+    private final JPasswordField nvidiaApiKeyField = new JPasswordField(stateService.getNvidiaKey());
+    @Getter
     private final JPasswordField awsSecretKeyField = new JPasswordField(stateService.getAwsSecretKey());
     @Getter
     private final JPasswordField awsBearerTokenField = new JPasswordField(stateService.getAwsBearerToken());
@@ -146,6 +148,8 @@ public class LLMProvidersComponent extends AbstractSettingsComponent {
     private final JCheckBox kimiEnabledCheckBox = new JCheckBox("", stateService.isKimiEnabled());
     @Getter
     private final JCheckBox glmEnabledCheckBox = new JCheckBox("", stateService.isGlmEnabled());
+    @Getter
+    private final JCheckBox nvidiaEnabledCheckBox = new JCheckBox("", stateService.isNvidiaEnabled());
     @Getter
     private final JCheckBox enableAzureOpenAICheckBox = new JCheckBox("", stateService.getShowAzureOpenAIFields());
     @Getter
@@ -238,6 +242,9 @@ public class LLMProvidersComponent extends AbstractSettingsComponent {
         addProviderSettingRow(panel, gbc, "GLM API Key", glmEnabledCheckBox,
                 createTextWithPasswordButton(glmApiKeyField, "https://z.ai/manage-apikey/apikey-list"));
         addHintText(panel, gbc, "Uses Zhipu AI (Z.AI) platform API; get your key at z.ai");
+        addProviderSettingRow(panel, gbc, "NVIDIA API Key", nvidiaEnabledCheckBox,
+                createTextWithPasswordButton(nvidiaApiKeyField, "https://build.nvidia.com"));
+        addHintText(panel, gbc, "Uses NVIDIA NIM OpenAI-compatible API (integrate.api.nvidia.com); get your key at build.nvidia.com");
 
         addAzureOpenAIPanel(panel, gbc);
         addAWSPanel(panel, gbc);
@@ -291,6 +298,7 @@ public class LLMProvidersComponent extends AbstractSettingsComponent {
         grokEnabledCheckBox.addItemListener(e -> updateUrlFieldState(grokEnabledCheckBox, grokApiKeyField));
         kimiEnabledCheckBox.addItemListener(e -> updateUrlFieldState(kimiEnabledCheckBox, kimiApiKeyField));
         glmEnabledCheckBox.addItemListener(e -> updateUrlFieldState(glmEnabledCheckBox, glmApiKeyField));
+        nvidiaEnabledCheckBox.addItemListener(e -> updateUrlFieldState(nvidiaEnabledCheckBox, nvidiaApiKeyField));
         enableAzureOpenAICheckBox.addItemListener(e -> updateUrlFieldState(enableAzureOpenAICheckBox, azureOpenAIEndpointField));
 
         updateUrlFieldState(lmStudioFallbackContextEnabledCheckBox, lmStudioFallbackContextField);

--- a/src/main/java/com/devoxx/genie/ui/settings/llm/LLMProvidersConfigurable.java
+++ b/src/main/java/com/devoxx/genie/ui/settings/llm/LLMProvidersConfigurable.java
@@ -68,6 +68,7 @@ public class LLMProvidersConfigurable implements Configurable {
         isModified |= isFieldModified(llmSettingsComponent.getGrokApiKeyField(), stateService.getGrokKey());
         isModified |= isFieldModified(llmSettingsComponent.getKimiApiKeyField(), stateService.getKimiKey());
         isModified |= isFieldModified(llmSettingsComponent.getGlmApiKeyField(), stateService.getGlmKey());
+        isModified |= isFieldModified(llmSettingsComponent.getNvidiaApiKeyField(), stateService.getNvidiaKey());
 
         isModified |= isFieldModified(llmSettingsComponent.getOllamaModelUrlField(), stateService.getOllamaModelUrl());
         isModified |= Boolean.TRUE.equals(stateService.getOllamaContextWindowOverrideEnabled())
@@ -123,6 +124,7 @@ public class LLMProvidersConfigurable implements Configurable {
         isModified |= stateService.isGrokEnabled() != llmSettingsComponent.getGrokEnabledCheckBox().isSelected();
         isModified |= stateService.isKimiEnabled() != llmSettingsComponent.getKimiEnabledCheckBox().isSelected();
         isModified |= stateService.isGlmEnabled() != llmSettingsComponent.getGlmEnabledCheckBox().isSelected();
+        isModified |= stateService.isNvidiaEnabled() != llmSettingsComponent.getNvidiaEnabledCheckBox().isSelected();
         isModified |= stateService.getShowAzureOpenAIFields() != llmSettingsComponent.getEnableAzureOpenAICheckBox().isSelected();
 
         return isModified;
@@ -168,6 +170,7 @@ public class LLMProvidersConfigurable implements Configurable {
         settings.setGrokKey(new String(llmSettingsComponent.getGrokApiKeyField().getPassword()));
         settings.setKimiKey(new String(llmSettingsComponent.getKimiApiKeyField().getPassword()));
         settings.setGlmKey(new String(llmSettingsComponent.getGlmApiKeyField().getPassword()));
+        settings.setNvidiaKey(new String(llmSettingsComponent.getNvidiaApiKeyField().getPassword()));
 
         settings.setShowAzureOpenAIFields(llmSettingsComponent.getEnableAzureOpenAICheckBox().isSelected());
         settings.setAzureOpenAIEndpoint(llmSettingsComponent.getAzureOpenAIEndpointField().getText());
@@ -205,6 +208,7 @@ public class LLMProvidersConfigurable implements Configurable {
         settings.setGrokEnabled(llmSettingsComponent.getGrokEnabledCheckBox().isSelected());
         settings.setKimiEnabled(llmSettingsComponent.getKimiEnabledCheckBox().isSelected());
         settings.setGlmEnabled(llmSettingsComponent.getGlmEnabledCheckBox().isSelected());
+        settings.setNvidiaEnabled(llmSettingsComponent.getNvidiaEnabledCheckBox().isSelected());
         settings.setShowAzureOpenAIFields(llmSettingsComponent.getEnableAzureOpenAICheckBox().isSelected());
 
         // Only notify the listener if an API key has changed, so we can refresh the LLM providers list in the UI
@@ -234,6 +238,7 @@ public class LLMProvidersConfigurable implements Configurable {
                 (!settings.getGrokKey().isBlank() && settings.isGrokEnabled()) ||
                 (!settings.getKimiKey().isBlank() && settings.isKimiEnabled()) ||
                 (!settings.getGlmKey().isBlank() && settings.isGlmEnabled()) ||
+                (!settings.getNvidiaKey().isBlank() && settings.isNvidiaEnabled()) ||
                 (!settings.getCustomOpenAIApiKey().isBlank() && settings.isCustomOpenAIApiKeyEnabled());
     }
 
@@ -277,6 +282,7 @@ public class LLMProvidersConfigurable implements Configurable {
         llmSettingsComponent.getOpenRouterApiKeyField().setText(settings.getOpenRouterKey());
         llmSettingsComponent.getKimiApiKeyField().setText(settings.getKimiKey());
         llmSettingsComponent.getGlmApiKeyField().setText(settings.getGlmKey());
+        llmSettingsComponent.getNvidiaApiKeyField().setText(settings.getNvidiaKey());
 
         llmSettingsComponent.getEnableAzureOpenAICheckBox().setSelected(settings.getShowAzureOpenAIFields());
         llmSettingsComponent.getAzureOpenAIEndpointField().setText(settings.getAzureOpenAIEndpoint());
@@ -317,6 +323,7 @@ public class LLMProvidersConfigurable implements Configurable {
         llmSettingsComponent.getGrokEnabledCheckBox().setSelected(settings.isGrokEnabled());
         llmSettingsComponent.getKimiEnabledCheckBox().setSelected(settings.isKimiEnabled());
         llmSettingsComponent.getGlmEnabledCheckBox().setSelected(settings.isGlmEnabled());
+        llmSettingsComponent.getNvidiaEnabledCheckBox().setSelected(settings.isNvidiaEnabled());
         llmSettingsComponent.getEnableAzureOpenAICheckBox().setSelected(settings.getShowAzureOpenAIFields());
     }
 }

--- a/src/test/java/com/devoxx/genie/chatmodel/cloud/nvidia/NvidiaChatModelFactoryTest.java
+++ b/src/test/java/com/devoxx/genie/chatmodel/cloud/nvidia/NvidiaChatModelFactoryTest.java
@@ -1,0 +1,156 @@
+package com.devoxx.genie.chatmodel.cloud.nvidia;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Verifies {@link NvidiaChatModelFactory#contextWindowFor(String)} — the heuristic that assigns a
+ * context window to each dynamically-listed NVIDIA model, since NVIDIA's {@code /v1/models}
+ * endpoint carries no context length. Cases cover the representative families and, crucially, the
+ * substring-collision edge cases (e.g. an embedder named after a base chat model).
+ */
+class NvidiaChatModelFactoryTest {
+
+    /** The 128K default must cover the bulk of NVIDIA's instruct LLMs. */
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "meta/llama-3.1-70b-instruct",
+            "meta/llama-3.3-70b-instruct",
+            "meta/llama-3.2-3b-instruct",
+            "nvidia/llama-3.1-nemotron-70b-instruct",
+            "nvidia/llama-3.1-nemotron-ultra-253b-v1",
+            "nvidia/llama-3.3-nemotron-super-49b-v1.5",
+            "qwen/qwen3.5-397b-a17b",
+            "deepseek-ai/deepseek-v4-pro",
+            "openai/gpt-oss-120b",
+            "z-ai/glm-5.1",
+            "moonshotai/kimi-k2.6",
+            "microsoft/phi-4-multimodal-instruct",
+            "mistralai/ministral-14b-instruct-2512",
+            "nv-mistralai/mistral-nemo-12b-instruct",
+            "google/gemma-3-12b-it"
+    })
+    void defaultsTo128kForMainstreamInstructModels(String modelId) {
+        assertThat(NvidiaChatModelFactory.contextWindowFor(modelId)).isEqualTo(128_000);
+    }
+
+    /** Family-specific windows, including the tricky mistral-large v1 (32K) vs v2/v3 (128K) split. */
+    @ParameterizedTest
+    @CsvSource({
+            "mistralai/mistral-large,                       32768",
+            "mistralai/mistral-large-2-instruct,            128000",
+            "mistralai/mistral-large-3-675b-instruct-2512,  128000",
+            "mistralai/mixtral-8x7b-instruct-v0.1,          32768",
+            "mistralai/mixtral-8x22b-v0.1,                  65536",
+            "mistralai/mistral-7b-instruct-v0.3,            32768",
+            "mistralai/codestral-22b-instruct-v0.1,         32768",
+            "ai21labs/jamba-1.5-large-instruct,             256000",
+            "meta/llama-4-maverick-17b-128e-instruct,       1000000",
+            "meta/llama2-70b,                               4096",
+            "meta/codellama-70b,                            16384",
+            "upstage/solar-10.7b-instruct,                  4096",
+            "nvidia/nemotron-4-340b-instruct,               4096",
+            "nvidia/nemotron-mini-4b-instruct,              4096",
+            "deepseek-ai/deepseek-coder-6.7b-instruct,      16384",
+            "bigcode/starcoder2-15b,                        16384",
+            "01-ai/yi-large,                                32768",
+            "databricks/dbrx-instruct,                      32768",
+            "google/gemma-2-2b-it,                          8192",
+            "google/gemma-2b,                               8192",
+            "google/gemma-3n-e4b-it,                        32768",
+            "google/codegemma-7b,                           8192",
+            "writer/palmyra-med-70b-32k,                    32768",
+            "writer/palmyra-fin-70b-32k,                    32768",
+            "nvidia/mistral-nemo-minitron-8b-8k-instruct,   8192",
+            "nvidia/llama3-chatqa-1.5-70b,                  8192"
+    })
+    void mapsKnownFamiliesToTheirWindow(String modelId, int expected) {
+        assertThat(NvidiaChatModelFactory.contextWindowFor(modelId)).isEqualTo(expected);
+    }
+
+    /**
+     * Auxiliary / non-chat models must NOT be mis-bucketed by a base-model name embedded in their
+     * id (e.g. {@code nv-embedqa-mistral-7b} contains "mistral-7b"; a reward model contains
+     * "340b"). They are checked first and pinned to the modest auxiliary window.
+     */
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "nvidia/nv-embedqa-mistral-7b-v2",
+            "nvidia/llama-3.2-nv-embedqa-1b-v1",
+            "nvidia/llama-nemotron-embed-vl-1b-v2",
+            "nvidia/llama-3.2-nemoretriever-1b-vlm-embed-v1",
+            "baai/bge-m3",
+            "snowflake/arctic-embed-l",
+            "nvidia/nvclip",
+            "nvidia/nemoretriever-parse",
+            "nvidia/nemotron-parse",
+            "meta/llama-guard-4-12b",
+            "nvidia/llama-3.1-nemoguard-8b-content-safety",
+            "nvidia/llama-3.1-nemoguard-8b-topic-control",
+            "nvidia/nemotron-4-340b-reward",
+            "nvidia/gliner-pii",
+            "nvidia/riva-translate-4b-instruct",
+            "nvidia/ai-synthetic-video-detector",
+            "google/deplot",
+            "microsoft/kosmos-2",
+            "google/diffusiongemma-26b-a4b-it"
+    })
+    void auxiliaryModelsGetModestWindowAndAreNeverMisBucketed(String modelId) {
+        assertThat(NvidiaChatModelFactory.contextWindowFor(modelId)).isEqualTo(8_192);
+    }
+
+    /** Whatever NVIDIA lists, every model must get a positive window — never the zero-context bug. */
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "01-ai/yi-large", "abacusai/dracarys-llama-3.1-70b-instruct", "adept/fuyu-8b",
+            "ai21labs/jamba-1.5-large-instruct", "aisingapore/sea-lion-7b-instruct", "baai/bge-m3",
+            "bigcode/starcoder2-15b", "bytedance/seed-oss-36b-instruct", "databricks/dbrx-instruct",
+            "deepseek-ai/deepseek-coder-6.7b-instruct", "deepseek-ai/deepseek-v4-flash",
+            "deepseek-ai/deepseek-v4-pro", "google/codegemma-1.1-7b", "google/codegemma-7b",
+            "google/deplot", "google/diffusiongemma-26b-a4b-it", "google/gemma-2-2b-it",
+            "google/gemma-2b", "google/gemma-3-12b-it", "google/gemma-3-4b-it", "google/gemma-3n-e2b-it",
+            "google/gemma-3n-e4b-it", "google/gemma-4-31b-it", "google/recurrentgemma-2b",
+            "ibm/granite-3.0-3b-a800m-instruct", "ibm/granite-3.0-8b-instruct", "ibm/granite-34b-code-instruct",
+            "ibm/granite-8b-code-instruct", "meta/codellama-70b", "meta/llama-3.1-70b-instruct",
+            "meta/llama-3.1-8b-instruct", "meta/llama-3.2-11b-vision-instruct", "meta/llama-3.2-1b-instruct",
+            "meta/llama-3.2-3b-instruct", "meta/llama-3.2-90b-vision-instruct", "meta/llama-3.3-70b-instruct",
+            "meta/llama-4-maverick-17b-128e-instruct", "meta/llama-guard-4-12b", "meta/llama2-70b",
+            "microsoft/kosmos-2", "microsoft/phi-3-vision-128k-instruct", "microsoft/phi-3.5-moe-instruct",
+            "microsoft/phi-4-mini-instruct", "microsoft/phi-4-multimodal-instruct", "minimaxai/minimax-m2.7",
+            "minimaxai/minimax-m3", "mistralai/codestral-22b-instruct-v0.1", "mistralai/ministral-14b-instruct-2512",
+            "mistralai/mistral-7b-instruct-v0.3", "mistralai/mistral-large", "mistralai/mistral-large-2-instruct",
+            "mistralai/mistral-large-3-675b-instruct-2512", "mistralai/mistral-medium-3.5-128b",
+            "mistralai/mistral-nemotron", "mistralai/mistral-small-4-119b-2603", "mistralai/mixtral-8x22b-v0.1",
+            "mistralai/mixtral-8x7b-instruct-v0.1", "moonshotai/kimi-k2.6", "nv-mistralai/mistral-nemo-12b-instruct",
+            "nvidia/ai-synthetic-video-detector", "nvidia/cosmos-reason2-8b", "nvidia/embed-qa-4",
+            "nvidia/gliner-pii", "nvidia/ising-calibration-1-35b-a3b", "nvidia/llama-3.1-nemoguard-8b-content-safety",
+            "nvidia/llama-3.1-nemoguard-8b-topic-control", "nvidia/llama-3.1-nemotron-51b-instruct",
+            "nvidia/llama-3.1-nemotron-70b-instruct", "nvidia/llama-3.1-nemotron-nano-8b-v1",
+            "nvidia/llama-3.1-nemotron-nano-vl-8b-v1", "nvidia/llama-3.1-nemotron-safety-guard-8b-v3",
+            "nvidia/llama-3.1-nemotron-ultra-253b-v1", "nvidia/llama-3.2-nemoretriever-1b-vlm-embed-v1",
+            "nvidia/llama-3.2-nv-embedqa-1b-v1", "nvidia/llama-3.3-nemotron-super-49b-v1",
+            "nvidia/llama-3.3-nemotron-super-49b-v1.5", "nvidia/llama-nemotron-embed-1b-v2",
+            "nvidia/llama-nemotron-embed-vl-1b-v2", "nvidia/llama3-chatqa-1.5-70b",
+            "nvidia/mistral-nemo-minitron-8b-8k-instruct", "nvidia/nemoretriever-parse",
+            "nvidia/nemotron-3-content-safety", "nvidia/nemotron-3-nano-30b-a3b",
+            "nvidia/nemotron-3-nano-omni-30b-a3b-reasoning", "nvidia/nemotron-3-super-120b-a12b",
+            "nvidia/nemotron-3-ultra-550b-a55b", "nvidia/nemotron-3.5-content-safety",
+            "nvidia/nemotron-4-340b-instruct", "nvidia/nemotron-4-340b-reward",
+            "nvidia/nemotron-content-safety-reasoning-4b", "nvidia/nemotron-mini-4b-instruct",
+            "nvidia/nemotron-nano-12b-v2-vl", "nvidia/nemotron-nano-3-30b-a3b", "nvidia/nemotron-parse",
+            "nvidia/neva-22b", "nvidia/nv-embed-v1", "nvidia/nv-embedcode-7b-v1", "nvidia/nv-embedqa-e5-v5",
+            "nvidia/nv-embedqa-mistral-7b-v2", "nvidia/nvclip", "nvidia/nvidia-nemotron-nano-9b-v2",
+            "nvidia/riva-translate-4b-instruct", "nvidia/riva-translate-4b-instruct-v1.1", "nvidia/vila",
+            "openai/gpt-oss-120b", "openai/gpt-oss-20b", "qwen/qwen3-next-80b-a3b-instruct",
+            "qwen/qwen3.5-122b-a10b", "qwen/qwen3.5-397b-a17b", "sarvamai/sarvam-m", "snowflake/arctic-embed-l",
+            "stepfun-ai/step-3.5-flash", "stepfun-ai/step-3.7-flash", "stockmark/stockmark-2-100b-instruct",
+            "upstage/solar-10.7b-instruct", "writer/palmyra-creative-122b", "writer/palmyra-fin-70b-32k",
+            "writer/palmyra-med-70b", "writer/palmyra-med-70b-32k", "z-ai/glm-5.1", "zyphra/zamba2-7b-instruct"
+    })
+    void everyListedModelGetsPositiveWindow(String modelId) {
+        assertThat(NvidiaChatModelFactory.contextWindowFor(modelId)).isPositive();
+    }
+}


### PR DESCRIPTION
## Summary
Adds **NVIDIA NIM** (build.nvidia.com) as an OpenAI-compatible cloud LLM provider.

- Base URL `https://integrate.api.nvidia.com/v1`, API-key based
- Settings row: enable checkbox + API key field + link to `https://build.nvidia.com`
- `NvidiaChatModelFactory` dynamically fetches the **full** catalogue from `/v1/models` (~120 models) rather than a hardcoded subset
- **Context window:** NVIDIA's `/v1/models` carries no context length, so each model gets a heuristic window (default 128K, with per-family overrides) instead of the primitive-int default of `0`. This value only feeds the token-usage bar and the "add project to context" budget — it never truncates conversations (chat memory is message-count based).
- Wired through: `ModelProvider` enum, `ChatModelFactoryProvider`, `CredentialKey`, `DevoxxGenieStateService`, `DevoxxGenieSettingsService`, `LLMProviderService`, `LLMModelRegistryService`, `AgentSettingsComponent`, and the provider/model settings UI.

## Tests
- `NvidiaChatModelFactoryTest` validates the context-window heuristic (representative families, substring-collision edge cases, and that all 121 live model ids yield a positive window).
- `compileJava`, provider completeness tests, and the model/registry tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)