### PR TITLE
fix: guard thread-pool shutdown against a null Application during JVM exit

### DIFF
--- a/src/main/java/com/devoxx/genie/service/prompt/threading/ThreadPoolShutdownManager.java
+++ b/src/main/java/com/devoxx/genie/service/prompt/threading/ThreadPoolShutdownManager.java
@@ -1,5 +1,6 @@
 package com.devoxx.genie.service.prompt.threading;
 
+import com.intellij.openapi.application.Application;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.project.ProjectManager;
@@ -31,6 +32,14 @@ public class ThreadPoolShutdownManager implements ProjectManagerListener {
      */
     private static void shutdownThreadPools() {
         try {
+            // The JVM shutdown hook can fire after the IntelliJ Application has already been
+            // torn down, at which point ApplicationManager.getApplication() returns null and
+            // ThreadPoolManager.getInstance() would NPE inside getApplication().getService(...).
+            // Skip cleanly in that case — the pools die with the JVM anyway.
+            Application application = ApplicationManager.getApplication();
+            if (application == null) {
+                return;
+            }
             ThreadPoolManager threadPoolManager = ThreadPoolManager.getInstance();
             if (threadPoolManager != null) {
                 log.info("Shutting down thread pools");

--- a/src/test/java/com/devoxx/genie/service/prompt/threading/ThreadPoolShutdownManagerTest.java
+++ b/src/test/java/com/devoxx/genie/service/prompt/threading/ThreadPoolShutdownManagerTest.java
@@ -1,0 +1,84 @@
+package com.devoxx.genie.service.prompt.threading;
+
+import com.intellij.openapi.application.Application;
+import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.util.messages.MessageBus;
+import com.intellij.util.messages.MessageBusConnection;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import java.lang.reflect.Method;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class ThreadPoolShutdownManagerTest {
+
+    private static final String CLASS_NAME =
+            "com.devoxx.genie.service.prompt.threading.ThreadPoolShutdownManager";
+
+    /**
+     * Forces the class's static initializer to run while a mocked Application is available,
+     * so referencing it later (to invoke the private shutdown method) cannot NPE inside the
+     * static block itself. The initializer subscribes to the message bus and registers a JVM
+     * shutdown hook.
+     */
+    private void forceClassInitialized(@org.jetbrains.annotations.NotNull Application mockApp,
+                                       @org.jetbrains.annotations.NotNull MockedStatic<ApplicationManager> appMgr)
+            throws Exception {
+        MessageBus mockBus = mock(MessageBus.class);
+        MessageBusConnection mockConn = mock(MessageBusConnection.class);
+        when(mockApp.getMessageBus()).thenReturn(mockBus);
+        when(mockBus.connect()).thenReturn(mockConn);
+        appMgr.when(ApplicationManager::getApplication).thenReturn(mockApp);
+        Class.forName(CLASS_NAME, true, getClass().getClassLoader());
+    }
+
+    private Method shutdownMethod() throws Exception {
+        Method m = Class.forName(CLASS_NAME).getDeclaredMethod("shutdownThreadPools");
+        m.setAccessible(true);
+        return m;
+    }
+
+    @Test
+    void shutdownThreadPools_whenApplicationIsNull_returnsWithoutTouchingThreadPoolManager() throws Exception {
+        try (MockedStatic<ApplicationManager> appMgr = mockStatic(ApplicationManager.class);
+             MockedStatic<ThreadPoolManager> tpm = mockStatic(ThreadPoolManager.class)) {
+
+            Application mockApp = mock(Application.class);
+            forceClassInitialized(mockApp, appMgr);
+
+            // Simulate the JVM shutdown hook firing after the Application has been torn down.
+            appMgr.when(ApplicationManager::getApplication).thenReturn(null);
+
+            Method shutdown = shutdownMethod();
+
+            // The guard must swallow the missing Application cleanly — no NPE from getInstance().
+            assertThatCode(() -> shutdown.invoke(null)).doesNotThrowAnyException();
+            tpm.verify(ThreadPoolManager::getInstance, never());
+        }
+    }
+
+    @Test
+    void shutdownThreadPools_whenApplicationPresent_shutsDownThreadPools() throws Exception {
+        try (MockedStatic<ApplicationManager> appMgr = mockStatic(ApplicationManager.class);
+             MockedStatic<ThreadPoolManager> tpm = mockStatic(ThreadPoolManager.class)) {
+
+            Application mockApp = mock(Application.class);
+            forceClassInitialized(mockApp, appMgr);
+
+            ThreadPoolManager mockManager = mock(ThreadPoolManager.class);
+            tpm.when(ThreadPoolManager::getInstance).thenReturn(mockManager);
+
+            shutdownMethod().invoke(null);
+
+            verify(mockManager).shutdown();
+        }
+    }
+}


### PR DESCRIPTION
## Problem

`ThreadPoolShutdownManager` registers a JVM shutdown hook that calls `ThreadPoolManager.getInstance()`. That hook can fire **after** the IntelliJ `Application` has already been torn down, at which point `ApplicationManager.getApplication()` returns `null` and `getInstance()` NPEs inside `getApplication().getService(...)`.

Observed repeatedly in `idea.log` (once per IDE exit):

```
java.lang.NullPointerException: Cannot invoke "...Application.getService(...)" because
  the return value of "...ApplicationManager.getApplication()" is null
    at ThreadPoolManager.getInstance(ThreadPoolManager.java:29)
    at ThreadPoolShutdownManager.shutdownThreadPools(ThreadPoolShutdownManager.java:34)
    at ThreadPoolShutdownManager.lambda$static$0(ThreadPoolShutdownManager.java:25)
```

It was caught by the surrounding `try/catch`, but during shutdown it still printed a raw stack trace to stdout — noise on every exit.

## Fix

Guard `shutdownThreadPools()` with a null check on the `Application` and return early when it's gone — the pools die with the JVM anyway.

## Tests

New `ThreadPoolShutdownManagerTest`:
- null Application → no-op, never reaches `getInstance()` (regression guard)
- present Application → pools are shut down

Harmless cosmetic fix, independent of #1177.

🤖 Generated with [Claude Code](https://claude.com/claude-code)