### PR TITLE
Type-to-filter the model dropdown

### DIFF
--- a/src/main/java/com/devoxx/genie/ui/component/FilteringComboBox.java
+++ b/src/main/java/com/devoxx/genie/ui/component/FilteringComboBox.java
@@ -1,0 +1,239 @@
+package com.devoxx.genie.ui.component;
+
+import com.intellij.openapi.ui.ComboBox;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import javax.swing.BorderFactory;
+import javax.swing.ComboBoxEditor;
+import javax.swing.DefaultComboBoxModel;
+import javax.swing.JTextField;
+import javax.swing.SwingUtilities;
+import javax.swing.event.DocumentEvent;
+import javax.swing.event.DocumentListener;
+import javax.swing.event.PopupMenuEvent;
+import javax.swing.event.PopupMenuListener;
+import java.awt.Component;
+import java.awt.event.ActionListener;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+/**
+ * A {@link ComboBox} that lets the user type to reduce its items to those whose search text
+ * (case-insensitive substring) matches the typed query. Built for long lists — e.g. the 100+
+ * NVIDIA models — where a plain dropdown is impractical.
+ *
+ * <p>The combo is editable so the query can be typed inline, but its editor is wired so that
+ * {@link #getSelectedItem()} ALWAYS returns an item of type {@code T} (or {@code null}) — never the
+ * raw typed {@code String}. Existing {@code (T) combo.getSelectedItem()} call sites therefore keep
+ * working unchanged. Selection {@link ActionListener}s fire only on genuine user commits (clicking a
+ * row / pressing Enter on a match), never while the list is being re-filtered.</p>
+ *
+ * <p>The popup rows still use whatever {@code ListCellRenderer} is installed; only the collapsed
+ * field shows the plain {@code displayTextExtractor} text (the editor component).</p>
+ *
+ * @param <T> the element type
+ */
+public class FilteringComboBox<T> extends ComboBox<T> {
+
+    private final transient Function<? super T, String> displayTextExtractor;
+    private final transient Function<? super T, String> searchTextExtractor;
+
+    /** The complete, unfiltered set of items; the model shown may be a filtered subset of this. */
+    private final transient List<T> allItems = new ArrayList<>();
+
+    private final JTextField editorField = new JTextField();
+
+    /** Re-entrancy guard: {@code true} while we mutate the model/editor programmatically. */
+    private boolean syncing = false;
+
+    /** Last committed selection (an item of {@code T}); what {@link #getSelectedItem()} reflects. */
+    private transient T committed = null;
+
+    /**
+     * @param displayTextExtractor produces the text shown in the collapsed field for a selected item
+     * @param searchTextExtractor  produces the text a typed query is matched against (substring)
+     */
+    public FilteringComboBox(@NotNull Function<? super T, String> displayTextExtractor,
+                             @NotNull Function<? super T, String> searchTextExtractor) {
+        this.displayTextExtractor = displayTextExtractor;
+        this.searchTextExtractor = searchTextExtractor;
+
+        setEditable(true);
+        setEditor(new FilterEditor());
+        editorField.setBorder(BorderFactory.createEmptyBorder());
+
+        editorField.getDocument().addDocumentListener(new DocumentListener() {
+            @Override public void insertUpdate(DocumentEvent e) { onQueryChanged(); }
+            @Override public void removeUpdate(DocumentEvent e) { onQueryChanged(); }
+            @Override public void changedUpdate(DocumentEvent e) { onQueryChanged(); }
+        });
+
+        // When the popup opens while the field still shows the committed selection (i.e. the user
+        // clicked the arrow rather than typing a query), show the full list. During typing the field
+        // holds the query — not the committed item — so this leaves the filtered subset intact.
+        addPopupMenuListener(new PopupMenuListener() {
+            @Override public void popupMenuWillBecomeVisible(PopupMenuEvent e) {
+                if (!syncing && showsCommittedSelection() && getItemCount() != allItems.size()) {
+                    rebuildModel(allItems);
+                }
+            }
+            @Override public void popupMenuWillBecomeInvisible(PopupMenuEvent e) { /* no-op */ }
+            @Override public void popupMenuCanceled(PopupMenuEvent e) { /* no-op */ }
+        });
+    }
+
+    /** True when the editor field shows the committed selection rather than an in-progress query. */
+    private boolean showsCommittedSelection() {
+        String text = editorField.getText();
+        return committed == null ? text.isEmpty() : text.equals(displayTextExtractor.apply(committed));
+    }
+
+    /**
+     * Case-insensitive substring filter. Package-private and static so the matching logic can be
+     * unit-tested without instantiating Swing components.
+     */
+    static <T> List<T> filter(@NotNull List<T> items,
+                              @Nullable String query,
+                              @NotNull Function<? super T, String> searchTextExtractor) {
+        if (query == null || query.isBlank()) {
+            return new ArrayList<>(items);
+        }
+        String needle = query.trim().toLowerCase(Locale.ROOT);
+        return items.stream()
+                .filter(item -> {
+                    String text = searchTextExtractor.apply(item);
+                    return text != null && text.toLowerCase(Locale.ROOT).contains(needle);
+                })
+                .collect(Collectors.toList());
+    }
+
+    private void onQueryChanged() {
+        if (syncing) {
+            return;
+        }
+        List<T> matches = filter(allItems, editorField.getText(), searchTextExtractor);
+        rebuildModel(matches);
+        // Reflect the new match set in the popup on the next EDT cycle (mutating popup visibility
+        // directly inside a document event is unsafe). We only ever open/close it — never hide-then-
+        // show — so no spurious popup events are generated while the user is typing. Guarded on
+        // isShowing() since the popup can only be shown for a displayed combo.
+        SwingUtilities.invokeLater(() -> {
+            if (isShowing()) {
+                setPopupVisible(getItemCount() > 0);
+            }
+        });
+    }
+
+    /**
+     * Swap the displayed model to {@code items} without firing selection events to external listeners
+     * and without disturbing the committed selection or the query text the user is typing.
+     */
+    private void rebuildModel(@NotNull List<T> items) {
+        ActionListener[] listeners = getActionListeners();
+        for (ActionListener listener : listeners) {
+            removeActionListener(listener);
+        }
+        syncing = true;
+        try {
+            DefaultComboBoxModel<T> model = new DefaultComboBoxModel<>();
+            for (T item : items) {
+                model.addElement(item);
+            }
+            setModel(model);
+            // Keep the committed item as the selected object even when it is filtered out of view, so
+            // getSelectedItem() stays a valid T (never null mid-typing, never a String).
+            setSelectedItem(committed);
+        } finally {
+            syncing = false;
+            for (ActionListener listener : listeners) {
+                addActionListener(listener);
+            }
+        }
+    }
+
+    private void setEditorTextSilently(String text) {
+        syncing = true;
+        try {
+            editorField.setText(text);
+            editorField.setCaretPosition(editorField.getDocument().getLength());
+        } finally {
+            syncing = false;
+        }
+    }
+
+    // --- Keep the master list in sync with the population calls existing code already uses ---
+
+    @Override
+    public void addItem(T item) {
+        super.addItem(item);
+        if (!syncing) {
+            allItems.add(item);
+        }
+    }
+
+    @Override
+    public void removeAllItems() {
+        super.removeAllItems();
+        if (!syncing) {
+            allItems.clear();
+            committed = null;
+            setEditorTextSilently("");
+        }
+    }
+
+    /**
+     * Editable-combo editor that renders a {@code T} as its display text but always returns the
+     * underlying {@code T} (or {@code null}) from {@link #getItem()} — so committing the editor never
+     * turns the combo's selected item into a raw {@code String}.
+     */
+    private final class FilterEditor implements ComboBoxEditor {
+
+        @Override
+        public Component getEditorComponent() {
+            return editorField;
+        }
+
+        @Override
+        public void setItem(Object anObject) {
+            if (anObject == null) {
+                committed = null;
+                if (!syncing) {
+                    setEditorTextSilently("");
+                }
+            } else if (!(anObject instanceof String)) {
+                @SuppressWarnings("unchecked")
+                T item = (T) anObject;
+                committed = item;
+                if (!syncing) {
+                    setEditorTextSilently(displayTextExtractor.apply(item));
+                }
+            }
+            // A raw String (shouldn't occur) is ignored so the committed T is never overwritten.
+        }
+
+        @Override
+        public Object getItem() {
+            return committed;
+        }
+
+        @Override
+        public void selectAll() {
+            editorField.selectAll();
+            editorField.requestFocus();
+        }
+
+        @Override
+        public void addActionListener(ActionListener l) {
+            editorField.addActionListener(l);
+        }
+
+        @Override
+        public void removeActionListener(ActionListener l) {
+            editorField.removeActionListener(l);
+        }
+    }
+}

--- a/src/main/java/com/devoxx/genie/ui/panel/LlmProviderPanel.java
+++ b/src/main/java/com/devoxx/genie/ui/panel/LlmProviderPanel.java
@@ -16,6 +16,7 @@ import com.devoxx.genie.ui.util.DevoxxGenieFontsUtil;
 import com.devoxx.genie.ui.util.NotificationUtil;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.project.Project;
+import com.devoxx.genie.ui.component.FilteringComboBox;
 import com.intellij.openapi.ui.ComboBox;
 import com.intellij.openapi.ui.Messages;
 import com.intellij.ui.components.JBPanel;
@@ -51,7 +52,10 @@ public class LlmProviderPanel extends JBPanel<LlmProviderPanel> implements LLMSe
     @Getter
     private final ComboBox<ModelProvider> modelProviderComboBox = new ComboBox<>();
     @Getter
-    private final ComboBox<LanguageModel> modelNameComboBox = new ComboBox<>();
+    private final FilteringComboBox<LanguageModel> modelNameComboBox = new FilteringComboBox<>(
+            model -> model.getDisplayName() != null ? model.getDisplayName() : model.getModelName(),
+            model -> (model.getDisplayName() == null ? "" : model.getDisplayName()) + " "
+                    + (model.getModelName() == null ? "" : model.getModelName()));
 
     private JButton refreshButton;
 

--- a/src/test/java/com/devoxx/genie/ui/component/FilteringComboBoxTest.java
+++ b/src/test/java/com/devoxx/genie/ui/component/FilteringComboBoxTest.java
@@ -1,0 +1,128 @@
+package com.devoxx.genie.ui.component;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.function.Function;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests for {@link FilteringComboBox#filter(List, String, Function)} — the case-insensitive
+ * substring matcher behind the type-to-filter model dropdown. Kept free of Swing so it runs headless.
+ */
+class FilteringComboBoxTest {
+
+    private static final Function<String, String> IDENTITY = s -> s;
+
+    private static final List<String> NVIDIA_SAMPLE = List.of(
+            "moonshotai/kimi-k2.6",
+            "meta/llama-3.3-70b-instruct",
+            "nvidia/llama-3.1-nemotron-70b-instruct",
+            "qwen/qwen3.5-397b-a17b",
+            "deepseek-ai/deepseek-v4-pro",
+            "baai/bge-m3");
+
+    @Test
+    void matchesSubstringCaseInsensitively() {
+        assertThat(FilteringComboBox.filter(NVIDIA_SAMPLE, "kim", IDENTITY))
+                .containsExactly("moonshotai/kimi-k2.6");
+        assertThat(FilteringComboBox.filter(NVIDIA_SAMPLE, "KIM", IDENTITY))
+                .containsExactly("moonshotai/kimi-k2.6");
+    }
+
+    @Test
+    void matchesAnywhereInTheText() {
+        assertThat(FilteringComboBox.filter(NVIDIA_SAMPLE, "llama", IDENTITY))
+                .containsExactly("meta/llama-3.3-70b-instruct", "nvidia/llama-3.1-nemotron-70b-instruct");
+        assertThat(FilteringComboBox.filter(NVIDIA_SAMPLE, "nemotron", IDENTITY))
+                .containsExactly("nvidia/llama-3.1-nemotron-70b-instruct");
+    }
+
+    @Test
+    void blankOrNullQueryReturnsEverything() {
+        assertThat(FilteringComboBox.filter(NVIDIA_SAMPLE, "", IDENTITY)).isEqualTo(NVIDIA_SAMPLE);
+        assertThat(FilteringComboBox.filter(NVIDIA_SAMPLE, "   ", IDENTITY)).isEqualTo(NVIDIA_SAMPLE);
+        assertThat(FilteringComboBox.filter(NVIDIA_SAMPLE, null, IDENTITY)).isEqualTo(NVIDIA_SAMPLE);
+    }
+
+    @Test
+    void queryIsTrimmedBeforeMatching() {
+        assertThat(FilteringComboBox.filter(NVIDIA_SAMPLE, "  qwen  ", IDENTITY))
+                .containsExactly("qwen/qwen3.5-397b-a17b");
+    }
+
+    @Test
+    void noMatchReturnsEmpty() {
+        assertThat(FilteringComboBox.filter(NVIDIA_SAMPLE, "does-not-exist", IDENTITY)).isEmpty();
+    }
+
+    @Test
+    void searchesAgainstTheExtractedTextNotToString() {
+        record Model(String display, String id) { }
+        List<Model> models = List.of(
+                new Model("Moonshot v1 8K", "moonshot-v1-8k"),
+                new Model("Kimi K2 Turbo", "kimi-k2-turbo-preview"));
+        Function<Model, String> search = m -> m.display() + " " + m.id();
+
+        // Matches on the human display name...
+        assertThat(FilteringComboBox.filter(models, "moonshot", search)).hasSize(1);
+        // ...and on the raw model id.
+        assertThat(FilteringComboBox.filter(models, "turbo-preview", search))
+                .singleElement().extracting(Model::id).isEqualTo("kimi-k2-turbo-preview");
+    }
+
+    @Test
+    void filterReturnsANewListAndDoesNotMutateInput() {
+        List<String> original = List.copyOf(NVIDIA_SAMPLE);
+        FilteringComboBox.filter(NVIDIA_SAMPLE, "llama", IDENTITY);
+        assertThat(NVIDIA_SAMPLE).isEqualTo(original);
+    }
+
+    /**
+     * Reproduces the reported bug: typing successive characters must keep narrowing the list. The
+     * item-count is reduced synchronously by the editor's document listener, so this is observable
+     * without pumping the EDT (only the popup toggle is deferred, and is irrelevant here).
+     */
+    @Test
+    void typingSuccessiveCharactersKeepsNarrowingTheModel() {
+        FilteringComboBox<String> combo = new FilteringComboBox<>(Function.identity(), Function.identity());
+        for (String id : NVIDIA_SAMPLE) {
+            combo.addItem(id);
+        }
+        javax.swing.text.JTextComponent editor =
+                (javax.swing.text.JTextComponent) combo.getEditor().getEditorComponent();
+
+        assertThat(combo.getItemCount()).isEqualTo(NVIDIA_SAMPLE.size());
+
+        editor.setText("k");                       // first char — matches "kimi" and "deepseek"
+        assertThat(combo.getItemCount()).isEqualTo(2);
+
+        editor.setText("ki");                      // second char — used to reset to the full list
+        assertThat(combo.getItemCount()).isEqualTo(1);
+        assertThat(combo.getItemAt(0)).isEqualTo("moonshotai/kimi-k2.6");
+
+        editor.setText("kix");                     // no match
+        assertThat(combo.getItemCount()).isZero();
+
+        editor.setText("");                        // cleared — full list returns
+        assertThat(combo.getItemCount()).isEqualTo(NVIDIA_SAMPLE.size());
+    }
+
+    /** getSelectedItem() must never return the raw typed String, even mid-filter. */
+    @Test
+    void selectedItemIsNeverTheTypedString() {
+        FilteringComboBox<String> combo = new FilteringComboBox<>(Function.identity(), Function.identity());
+        NVIDIA_SAMPLE.forEach(combo::addItem);
+        javax.swing.text.JTextComponent editor =
+                (javax.swing.text.JTextComponent) combo.getEditor().getEditorComponent();
+
+        editor.setText("llama");                   // "llama" is a query, not one of the items
+        Object selected = combo.getSelectedItem();
+        // Never the raw typed query; either no committed selection (null) or a genuine item.
+        assertThat(selected).isNotEqualTo("llama");
+        if (selected != null) {
+            assertThat(NVIDIA_SAMPLE).contains((String) selected);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
The model-name dropdown can hold 100+ entries (e.g. NVIDIA lists ~120 models), making a plain dropdown impractical. Introduces `FilteringComboBox<T>` and uses it for the model combo so **typing reduces the list to matching models**.

- Editable combo, but a custom `ComboBoxEditor` makes `getSelectedItem()` always return an item of type `T` (or `null`) — **never the typed String** — so existing `(LanguageModel) getSelectedItem()` call sites keep working. Selection listeners fire only on genuine user commits.
- Matching is a case-insensitive substring over both the display name and the model id.
- The popup rows keep the rich `ModelInfoRenderer`; the collapsed field shows the model's display name.
- The full list is restored when the popup is opened while the field still shows the committed selection, so re-opening always starts from every item.

## Tests
- `FilteringComboBoxTest` covers the matcher (case/trim/substring/no-match) and simulates successive keystrokes to assert the list keeps narrowing (regression for the "second keystroke reset the list" bug).
- `compileJava`, `FilteringComboBoxTest`, and the existing `LlmProviderPanelTest` pass.

> Note: independent of #1171 — the only shared file (`LlmProviderPanel.java`) is touched in different regions, so the two merge cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)