### PR TITLE
fix: persist conversations to history when a run fails after streaming an answer

### DIFF
--- a/src/main/java/com/devoxx/genie/service/prompt/response/streaming/StreamingResponseHandler.java
+++ b/src/main/java/com/devoxx/genie/service/prompt/response/streaming/StreamingResponseHandler.java
@@ -267,6 +267,10 @@ public class StreamingResponseHandler implements StreamingChatResponseHandler {
     public void onError(@NotNull Throwable error) {
         log.error("Streaming error for context {}: {}", context.getId(), error.getMessage());
 
+        // Persist any answer already streamed before the failure so the run survives in
+        // conversation history. Must run before the UI teardown below.
+        persistPartialResponseOnError();
+
         // Deactivate activity handlers BEFORE hiding to prevent race condition
         if (conversationViewController != null) {
             conversationViewController.deactivateActivityHandlers();
@@ -292,6 +296,39 @@ public class StreamingResponseHandler implements StreamingChatResponseHandler {
             "Error during streaming response", error);
         PromptErrorHandler.handleException(context.getProject(), streamingError, context);
         onErrorCallback.accept(streamingError);
+    }
+
+    /**
+     * Persists a run that produced visible answer text but then failed. Conversation
+     * persistence is normally triggered only from {@link #onCompleteResponse} (which
+     * publishes {@link AppTopics#CONVERSATION_TOPIC} → {@code ChatService.saveConversation}).
+     * Without this, an agent/streaming run that streamed a visible answer and then hit a
+     * trailing provider error (e.g. NVIDIA 404 / ConnectException mid tool-loop) would be
+     * dropped from conversation history entirely, even though the user already saw the
+     * answer. Mirrors how {@link #stop()} preserves the partial text in the live view.
+     */
+    private void persistPartialResponseOnError() {
+        if (isStopped || isCompleted) {
+            // stop() finalizes its own message; a completed run already persisted. Avoid
+            // re-publishing a fresh conversation for a trailing/duplicate error callback.
+            return;
+        }
+        String partial = getAccumulatedText();
+        if (partial.isEmpty()) {
+            // Provider failed before producing any text — there is nothing worth saving.
+            return;
+        }
+        try {
+            context.setExecutionTimeMs(System.currentTimeMillis() - startTime);
+            context.setAiMessage(dev.langchain4j.data.message.AiMessage.from(partial));
+            project.getMessageBus()
+                    .syncPublisher(AppTopics.CONVERSATION_TOPIC)
+                    .onNewConversation(context);
+            log.debug("Persisted partial response to history after streaming error for context {}", context.getId());
+        } catch (Exception e) {
+            // Best-effort: a persistence failure must not mask the original streaming error.
+            log.warn("Failed to persist partial response after streaming error for context {}", context.getId(), e);
+        }
     }
 
     /**

--- a/src/main/java/com/devoxx/genie/service/prompt/strategy/AbstractPromptExecutionStrategy.java
+++ b/src/main/java/com/devoxx/genie/service/prompt/strategy/AbstractPromptExecutionStrategy.java
@@ -15,6 +15,7 @@ import com.devoxx.genie.service.rag.RAGEventPublisher;
 import com.devoxx.genie.service.rag.SearchResult;
 import com.devoxx.genie.service.rag.SemanticSearchService;
 import com.devoxx.genie.ui.panel.PromptOutputPanel;
+import com.devoxx.genie.ui.topic.AppTopics;
 import com.devoxx.genie.ui.util.NotificationUtil;
 import com.intellij.openapi.project.Project;
 import dev.langchain4j.data.message.AiMessage;
@@ -304,6 +305,36 @@ public abstract class AbstractPromptExecutionStrategy implements PromptExecution
             "Error in " + getStrategyName() + " execution", error);
         PromptErrorHandler.handleException(context.getProject(), executionError, context);
         resultTask.complete(PromptResult.failure(context, executionError));
+    }
+
+    /**
+     * Persists a partially-completed run to conversation history after a failure. Strategies
+     * that display answer text incrementally (streaming, CLI, ACP) otherwise only persist on
+     * clean completion, so a run that streamed a visible answer and then failed would vanish
+     * from history entirely. Mirrors the streaming {@code onError} behaviour.
+     * <p>
+     * No-op when no text was produced (nothing worth saving). Best-effort: a persistence
+     * failure is logged and swallowed so it can never mask the original error.
+     *
+     * @param context         the chat message context (its AI message and execution time are set here)
+     * @param partialText     the answer text streamed before the failure
+     * @param startTimeMillis the run start time, used to compute the execution duration
+     */
+    protected void persistPartialResponseOnError(@NotNull ChatMessageContext context,
+                                                 @NotNull String partialText,
+                                                 long startTimeMillis) {
+        if (partialText.isEmpty()) {
+            return;
+        }
+        try {
+            context.setExecutionTimeMs(System.currentTimeMillis() - startTimeMillis);
+            context.setAiMessage(AiMessage.from(partialText));
+            project.getMessageBus()
+                    .syncPublisher(AppTopics.CONVERSATION_TOPIC)
+                    .onNewConversation(context);
+        } catch (Exception e) {
+            log.warn("Failed to persist partial response after error for context {}", context.getId(), e);
+        }
     }
     
     /**

--- a/src/main/java/com/devoxx/genie/service/prompt/strategy/AcpPromptStrategy.java
+++ b/src/main/java/com/devoxx/genie/service/prompt/strategy/AcpPromptStrategy.java
@@ -9,6 +9,7 @@ import com.devoxx.genie.service.prompt.result.PromptResult;
 import com.devoxx.genie.service.prompt.threading.PromptTask;
 import com.devoxx.genie.ui.panel.PromptOutputPanel;
 import com.devoxx.genie.ui.settings.DevoxxGenieStateService;
+import com.devoxx.genie.ui.topic.AppTopics;
 import com.devoxx.genie.ui.compose.ConversationViewController;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.project.Project;
@@ -124,33 +125,61 @@ public class AcpPromptStrategy extends AbstractPromptExecutionStrategy {
             long elapsed = System.currentTimeMillis() - startTime;
             log.info("ACP session completed: elapsed={}ms, responseLength={}", elapsed, accumulatedResponse.length());
 
-            ApplicationManager.getApplication().invokeLater(() -> {
-                String exitMsg = "\n=== ACP session completed (after " + elapsed + "ms) ===\n";
-                consoleManager.printSystem(exitMsg);
-
-                context.setExecutionTimeMs(elapsed);
-                String finalText = accumulatedResponse.toString();
-                if (!finalText.isEmpty()) {
-                    context.setAiMessage(AiMessage.from(finalText));
-                }
-
-                if (viewController != null) {
-                    viewController.updateAiMessageContent(context);
-                    viewController.markMCPLogsAsCompleted(context.getId());
-                }
-
-                ChatMemoryManager.getInstance().addAiResponse(context);
-                resultTask.complete(PromptResult.success(context));
-            });
+            ApplicationManager.getApplication().invokeLater(() ->
+                    finalizeAcpSuccess(elapsed, accumulatedResponse, consoleManager, viewController, context, resultTask));
 
         } catch (Exception e) {
             activeClient = null;
             log.error("ACP session failed: {}", e.getMessage(), e);
-            ApplicationManager.getApplication().invokeLater(() -> {
-                consoleManager.printError("[ACP] Error: " + e.getMessage());
-                resultTask.complete(PromptResult.failure(context, e));
-            });
+            ApplicationManager.getApplication().invokeLater(() ->
+                    finalizeAcpError(e, accumulatedResponse, startTime, consoleManager, context, resultTask));
         }
+    }
+
+    private void finalizeAcpSuccess(long elapsed,
+                                    @NotNull StringBuilder accumulatedResponse,
+                                    @NotNull CliConsoleManager consoleManager,
+                                    @Nullable ConversationViewController viewController,
+                                    @NotNull ChatMessageContext context,
+                                    @NotNull PromptTask<PromptResult> resultTask) {
+        String exitMsg = "\n=== ACP session completed (after " + elapsed + "ms) ===\n";
+        consoleManager.printSystem(exitMsg);
+
+        context.setExecutionTimeMs(elapsed);
+        String finalText = accumulatedResponse.toString();
+        if (!finalText.isEmpty()) {
+            context.setAiMessage(AiMessage.from(finalText));
+        }
+
+        if (viewController != null) {
+            viewController.updateAiMessageContent(context);
+            viewController.markMCPLogsAsCompleted(context.getId());
+        }
+
+        ChatMemoryManager.getInstance().addAiResponse(context);
+
+        // Persist to conversation history. ACP previously never published this event, so every
+        // ACP run — success or failure — was absent from history; align it with the
+        // Streaming/NonStreaming/CLI strategies which all persist here.
+        project.getMessageBus()
+                .syncPublisher(AppTopics.CONVERSATION_TOPIC)
+                .onNewConversation(context);
+
+        resultTask.complete(PromptResult.success(context));
+    }
+
+    private void finalizeAcpError(@NotNull Exception e,
+                                  @NotNull StringBuilder accumulatedResponse,
+                                  long startTime,
+                                  @NotNull CliConsoleManager consoleManager,
+                                  @NotNull ChatMessageContext context,
+                                  @NotNull PromptTask<PromptResult> resultTask) {
+        consoleManager.printError("[ACP] Error: " + e.getMessage());
+
+        // Persist any answer already streamed before the failure so the run survives in history.
+        persistPartialResponseOnError(context, accumulatedResponse.toString(), startTime);
+
+        resultTask.complete(PromptResult.failure(context, e));
     }
 
     @Override

--- a/src/main/java/com/devoxx/genie/service/prompt/strategy/CliPromptStrategy.java
+++ b/src/main/java/com/devoxx/genie/service/prompt/strategy/CliPromptStrategy.java
@@ -249,7 +249,8 @@ public class CliPromptStrategy extends AbstractPromptExecutionStrategy {
                 finalizeSuccess(exitMsg, outcome.startTime(), outcome.accumulatedResponse(), consoleManager,
                         viewController, context, resultTask);
             } else {
-                finalizeError(outcome.exitCode(), exitMsg, outcome.stderrLines(), consoleManager, context, resultTask);
+                finalizeError(outcome.exitCode(), exitMsg, outcome.stderrLines(),
+                        outcome.accumulatedResponse(), outcome.startTime(), consoleManager, context, resultTask);
             }
         });
     }
@@ -304,10 +305,18 @@ public class CliPromptStrategy extends AbstractPromptExecutionStrategy {
     private void finalizeError(int exitCode,
                                @NotNull String exitMsg,
                                @NotNull List<String> stderrLines,
+                               @NotNull StringBuilder accumulatedResponse,
+                               long startTime,
                                @NotNull CliConsoleManager consoleManager,
                                @NotNull ChatMessageContext context,
                                @NotNull PromptTask<PromptResult> resultTask) {
         consoleManager.printError(exitMsg);
+
+        // A CLI tool can stream a full, visible answer and still exit non-zero (e.g. a trailing
+        // cleanup error). Persist whatever was already shown so the run survives in conversation
+        // history instead of vanishing — matching the streaming/onError behaviour.
+        persistPartialResponseOnError(context, accumulatedResponse.toString(), startTime);
+
         String errorOutput = String.join("\n", stderrLines).trim();
         resultTask.complete(PromptResult.failure(context,
                 new RuntimeException("CLI process exited with code " + exitCode +

--- a/src/test/java/com/devoxx/genie/service/prompt/response/streaming/StreamingResponseHandlerTest.java
+++ b/src/test/java/com/devoxx/genie/service/prompt/response/streaming/StreamingResponseHandlerTest.java
@@ -672,4 +672,63 @@ class StreamingResponseHandlerTest {
 
         assertThat(onErrorCalled.get()).isTrue();
     }
+
+    // --- Persist partial answer on error (bug: agent/streaming runs that error mid-loop
+    //     were never saved to conversation history, even after streaming a visible answer) ---
+
+    @Test
+    void onError_afterStreamingAnswer_persistsConversationToHistory() {
+        StreamingResponseHandler handler = createHandler();
+
+        // Agent mode: the model streams a visible answer (turn 1)...
+        handler.onPartialResponse("Here is the answer you asked for.");
+        // ...then a later request in the tool loop fails (e.g. NVIDIA 404 / ConnectException).
+        handler.onError(new RuntimeException("{\"status\":404,\"title\":\"Not Found\"}"));
+
+        // The run produced a visible answer, so it must be persisted (published on the
+        // CONVERSATION_TOPIC) — otherwise it silently vanishes from conversation history.
+        verify(mockProject.getMessageBus().syncPublisher(AppTopics.CONVERSATION_TOPIC))
+                .onNewConversation(mockContext);
+    }
+
+    @Test
+    void onError_afterStreamingAnswer_setsAccumulatedTextAsAiMessageBeforePersisting() {
+        StreamingResponseHandler handler = createHandler();
+
+        handler.onPartialResponse("Partial answer ");
+        handler.onPartialResponse("before the error.");
+        handler.onError(new RuntimeException("boom"));
+
+        // The persisted AI message must carry the full accumulated text, so history shows
+        // the answer the user actually saw (not an empty AI turn).
+        ArgumentCaptor<AiMessage> captor = ArgumentCaptor.forClass(AiMessage.class);
+        verify(mockContext, atLeastOnce()).setAiMessage(captor.capture());
+        assertThat(captor.getValue().text()).isEqualTo("Partial answer before the error.");
+    }
+
+    @Test
+    void onError_withoutAnyStreamedText_doesNotPersist() {
+        StreamingResponseHandler handler = createHandler();
+
+        // The provider errored before producing any text — there is nothing worth saving.
+        handler.onError(new RuntimeException("Immediate connection failure"));
+
+        verify(mockProject.getMessageBus().syncPublisher(AppTopics.CONVERSATION_TOPIC), never())
+                .onNewConversation(any());
+    }
+
+    @Test
+    void onError_afterStop_doesNotPersist() {
+        StreamingResponseHandler handler = createHandler();
+        handler.onPartialResponse("Some partial text");
+
+        // A user-initiated stop already finalizes the message; a trailing provider error
+        // must not re-persist it as a fresh conversation.
+        handler.stop();
+        clearInvocations(mockMessageBus);
+
+        handler.onError(new RuntimeException("late error after stop"));
+
+        verify(mockMessageBus, never()).syncPublisher(AppTopics.CONVERSATION_TOPIC);
+    }
 }

--- a/src/test/java/com/devoxx/genie/service/prompt/strategy/AcpPromptStrategyTest.java
+++ b/src/test/java/com/devoxx/genie/service/prompt/strategy/AcpPromptStrategyTest.java
@@ -13,11 +13,15 @@ import com.devoxx.genie.service.prompt.memory.ChatMemoryService;
 import com.devoxx.genie.service.prompt.result.PromptResult;
 import com.devoxx.genie.service.prompt.threading.PromptTask;
 import com.devoxx.genie.service.prompt.threading.ThreadPoolManager;
+import com.devoxx.genie.ui.compose.ConversationViewController;
+import com.devoxx.genie.ui.listener.ConversationEventListener;
 import com.devoxx.genie.ui.panel.PromptOutputPanel;
 import com.devoxx.genie.ui.settings.DevoxxGenieStateService;
+import com.devoxx.genie.ui.topic.AppTopics;
 import com.intellij.openapi.application.Application;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.project.Project;
+import com.intellij.util.messages.MessageBus;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -202,5 +206,105 @@ class AcpPromptStrategyTest {
         strategy.cancel();
 
         verify(mockClient).close();
+    }
+
+    // --- Persistence to conversation history (ACP previously never saved runs at all) ---
+
+    @Test
+    void finalizeAcpSuccess_persistsConversationToHistory() throws Exception {
+        ConversationEventListener mockListener = mock(ConversationEventListener.class);
+        MessageBus mockMessageBus = mock(MessageBus.class);
+        when(mockProject.getMessageBus()).thenReturn(mockMessageBus);
+        when(mockMessageBus.syncPublisher(AppTopics.CONVERSATION_TOPIC)).thenReturn(mockListener);
+
+        CliConsoleManager localConsoleManager = mock(CliConsoleManager.class);
+        @SuppressWarnings("unchecked")
+        PromptTask<PromptResult> localResultTask = mock(PromptTask.class);
+
+        ChatMessageContext context = ChatMessageContext.builder()
+                .project(mockProject)
+                .id("acp-success-persist")
+                .tabId("tab-1")
+                .userPrompt("hello acp")
+                .languageModel(mockLanguageModel)
+                .build();
+
+        java.lang.reflect.Method finalizeSuccess = AcpPromptStrategy.class.getDeclaredMethod(
+                "finalizeAcpSuccess", long.class, StringBuilder.class, CliConsoleManager.class,
+                ConversationViewController.class, ChatMessageContext.class, PromptTask.class);
+        finalizeSuccess.setAccessible(true);
+
+        finalizeSuccess.invoke(strategy, 1234L, new StringBuilder("ACP answer"),
+                localConsoleManager, null, context, localResultTask);
+
+        // ACP runs must now appear in history like every other strategy.
+        verify(mockListener).onNewConversation(context);
+        verify(mockChatMemoryManager).addAiResponse(context);
+        verify(localResultTask).complete(any(PromptResult.class));
+    }
+
+    @Test
+    void finalizeAcpError_withStreamedOutput_persistsConversationToHistory() throws Exception {
+        ConversationEventListener mockListener = mock(ConversationEventListener.class);
+        MessageBus mockMessageBus = mock(MessageBus.class);
+        when(mockProject.getMessageBus()).thenReturn(mockMessageBus);
+        when(mockMessageBus.syncPublisher(AppTopics.CONVERSATION_TOPIC)).thenReturn(mockListener);
+
+        CliConsoleManager localConsoleManager = mock(CliConsoleManager.class);
+        @SuppressWarnings("unchecked")
+        PromptTask<PromptResult> localResultTask = mock(PromptTask.class);
+
+        ChatMessageContext context = ChatMessageContext.builder()
+                .project(mockProject)
+                .id("acp-error-persist")
+                .userPrompt("hello acp")
+                .languageModel(mockLanguageModel)
+                .build();
+
+        java.lang.reflect.Method finalizeError = AcpPromptStrategy.class.getDeclaredMethod(
+                "finalizeAcpError", Exception.class, StringBuilder.class, long.class,
+                CliConsoleManager.class, ChatMessageContext.class, PromptTask.class);
+        finalizeError.setAccessible(true);
+
+        finalizeError.invoke(strategy, new RuntimeException("acp crashed"),
+                new StringBuilder("Partial ACP answer"), System.currentTimeMillis(),
+                localConsoleManager, context, localResultTask);
+
+        verify(mockListener).onNewConversation(context);
+        assertThat(context.getAiMessage()).isNotNull();
+        assertThat(context.getAiMessage().text()).isEqualTo("Partial ACP answer");
+        verify(localResultTask).complete(any(PromptResult.class));
+    }
+
+    @Test
+    void finalizeAcpError_withoutStreamedOutput_doesNotPersist() throws Exception {
+        ConversationEventListener mockListener = mock(ConversationEventListener.class);
+        MessageBus mockMessageBus = mock(MessageBus.class);
+        when(mockProject.getMessageBus()).thenReturn(mockMessageBus);
+        when(mockMessageBus.syncPublisher(AppTopics.CONVERSATION_TOPIC)).thenReturn(mockListener);
+
+        CliConsoleManager localConsoleManager = mock(CliConsoleManager.class);
+        @SuppressWarnings("unchecked")
+        PromptTask<PromptResult> localResultTask = mock(PromptTask.class);
+
+        ChatMessageContext context = ChatMessageContext.builder()
+                .project(mockProject)
+                .id("acp-error-empty")
+                .userPrompt("hello acp")
+                .languageModel(mockLanguageModel)
+                .build();
+
+        java.lang.reflect.Method finalizeError = AcpPromptStrategy.class.getDeclaredMethod(
+                "finalizeAcpError", Exception.class, StringBuilder.class, long.class,
+                CliConsoleManager.class, ChatMessageContext.class, PromptTask.class);
+        finalizeError.setAccessible(true);
+
+        // Failed before producing any output — nothing to persist.
+        finalizeError.invoke(strategy, new RuntimeException("acp failed to start"),
+                new StringBuilder(), System.currentTimeMillis(),
+                localConsoleManager, context, localResultTask);
+
+        verify(mockListener, never()).onNewConversation(any());
+        verify(localResultTask).complete(any(PromptResult.class));
     }
 }

--- a/src/test/java/com/devoxx/genie/service/prompt/strategy/CliPromptStrategyTest.java
+++ b/src/test/java/com/devoxx/genie/service/prompt/strategy/CliPromptStrategyTest.java
@@ -229,6 +229,72 @@ class CliPromptStrategyTest {
     }
 
     @Test
+    void finalizeError_withStreamedOutput_persistsConversationToHistory() throws Exception {
+        // A CLI tool that streamed a visible answer but exited non-zero must still be saved.
+        ConversationEventListener mockListener = mock(ConversationEventListener.class);
+        MessageBus mockMessageBus = mock(MessageBus.class);
+        when(mockProject.getMessageBus()).thenReturn(mockMessageBus);
+        when(mockMessageBus.syncPublisher(AppTopics.CONVERSATION_TOPIC)).thenReturn(mockListener);
+
+        CliConsoleManager localConsoleManager = mock(CliConsoleManager.class);
+        @SuppressWarnings("unchecked")
+        PromptTask<PromptResult> localResultTask = mock(PromptTask.class);
+
+        ChatMessageContext context = ChatMessageContext.builder()
+                .project(mockProject)
+                .id("cli-error-persist")
+                .tabId("tab-1")
+                .userPrompt("do the thing")
+                .languageModel(mockLanguageModel)
+                .build();
+
+        java.lang.reflect.Method finalizeError = CliPromptStrategy.class.getDeclaredMethod(
+                "finalizeError", int.class, String.class, List.class, StringBuilder.class, long.class,
+                CliConsoleManager.class, ChatMessageContext.class, PromptTask.class);
+        finalizeError.setAccessible(true);
+
+        StringBuilder streamed = new StringBuilder("Partial answer before the crash");
+        finalizeError.invoke(strategy, 1, "exit msg", Collections.singletonList("boom"),
+                streamed, System.currentTimeMillis(), localConsoleManager, context, localResultTask);
+
+        verify(mockListener).onNewConversation(context);
+        assertThat(context.getAiMessage()).isNotNull();
+        assertThat(context.getAiMessage().text()).isEqualTo("Partial answer before the crash");
+        verify(localResultTask).complete(any(PromptResult.class));
+    }
+
+    @Test
+    void finalizeError_withoutStreamedOutput_doesNotPersist() throws Exception {
+        ConversationEventListener mockListener = mock(ConversationEventListener.class);
+        MessageBus mockMessageBus = mock(MessageBus.class);
+        when(mockProject.getMessageBus()).thenReturn(mockMessageBus);
+        when(mockMessageBus.syncPublisher(AppTopics.CONVERSATION_TOPIC)).thenReturn(mockListener);
+
+        CliConsoleManager localConsoleManager = mock(CliConsoleManager.class);
+        @SuppressWarnings("unchecked")
+        PromptTask<PromptResult> localResultTask = mock(PromptTask.class);
+
+        ChatMessageContext context = ChatMessageContext.builder()
+                .project(mockProject)
+                .id("cli-error-empty")
+                .userPrompt("do the thing")
+                .languageModel(mockLanguageModel)
+                .build();
+
+        java.lang.reflect.Method finalizeError = CliPromptStrategy.class.getDeclaredMethod(
+                "finalizeError", int.class, String.class, List.class, StringBuilder.class, long.class,
+                CliConsoleManager.class, ChatMessageContext.class, PromptTask.class);
+        finalizeError.setAccessible(true);
+
+        // Process failed before producing any output — nothing to persist.
+        finalizeError.invoke(strategy, 127, "exit msg", Collections.singletonList("not found"),
+                new StringBuilder(), System.currentTimeMillis(), localConsoleManager, context, localResultTask);
+
+        verify(mockListener, never()).onNewConversation(any());
+        verify(localResultTask).complete(any(PromptResult.class));
+    }
+
+    @Test
     void cancel_withActiveProcess_destroysProcess() throws Exception {
         Process mockProcess = mock(Process.class);
         when(mockProcess.isAlive()).thenReturn(true);


### PR DESCRIPTION
## Problem

Reported as: *"the LLM answered correctly, but the prompt/conversation isn't shown in conversation history"* — intermittent, seen with the NVIDIA provider in agent + streaming mode.

**Root cause (confirmed via `idea.log` + the SQLite `conversations.db`):** conversations are persisted only on **clean completion** (`StreamingResponseHandler.onCompleteResponse` → `CONVERSATION_TOPIC.onNewConversation` → `ChatService.saveConversation`). When a streaming/agent run streams a visible answer and then a later request in the tool loop **errors** (NVIDIA `ConnectException` / `404 "Function … Not found for account"`), it goes through `onError`, which published nothing — so the entire run, including the answer the user saw, silently vanished from history. Intermittent because it depends on whether the provider errors mid-run.

Evidence: the DB had **zero** rows for the NVIDIA provider despite many attempts, and the error path never fired the persistence event.

## Audit of all incremental-display strategies

| Strategy | Before | After |
|---|---|---|
| Streaming | dropped on error | ✅ persists accumulated partial answer |
| Non-streaming | already correct (display + persist atomic on success) | unchanged |
| **CLI** | persisted only on exit 0 | ✅ `finalizeError` persists output streamed before a non-zero exit |
| **ACP** | **never published `onNewConversation` — even on success** | ✅ persists on success *and* on partial-error |

ACP had a bigger latent bug: every ACP run was always absent from history.

## Changes

- New shared `AbstractPromptExecutionStrategy.persistPartialResponseOnError(context, partialText, startTimeMillis)` — sets the AI message + execution time and publishes the conversation event. No-op on empty text; best-effort `try/catch` so a persistence failure can't mask the original error.
- `StreamingResponseHandler.onError` persists the accumulated answer (guarded by `isStopped`/`isCompleted`; keeps its own copy of the helper as it isn't a strategy subclass).
- `CliPromptStrategy.finalizeError` persists partial output on non-zero exit.
- `AcpPromptStrategy` refactored into `finalizeAcpSuccess` (now persists — the previously-missing publish) and `finalizeAcpError` (persists partial).

## Tests

Reflection-based, mirroring the existing `finalizeSuccess_publishesConversationTopic`:
- Streaming: `onError` persists after a streamed answer / sets accumulated text / doesn't persist with no text / doesn't persist after `stop()`.
- CLI: `finalizeError` with and without streamed output.
- ACP: `finalizeAcpSuccess` persists; `finalizeAcpError` with and without output.

Full test suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)