### PR TITLE
fix: only show ACP/CLI Runners when a tool is enabled

### DIFF
--- a/src/main/java/com/devoxx/genie/service/LLMProviderService.java
+++ b/src/main/java/com/devoxx/genie/service/LLMProviderService.java
@@ -61,7 +61,14 @@ public class LLMProviderService {
     }
 
     private List<ModelProvider> getLocalModelProviders() {
-        return ModelProvider.fromType(Type.LOCAL);
+        // CLIRunners and ACPRunners are declared as Type.LOCAL but are only available
+        // when the user has configured (and enabled) at least one CLI/ACP tool. They are
+        // added conditionally by getCliRunnersProvider()/getAcpRunnersProvider(), so they
+        // must be excluded from the blanket local list here to avoid appearing unconditionally.
+        return ModelProvider.fromType(Type.LOCAL).stream()
+                .filter(provider -> provider != ModelProvider.CLIRunners
+                        && provider != ModelProvider.ACPRunners)
+                .toList();
     }
 
     /**

--- a/src/test/java/com/devoxx/genie/service/LLMProviderServiceTest.java
+++ b/src/test/java/com/devoxx/genie/service/LLMProviderServiceTest.java
@@ -2,6 +2,8 @@ package com.devoxx.genie.service;
 
 import com.devoxx.genie.model.LanguageModel;
 import com.devoxx.genie.model.enumarations.ModelProvider;
+import com.devoxx.genie.model.spec.AcpToolConfig;
+import com.devoxx.genie.model.spec.CliToolConfig;
 import com.devoxx.genie.service.credentials.CredentialKey;
 import com.devoxx.genie.service.credentials.CredentialService;
 import com.devoxx.genie.service.models.LLMModelRegistryService;
@@ -106,6 +108,54 @@ class LLMProviderServiceTest {
         List<ModelProvider> providers = providerService.getAvailableModelProviders();
 
         assertThat(providers).doesNotContain(ModelProvider.OpenAI);
+    }
+
+    @Test
+    void acpRunnersNotAvailableWhenNoAcpToolConfigured() {
+        // No ACP tools configured (the default) -> ACP Runners must NOT appear in the provider list.
+        List<ModelProvider> providers = providerService.getAvailableModelProviders();
+
+        assertThat(providers).doesNotContain(ModelProvider.ACPRunners);
+    }
+
+    @Test
+    void acpRunnersNotAvailableWhenAllAcpToolsDisabled() {
+        stateService.setAcpTools(List.of(
+                AcpToolConfig.builder().name("Claude ACP").enabled(false).build()
+        ));
+
+        List<ModelProvider> providers = providerService.getAvailableModelProviders();
+
+        assertThat(providers).doesNotContain(ModelProvider.ACPRunners);
+    }
+
+    @Test
+    void acpRunnersAvailableWhenAnAcpToolIsEnabled() {
+        stateService.setAcpTools(List.of(
+                AcpToolConfig.builder().name("Claude ACP").enabled(true).build()
+        ));
+
+        List<ModelProvider> providers = providerService.getAvailableModelProviders();
+
+        assertThat(providers).contains(ModelProvider.ACPRunners);
+    }
+
+    @Test
+    void cliRunnersNotAvailableWhenNoCliToolConfigured() {
+        List<ModelProvider> providers = providerService.getAvailableModelProviders();
+
+        assertThat(providers).doesNotContain(ModelProvider.CLIRunners);
+    }
+
+    @Test
+    void cliRunnersAvailableWhenACliToolIsEnabled() {
+        stateService.setCliTools(List.of(
+                CliToolConfig.builder().name("Aider").enabled(true).build()
+        ));
+
+        List<ModelProvider> providers = providerService.getAvailableModelProviders();
+
+        assertThat(providers).contains(ModelProvider.CLIRunners);
     }
 
     @Test


### PR DESCRIPTION
## Summary
- "ACP Runners" (and "CLI Runners") always appeared in the LLM provider dropdown even when no ACP/CLI tool was configured.
- Root cause: `ACPRunners`/`CLIRunners` are declared as `Type.LOCAL`, so `getLocalModelProviders()` added them unconditionally via `fromType(Type.LOCAL)`, bypassing the enabled-tool guards `getAcpRunnersProvider()`/`getCliRunnersProvider()`.
- Fix: filter both runner providers out of `getLocalModelProviders()` so the enabled-tool guards are the single source of truth.

## Test plan
- [x] `LLMProviderServiceTest` — runner providers hidden when no tool configured / all tools disabled, shown when a tool is enabled (ACP and CLI)
- [x] `LlmProviderPanelTest` — no regressions
- [x] Full `./gradlew test` suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)