### PR TITLE
feat: Show Thinking setting for reasoning models

### DIFF
--- a/backlog/tasks/task-240 - Enable-Ollama-thinking-from-settings.md
+++ b/backlog/tasks/task-240 - Enable-Ollama-thinking-from-settings.md
@@ -1,0 +1,85 @@
+---
+id: TASK-240
+title: Enable Ollama thinking from settings
+status: In Progress
+assignee: []
+created_date: '2026-07-01 14:48'
+updated_date: '2026-07-02 09:35'
+labels:
+  - settings
+  - ollama
+  - langchain4j
+dependencies: []
+modified_files:
+  - src/main/java/com/devoxx/genie/ui/settings/DevoxxGenieStateService.java
+  - src/main/java/com/devoxx/genie/ui/settings/llm/LLMProvidersComponent.java
+  - src/main/java/com/devoxx/genie/ui/settings/LLMProvidersConfigurable.java
+  - >-
+    src/main/java/com/devoxx/genie/chatmodel/local/ollama/OllamaChatModelFactory.java
+  - >-
+    src/main/java/com/devoxx/genie/service/prompt/response/nonstreaming/NonStreamingPromptExecutionService.java
+  - >-
+    src/main/java/com/devoxx/genie/service/prompt/response/streaming/StreamingResponseHandler.java
+  - >-
+    src/main/java/com/devoxx/genie/service/prompt/response/streaming/ThinkingResponseFormatter.java
+  - >-
+    src/main/java/com/devoxx/genie/service/prompt/strategy/NonStreamingPromptStrategy.java
+  - >-
+    src/main/java/com/devoxx/genie/service/prompt/strategy/StreamingPromptStrategy.java
+  - src/main/kotlin/com/devoxx/genie/ui/compose/components/AiBubble.kt
+  - src/main/kotlin/com/devoxx/genie/ui/compose/components/MessagePair.kt
+  - src/main/kotlin/com/devoxx/genie/ui/compose/model/MessageUiModel.kt
+  - src/main/kotlin/com/devoxx/genie/ui/compose/theme/DevoxxGenieTheme.kt
+  - >-
+    src/main/kotlin/com/devoxx/genie/ui/compose/viewmodel/ConversationViewModel.kt
+  - src/test/java/com/devoxx/genie/ui/settings/DevoxxGenieStateServiceTest.java
+  - >-
+    src/test/java/com/devoxx/genie/ui/settings/llm/LLMProvidersConfigurableTest.java
+  - >-
+    src/test/java/com/devoxx/genie/chatmodel/local/ollama/OllamaChatModelFactoryTest.java
+  - >-
+    src/test/java/com/devoxx/genie/service/prompt/response/nonstreaming/NonStreamingPromptExecutionServiceTest.java
+  - >-
+    src/test/java/com/devoxx/genie/service/prompt/response/streaming/StreamingResponseHandlerTest.java
+  - >-
+    src/test/java/com/devoxx/genie/service/prompt/response/streaming/TestStreamingResponseHandler.java
+  - >-
+    src/test/java/com/devoxx/genie/service/prompt/strategy/NonStreamingPromptStrategyTest.java
+  - >-
+    src/test/java/com/devoxx/genie/service/prompt/strategy/StreamingPromptStrategyTest.java
+  - >-
+    src/test/kotlin/com/devoxx/genie/ui/compose/viewmodel/ConversationViewModelThinkingTest.kt
+priority: medium
+ordinal: 2000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Allow users to opt into Ollama reasoning/thinking output from the LLM Providers settings, near the existing stream mode setting. When disabled, behavior must remain unchanged. When enabled, DevoxxGenie should request Ollama thinking through LangChain4j and make returned thinking visible in responses without losing normal answer text or token metrics.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 A persisted settings checkbox lets users enable or disable Ollama thinking, defaulting to disabled for existing behavior.
+- [x] #2 Settings modified/apply/reset logic correctly detects, saves, and restores the Ollama thinking setting.
+- [x] #3 Ollama chat and streaming model creation enable LangChain4j thinking only when the setting is enabled.
+- [x] #4 Streaming Ollama thinking tokens are captured and rendered in the response without replacing the final answer text.
+- [x] #5 Automated tests cover settings persistence, Ollama model wiring, and streaming thinking handling.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented with TDD. Important follow-up from manual test: normal streaming chat goes through LangChain4j AiServices TokenStream, so StreamingPromptStrategy must subscribe to onPartialThinking(handler::onPartialThinking); direct handler support alone is insufficient. Verification: full ./gradlew test passed before the subscription patch; after patch, reran affected test classes successfully.
+
+Updated the thinking renderer from a generic details block to a visible Markdown callout: `> 🧠 **Thinking**`, followed by the final answer. This makes the reasoning visually distinct in the response UI. Verification after the style change: affected tests passed.
+
+Updated the Ollama thinking UI refinement: streaming thinking is now encoded with internal thinking markers, split into `thinkingMarkdown` in the Compose view model, and rendered as its own theme-aware `ThinkingBubble` before the final assistant response bubble. Added targeted regression coverage for marker formatting and view-model splitting.
+
+Fixed the non-streaming Ollama thinking gap: the normal no-tool non-streaming path now calls `ChatModel.chat(...)` directly instead of `AiServices` returning only a `String`, preserving `AiMessage.thinking()`. `NonStreamingPromptStrategy` formats returned `AiMessage.thinking()` with the same internal markers used by streaming so the Compose thinking bubble appears when streaming is off. Also refactored `ThinkingBubble` to render its content as Markdown.
+
+Scope expanded beyond Ollama: the setting was renamed from ollamaThinkingEnabled to showThinkingEnabled (checkbox label "Show Thinking") and wired into all OpenAI-compatible factories via new ThinkingSupport helper — LocalChatModelFactory base (LMStudio, Jan, GPT4All, Exo), llama.cpp, CustomOpenAI, OpenAI, DeepSeek, DeepInfra, OpenRouter, Groq, Grok, GLM, Kimi, Nvidia — plus Mistral (returnThinking on MistralAi builders). The flag is client-side only (langchain4j parses the reasoning_content response field), so it is a harmless no-op for providers/models that emit no reasoning. Not covered: Anthropic/Gemini/Bedrock (extended thinking there must be enabled with a token budget → cost implications; follow-up task) and Azure OpenAI (azure module lacks returnThinking). Known limitation: langchain4j 1.17.1 parses only reasoning_content, so OpenRouter/Groq (which use a 'reasoning' field) won't show thinking yet.
+
+Also fixed: non-streaming prompts with agent/MCP tools dropped thinking because the AiServices Assistant interface returned String (langchain4j discards AiMessage.thinking() for String return types). Assistant.chat() now returns AiMessage.
+<!-- SECTION:NOTES:END -->

--- a/docs/superpowers/plans/2026-07-01-ollama-thinking-setting.md
+++ b/docs/superpowers/plans/2026-07-01-ollama-thinking-setting.md
@@ -1,0 +1,61 @@
+# Ollama Thinking Setting Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add an opt-in setting that lets users show Ollama model thinking/reasoning in plugin responses.
+
+**Architecture:** Persist a new boolean in `DevoxxGenieStateService`, expose it as a checkbox near the existing stream mode setting, wire it into Ollama LangChain4j builders with `think(true)` and `returnThinking(true)`, and capture streaming `PartialThinking` tokens in the existing streaming response handler. Keep the default disabled so existing behavior is unchanged.
+
+**Tech Stack:** Java 17, IntelliJ settings UI/Swing, LangChain4j 1.17.1 Ollama, JUnit 5, Mockito, AssertJ.
+
+---
+
+### Task 1: Persist and expose the settings checkbox
+
+**Files:**
+- Modify: `src/main/java/com/devoxx/genie/ui/settings/DevoxxGenieStateService.java`
+- Modify: `src/main/java/com/devoxx/genie/ui/settings/llm/LLMProvidersComponent.java`
+- Modify: `src/main/java/com/devoxx/genie/ui/settings/llm/LLMProvidersConfigurable.java`
+- Test: `src/test/java/com/devoxx/genie/ui/settings/llm/LLMProvidersConfigurableTest.java`
+- Test: `src/test/java/com/devoxx/genie/ui/settings/DevoxxGenieStateServiceTest.java`
+
+- [ ] Write failing tests that the new setting defaults to false, is modified when the checkbox changes, applies to state, and resets from state.
+- [ ] Run the targeted tests and verify failures mention missing `getOllamaThinkingEnabled` / checkbox accessors.
+- [ ] Add `private Boolean ollamaThinkingEnabled = false` plus getter/setter in `DevoxxGenieStateService`.
+- [ ] Add `ollamaThinkingCheckBox` to `LLMProvidersComponent` near stream mode with a short hint.
+- [ ] Include the checkbox in `isModified()`, `apply()`, and `reset()`.
+- [ ] Run the targeted tests and verify they pass.
+
+### Task 2: Wire the setting into Ollama model creation
+
+**Files:**
+- Modify: `src/main/java/com/devoxx/genie/chatmodel/local/ollama/OllamaChatModelFactory.java`
+- Test: `src/test/java/com/devoxx/genie/chatmodel/local/ollama/OllamaChatModelFactoryTest.java`
+
+- [ ] Write failing tests that disabled thinking leaves `think()` null and enabled thinking sets `think()` true for both chat and streaming models.
+- [ ] Use reflection in tests to assert the private LangChain4j `returnThinking` flag is false/true as appropriate.
+- [ ] Run targeted tests and verify they fail before implementation.
+- [ ] Read `DevoxxGenieStateService.getOllamaThinkingEnabled()` in the factory and call `.think(true).returnThinking(true)` only when enabled.
+- [ ] Run targeted tests and verify they pass.
+
+### Task 3: Capture streaming thinking tokens in responses
+
+**Files:**
+- Modify: `src/main/java/com/devoxx/genie/service/prompt/response/streaming/StreamingResponseHandler.java`
+- Test: existing streaming handler tests if present, otherwise add focused test coverage in `src/test/java/com/devoxx/genie/service/prompt/response/streaming/StreamingResponseHandlerTest.java`.
+
+- [ ] Write a failing test that calls `onPartialThinking(new PartialThinking("reason"))`, then normal response tokens, and verifies the final persisted/displayed AI message contains both a clearly labeled thinking section and the answer.
+- [ ] Run targeted test and verify it fails because `onPartialThinking` is not handled.
+- [ ] Add a thinking accumulator and override `onPartialThinking(...)` to append tokens without replacing answer tokens.
+- [ ] Render the accumulated thinking before the answer as a Markdown details block: `<details><summary>Thinking</summary>\n\n...\n\n</details>\n\nanswer`.
+- [ ] Ensure final `AiMessage` uses the combined visible text when streaming occurred, while token usage handling remains unchanged.
+- [ ] Run targeted tests and verify they pass.
+
+### Task 4: Verify and update Backlog
+
+**Files:**
+- Modify: `backlog/tasks/task-240 - Enable-Ollama-thinking-from-settings.md` via MCP tools only.
+
+- [ ] Run `./gradlew test --tests ...` for changed test classes.
+- [ ] Run `./gradlew test` if targeted tests pass and time permits.
+- [ ] Mark TASK-240 acceptance criteria complete via Backlog MCP after verification.

--- a/src/main/java/com/devoxx/genie/chatmodel/ThinkingSupport.java
+++ b/src/main/java/com/devoxx/genie/chatmodel/ThinkingSupport.java
@@ -1,0 +1,22 @@
+package com.devoxx.genie.chatmodel;
+
+import com.devoxx.genie.ui.settings.DevoxxGenieStateService;
+
+/**
+ * Resolves the global "Show Thinking" setting for chat model factories.
+ *
+ * <p>Factories pass the flag to their builder's {@code returnThinking(...)}; langchain4j then
+ * surfaces any reasoning the provider emits (e.g. the OpenAI-compatible
+ * {@code reasoning_content} field) as {@link dev.langchain4j.data.message.AiMessage#thinking()}.
+ * The flag is client-side only: enabling it for providers/models that emit no reasoning is a
+ * no-op, so it is safe to apply unconditionally to every OpenAI-compatible builder.
+ */
+public final class ThinkingSupport {
+
+    private ThinkingSupport() {
+    }
+
+    public static boolean isEnabled() {
+        return Boolean.TRUE.equals(DevoxxGenieStateService.getInstance().getShowThinkingEnabled());
+    }
+}

--- a/src/main/java/com/devoxx/genie/chatmodel/cloud/deepinfra/DeepInfraChatModelFactory.java
+++ b/src/main/java/com/devoxx/genie/chatmodel/cloud/deepinfra/DeepInfraChatModelFactory.java
@@ -1,6 +1,7 @@
 package com.devoxx.genie.chatmodel.cloud.deepinfra;
 
 import com.devoxx.genie.chatmodel.ChatModelFactory;
+import com.devoxx.genie.chatmodel.ThinkingSupport;
 import com.devoxx.genie.model.CustomChatModel;
 import com.devoxx.genie.model.LanguageModel;
 import com.devoxx.genie.model.enumarations.ModelProvider;
@@ -28,6 +29,7 @@ public class DeepInfraChatModelFactory implements ChatModelFactory {
             .maxTokens(customChatModel.getMaxTokens())
             .timeout(Duration.ofSeconds(customChatModel.getTimeout()))
             .topP(customChatModel.getTopP())
+            .returnThinking(ThinkingSupport.isEnabled())
             .listeners(getListener())
             .build();
     }
@@ -41,6 +43,7 @@ public class DeepInfraChatModelFactory implements ChatModelFactory {
             .temperature(customChatModel.getTemperature())
             .topP(customChatModel.getTopP())
             .timeout(Duration.ofSeconds(customChatModel.getTimeout()))
+            .returnThinking(ThinkingSupport.isEnabled())
             .listeners(getListener())
             .build();
     }

--- a/src/main/java/com/devoxx/genie/chatmodel/cloud/deepseek/DeepSeekChatModelFactory.java
+++ b/src/main/java/com/devoxx/genie/chatmodel/cloud/deepseek/DeepSeekChatModelFactory.java
@@ -1,6 +1,7 @@
 package com.devoxx.genie.chatmodel.cloud.deepseek;
 
 import com.devoxx.genie.chatmodel.ChatModelFactory;
+import com.devoxx.genie.chatmodel.ThinkingSupport;
 import com.devoxx.genie.model.CustomChatModel;
 import com.devoxx.genie.model.LanguageModel;
 import com.devoxx.genie.model.enumarations.ModelProvider;
@@ -28,6 +29,7 @@ public class DeepSeekChatModelFactory implements ChatModelFactory {
             .maxTokens(4_000)   // 8K Beta https://platform.deepseek.com/api-docs/quick_start/pricing
             .timeout(Duration.ofSeconds(customChatModel.getTimeout()))
             .topP(customChatModel.getTopP())
+            .returnThinking(ThinkingSupport.isEnabled())
             .listeners(getListener())
             .build();
     }
@@ -42,6 +44,7 @@ public class DeepSeekChatModelFactory implements ChatModelFactory {
             .temperature(customChatModel.getTemperature())
             .topP(customChatModel.getTopP())
             .timeout(Duration.ofSeconds(customChatModel.getTimeout()))
+            .returnThinking(ThinkingSupport.isEnabled())
             .listeners(getListener())
             .build();
     }

--- a/src/main/java/com/devoxx/genie/chatmodel/cloud/glm/GLMChatModelFactory.java
+++ b/src/main/java/com/devoxx/genie/chatmodel/cloud/glm/GLMChatModelFactory.java
@@ -1,6 +1,7 @@
 package com.devoxx.genie.chatmodel.cloud.glm;
 
 import com.devoxx.genie.chatmodel.ChatModelFactory;
+import com.devoxx.genie.chatmodel.ThinkingSupport;
 import com.devoxx.genie.model.CustomChatModel;
 import com.devoxx.genie.model.LanguageModel;
 import com.devoxx.genie.model.enumarations.ModelProvider;
@@ -28,6 +29,7 @@ public class GLMChatModelFactory implements ChatModelFactory {
             .maxTokens(4_000)
             .timeout(Duration.ofSeconds(customChatModel.getTimeout()))
             .topP(customChatModel.getTopP())
+            .returnThinking(ThinkingSupport.isEnabled())
             .listeners(getListener())
             .build();
     }
@@ -42,6 +44,7 @@ public class GLMChatModelFactory implements ChatModelFactory {
             .temperature(customChatModel.getTemperature())
             .topP(customChatModel.getTopP())
             .timeout(Duration.ofSeconds(customChatModel.getTimeout()))
+            .returnThinking(ThinkingSupport.isEnabled())
             .listeners(getListener())
             .build();
     }

--- a/src/main/java/com/devoxx/genie/chatmodel/cloud/grok/GrokChatModelFactory.java
+++ b/src/main/java/com/devoxx/genie/chatmodel/cloud/grok/GrokChatModelFactory.java
@@ -1,6 +1,7 @@
 package com.devoxx.genie.chatmodel.cloud.grok;
 
 import com.devoxx.genie.chatmodel.ChatModelFactory;
+import com.devoxx.genie.chatmodel.ThinkingSupport;
 import com.devoxx.genie.model.CustomChatModel;
 import com.devoxx.genie.model.LanguageModel;
 import com.devoxx.genie.model.enumarations.ModelProvider;
@@ -27,6 +28,7 @@ public class GrokChatModelFactory implements ChatModelFactory {
                 .defaultRequestParameters(createChatContextParameters(customChatModel))
                 .maxRetries(customChatModel.getMaxRetries())
                 .timeout(Duration.ofSeconds(customChatModel.getTimeout()))
+                .returnThinking(ThinkingSupport.isEnabled())
                 .listeners(getListener())
                 .baseUrl(GROK_API_ENDPOINT)
                 .build();
@@ -39,6 +41,7 @@ public class GrokChatModelFactory implements ChatModelFactory {
                 .defaultRequestParameters(createChatContextParameters(customChatModel))
                 .modelName(customChatModel.getModelName())
                 .timeout(Duration.ofSeconds(customChatModel.getTimeout()))
+                .returnThinking(ThinkingSupport.isEnabled())
                 .listeners(getListener())
                 .baseUrl(GROK_API_ENDPOINT)
                 .build();

--- a/src/main/java/com/devoxx/genie/chatmodel/cloud/groq/GroqChatModelFactory.java
+++ b/src/main/java/com/devoxx/genie/chatmodel/cloud/groq/GroqChatModelFactory.java
@@ -1,6 +1,7 @@
 package com.devoxx.genie.chatmodel.cloud.groq;
 
 import com.devoxx.genie.chatmodel.ChatModelFactory;
+import com.devoxx.genie.chatmodel.ThinkingSupport;
 import com.devoxx.genie.model.CustomChatModel;
 import com.devoxx.genie.model.LanguageModel;
 import com.devoxx.genie.model.enumarations.ModelProvider;
@@ -27,6 +28,7 @@ public class GroqChatModelFactory implements ChatModelFactory {
             .temperature(customChatModel.getTemperature())
             .timeout(Duration.ofSeconds(customChatModel.getTimeout()))
             .topP(customChatModel.getTopP())
+            .returnThinking(ThinkingSupport.isEnabled())
             .listeners(getListener())
             .build();
     }

--- a/src/main/java/com/devoxx/genie/chatmodel/cloud/kimi/KimiChatModelFactory.java
+++ b/src/main/java/com/devoxx/genie/chatmodel/cloud/kimi/KimiChatModelFactory.java
@@ -1,6 +1,7 @@
 package com.devoxx.genie.chatmodel.cloud.kimi;
 
 import com.devoxx.genie.chatmodel.ChatModelFactory;
+import com.devoxx.genie.chatmodel.ThinkingSupport;
 import com.devoxx.genie.model.CustomChatModel;
 import com.devoxx.genie.model.LanguageModel;
 import com.devoxx.genie.model.enumarations.ModelProvider;
@@ -28,6 +29,7 @@ public class KimiChatModelFactory implements ChatModelFactory {
             .maxTokens(4_000)
             .timeout(Duration.ofSeconds(customChatModel.getTimeout()))
             .topP(customChatModel.getTopP())
+            .returnThinking(ThinkingSupport.isEnabled())
             .listeners(getListener())
             .build();
     }
@@ -42,6 +44,7 @@ public class KimiChatModelFactory implements ChatModelFactory {
             .temperature(customChatModel.getTemperature())
             .topP(customChatModel.getTopP())
             .timeout(Duration.ofSeconds(customChatModel.getTimeout()))
+            .returnThinking(ThinkingSupport.isEnabled())
             .listeners(getListener())
             .build();
     }

--- a/src/main/java/com/devoxx/genie/chatmodel/cloud/mistral/MistralChatModelFactory.java
+++ b/src/main/java/com/devoxx/genie/chatmodel/cloud/mistral/MistralChatModelFactory.java
@@ -1,6 +1,7 @@
 package com.devoxx.genie.chatmodel.cloud.mistral;
 
 import com.devoxx.genie.chatmodel.ChatModelFactory;
+import com.devoxx.genie.chatmodel.ThinkingSupport;
 import com.devoxx.genie.model.CustomChatModel;
 import com.devoxx.genie.model.LanguageModel;
 import com.devoxx.genie.model.enumarations.ModelProvider;
@@ -27,6 +28,7 @@ public class MistralChatModelFactory implements ChatModelFactory {
             .maxTokens(customChatModel.getMaxTokens())
             .timeout(Duration.ofSeconds(customChatModel.getTimeout()))
             .topP(customChatModel.getTopP())
+            .returnThinking(ThinkingSupport.isEnabled())
             .build();
     }
 
@@ -38,6 +40,7 @@ public class MistralChatModelFactory implements ChatModelFactory {
             .temperature(customChatModel.getTemperature())
             .topP(customChatModel.getTopP())
             .timeout(Duration.ofSeconds(customChatModel.getTimeout()))
+            .returnThinking(ThinkingSupport.isEnabled())
             .build();
     }
 

--- a/src/main/java/com/devoxx/genie/chatmodel/cloud/nvidia/NvidiaChatModelFactory.java
+++ b/src/main/java/com/devoxx/genie/chatmodel/cloud/nvidia/NvidiaChatModelFactory.java
@@ -1,6 +1,7 @@
 package com.devoxx.genie.chatmodel.cloud.nvidia;
 
 import com.devoxx.genie.chatmodel.ChatModelFactory;
+import com.devoxx.genie.chatmodel.ThinkingSupport;
 import com.devoxx.genie.chatmodel.local.LocalLLMProviderUtil;
 import com.devoxx.genie.model.CustomChatModel;
 import com.devoxx.genie.model.LanguageModel;
@@ -164,6 +165,7 @@ public class NvidiaChatModelFactory implements ChatModelFactory {
             .maxTokens(customChatModel.getMaxTokens())
             .timeout(Duration.ofSeconds(customChatModel.getTimeout()))
             .topP(customChatModel.getTopP())
+            .returnThinking(ThinkingSupport.isEnabled())
             .listeners(getListener())
             .build();
     }
@@ -177,6 +179,7 @@ public class NvidiaChatModelFactory implements ChatModelFactory {
             .temperature(customChatModel.getTemperature())
             .topP(customChatModel.getTopP())
             .timeout(Duration.ofSeconds(customChatModel.getTimeout()))
+            .returnThinking(ThinkingSupport.isEnabled())
             .listeners(getListener())
             .build();
     }

--- a/src/main/java/com/devoxx/genie/chatmodel/cloud/openai/OpenAIChatModelFactory.java
+++ b/src/main/java/com/devoxx/genie/chatmodel/cloud/openai/OpenAIChatModelFactory.java
@@ -1,6 +1,7 @@
 package com.devoxx.genie.chatmodel.cloud.openai;
 
 import com.devoxx.genie.chatmodel.ChatModelFactory;
+import com.devoxx.genie.chatmodel.ThinkingSupport;
 import com.devoxx.genie.model.CustomChatModel;
 import com.devoxx.genie.model.LanguageModel;
 import com.devoxx.genie.model.enumarations.ModelProvider;
@@ -26,6 +27,7 @@ public class OpenAIChatModelFactory implements ChatModelFactory {
                 .defaultRequestParameters(createChatContextParameters(customChatModel))
                 .maxRetries(customChatModel.getMaxRetries())
                 .timeout(Duration.ofSeconds(customChatModel.getTimeout()))
+                .returnThinking(ThinkingSupport.isEnabled())
                 .listeners(getListener())
                 .build();
     }
@@ -37,6 +39,7 @@ public class OpenAIChatModelFactory implements ChatModelFactory {
                 .defaultRequestParameters(createChatContextParameters(customChatModel))
                 .modelName(customChatModel.getModelName())
                 .timeout(Duration.ofSeconds(customChatModel.getTimeout()))
+                .returnThinking(ThinkingSupport.isEnabled())
                 .listeners(getListener())
                 .build();
     }

--- a/src/main/java/com/devoxx/genie/chatmodel/cloud/openrouter/OpenRouterChatModelFactory.java
+++ b/src/main/java/com/devoxx/genie/chatmodel/cloud/openrouter/OpenRouterChatModelFactory.java
@@ -1,6 +1,7 @@
 package com.devoxx.genie.chatmodel.cloud.openrouter;
 
 import com.devoxx.genie.chatmodel.ChatModelFactory;
+import com.devoxx.genie.chatmodel.ThinkingSupport;
 import com.devoxx.genie.model.CustomChatModel;
 import com.devoxx.genie.model.LanguageModel;
 import com.devoxx.genie.model.enumarations.ModelProvider;
@@ -40,6 +41,7 @@ public class OpenRouterChatModelFactory implements ChatModelFactory {
             .maxTokens(4_000)
             .timeout(Duration.ofSeconds(customChatModel.getTimeout()))
             .topP(customChatModel.getTopP())
+            .returnThinking(ThinkingSupport.isEnabled())
             .listeners(getListener())
             .build();
     }
@@ -54,6 +56,7 @@ public class OpenRouterChatModelFactory implements ChatModelFactory {
             .temperature(customChatModel.getTemperature())
             .topP(customChatModel.getTopP())
             .timeout(Duration.ofSeconds(customChatModel.getTimeout()))
+            .returnThinking(ThinkingSupport.isEnabled())
             .listeners(getListener())
             .build();
     }

--- a/src/main/java/com/devoxx/genie/chatmodel/local/LocalChatModelFactory.java
+++ b/src/main/java/com/devoxx/genie/chatmodel/local/LocalChatModelFactory.java
@@ -1,6 +1,7 @@
 package com.devoxx.genie.chatmodel.local;
 
 import com.devoxx.genie.chatmodel.ChatModelFactory;
+import com.devoxx.genie.chatmodel.ThinkingSupport;
 import com.devoxx.genie.model.CustomChatModel;
 import com.devoxx.genie.model.LanguageModel;
 import com.devoxx.genie.model.enumarations.ModelProvider;
@@ -70,6 +71,7 @@ public abstract class LocalChatModelFactory implements ChatModelFactory {
                 .maxTokens(customChatModel.getMaxTokens())
                 .timeout(Duration.ofSeconds(customChatModel.getTimeout()))
                 .topP(customChatModel.getTopP())
+                .returnThinking(ThinkingSupport.isEnabled())
                 .listeners(getListener())
                 .build();
     }
@@ -83,6 +85,7 @@ public abstract class LocalChatModelFactory implements ChatModelFactory {
                 .temperature(customChatModel.getTemperature())
                 .topP(customChatModel.getTopP())
                 .timeout(Duration.ofSeconds(customChatModel.getTimeout()))
+                .returnThinking(ThinkingSupport.isEnabled())
                 .listeners(getListener())
                 .build();
     }

--- a/src/main/java/com/devoxx/genie/chatmodel/local/customopenai/CustomOpenAIChatModelFactory.java
+++ b/src/main/java/com/devoxx/genie/chatmodel/local/customopenai/CustomOpenAIChatModelFactory.java
@@ -1,6 +1,7 @@
 package com.devoxx.genie.chatmodel.local.customopenai;
 
 import com.devoxx.genie.chatmodel.ChatModelFactory;
+import com.devoxx.genie.chatmodel.ThinkingSupport;
 import com.devoxx.genie.chatmodel.local.LocalLLMProviderUtil;
 import com.devoxx.genie.model.CustomChatModel;
 import com.devoxx.genie.model.LanguageModel;
@@ -62,6 +63,7 @@ public class CustomOpenAIChatModelFactory implements ChatModelFactory {
                 .maxTokens(customChatModel.getMaxTokens())
                 .timeout(Duration.ofSeconds(customChatModel.getTimeout()))
                 .topP(customChatModel.getTopP())
+                .returnThinking(ThinkingSupport.isEnabled())
                 .listeners(getListener())
                 .httpClientBuilder(getHttpClientBuilder())
                 .build();
@@ -77,6 +79,7 @@ public class CustomOpenAIChatModelFactory implements ChatModelFactory {
                 .temperature(customChatModel.getTemperature())
                 .topP(customChatModel.getTopP())
                 .timeout(Duration.ofSeconds(customChatModel.getTimeout()))
+                .returnThinking(ThinkingSupport.isEnabled())
                 .listeners(getListener())
                 .httpClientBuilder(getHttpClientBuilder())
                 .build();

--- a/src/main/java/com/devoxx/genie/chatmodel/local/llamacpp/LlamaChatModelFactory.java
+++ b/src/main/java/com/devoxx/genie/chatmodel/local/llamacpp/LlamaChatModelFactory.java
@@ -1,6 +1,7 @@
 package com.devoxx.genie.chatmodel.local.llamacpp;
 
 import com.devoxx.genie.chatmodel.ChatModelFactory;
+import com.devoxx.genie.chatmodel.ThinkingSupport;
 import com.devoxx.genie.model.CustomChatModel;
 import com.devoxx.genie.model.LanguageModel;
 import com.devoxx.genie.model.enumarations.ModelProvider;
@@ -25,6 +26,7 @@ public class LlamaChatModelFactory implements ChatModelFactory {
             .topP(customChatModel.getTopP())
             .maxRetries(customChatModel.getMaxRetries())
             .timeout(Duration.ofSeconds(customChatModel.getTimeout()))
+            .returnThinking(ThinkingSupport.isEnabled())
             .listeners(getListener())
             .build();
     }

--- a/src/main/java/com/devoxx/genie/chatmodel/local/ollama/OllamaChatModelFactory.java
+++ b/src/main/java/com/devoxx/genie/chatmodel/local/ollama/OllamaChatModelFactory.java
@@ -1,5 +1,6 @@
 package com.devoxx.genie.chatmodel.local.ollama;
 
+import com.devoxx.genie.chatmodel.ThinkingSupport;
 import com.devoxx.genie.chatmodel.local.LocalChatModelFactory;
 import com.devoxx.genie.model.CustomChatModel;
 import com.devoxx.genie.model.LanguageModel;
@@ -33,6 +34,8 @@ public class OllamaChatModelFactory extends LocalChatModelFactory {
                 .timeout(Duration.ofSeconds(customChatModel.getTimeout()))
                 .listeners(getListener());
 
+        applyThinkingSetting(builder);
+
         // Only send num_ctx when the user explicitly enabled request-time overriding.
         if (customChatModel.getContextWindowOverride() != null) {
             builder.numCtx(customChatModel.getContextWindowOverride());
@@ -50,12 +53,28 @@ public class OllamaChatModelFactory extends LocalChatModelFactory {
                 .topP(customChatModel.getTopP())
                 .timeout(Duration.ofSeconds(customChatModel.getTimeout()));
 
+        applyThinkingSetting(builder);
+
         // Only send num_ctx when the user explicitly enabled request-time overriding.
         if (customChatModel.getContextWindowOverride() != null) {
             builder.numCtx(customChatModel.getContextWindowOverride());
         }
 
         return builder.build();
+    }
+
+    // Unlike the client-side-only returnThinking flag, think(true) is sent to the Ollama API,
+    // so both are applied conditionally to keep the request unchanged when the setting is off.
+    private void applyThinkingSetting(@NotNull OllamaChatModel.OllamaChatModelBuilder builder) {
+        if (ThinkingSupport.isEnabled()) {
+            builder.think(true).returnThinking(true);
+        }
+    }
+
+    private void applyThinkingSetting(@NotNull OllamaStreamingChatModel.OllamaStreamingChatModelBuilder builder) {
+        if (ThinkingSupport.isEnabled()) {
+            builder.think(true).returnThinking(true);
+        }
     }
 
     @Override

--- a/src/main/java/com/devoxx/genie/service/prompt/response/nonstreaming/NonStreamingPromptExecutionService.java
+++ b/src/main/java/com/devoxx/genie/service/prompt/response/nonstreaming/NonStreamingPromptExecutionService.java
@@ -20,6 +20,7 @@ import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.project.Project;
 import dev.langchain4j.data.message.AiMessage;
 import dev.langchain4j.data.message.ChatMessage;
+import dev.langchain4j.data.message.UserMessage;
 import dev.langchain4j.memory.ChatMemory;
 import dev.langchain4j.model.chat.ChatModel;
 import dev.langchain4j.model.chat.response.ChatResponse;
@@ -201,11 +202,7 @@ public class NonStreamingPromptExecutionService {
             // and call chatModel directly with the multimodal UserMessage
             if (ChatMessageContextUtil.hasMultimodalContent(chatMessageContext)) {
                 log.info("Multimodal content detected — using direct chat model call (bypassing AiServices)");
-                chatMemory.add(chatMessageContext.getUserMessage());
-                List<ChatMessage> messages = chatMemory.messages();
-                ChatResponse response = chatModel.chat(messages);
-                chatMemory.add(response.aiMessage());
-                return response;
+                return executeDirectChat(chatModel, chatMemory, chatMessageContext.getUserMessage());
             }
 
             Assistant assistant = buildAssistant(chatModel, chatMemory, project);
@@ -222,23 +219,25 @@ public class NonStreamingPromptExecutionService {
                         .createMCPToolProvider(project, chatMessageContext.getMcpCallCount());
             }
 
-            if (toolProvider != null) {
-                log.debug("Tool provider created for non-streaming prompt");
-                assistant = AiServices.builder(Assistant.class)
-                        .chatModel(chatModel)
-                        .chatMemoryProvider(memoryId -> chatMemory)
-                        .systemMessageProvider(memoryId -> buildToolSystemPrompt(project))
-                        .toolProvider(toolProvider)
-                        .build();
-            }
-
             String userMessage = chatMessageContext.getUserMessage().singleText();
             String cleanText = TemplateVariableEscaper.escape(userMessage);
 
-            String queryResponse = assistant.chat(cleanText);
+            if (toolProvider == null) {
+                return executeDirectChat(chatModel, chatMemory, UserMessage.from(cleanText));
+            }
+
+            log.debug("Tool provider created for non-streaming prompt");
+            assistant = AiServices.builder(Assistant.class)
+                    .chatModel(chatModel)
+                    .chatMemoryProvider(memoryId -> chatMemory)
+                    .systemMessageProvider(memoryId -> buildToolSystemPrompt(project))
+                    .toolProvider(toolProvider)
+                    .build();
+
+            AiMessage queryResponse = assistant.chat(cleanText);
 
             return ChatResponse.builder()
-                    .aiMessage(AiMessage.aiMessage(queryResponse))
+                    .aiMessage(queryResponse)
                     .build();
 
         } catch (Exception e) {
@@ -262,6 +261,17 @@ public class NonStreamingPromptExecutionService {
         }
     }
 
+
+    private static @NotNull ChatResponse executeDirectChat(@NotNull ChatModel chatModel,
+                                                           @NotNull ChatMemory chatMemory,
+                                                           @NotNull UserMessage userMessage) {
+        chatMemory.add(userMessage);
+        List<ChatMessage> messages = chatMemory.messages();
+        ChatResponse response = chatModel.chat(messages);
+        chatMemory.add(response.aiMessage());
+        return response;
+    }
+
     private static @NotNull String buildToolSystemPrompt(@NotNull Project project) {
         return ChatMemoryManager.buildAugmentedSystemPrompt(project);
     }
@@ -277,9 +287,10 @@ public class NonStreamingPromptExecutionService {
     }
 
     /**
-     * The Code Assistant chat method
+     * The Code Assistant chat method. Returns the full {@link AiMessage} (not a plain
+     * String) so provider thinking/reasoning survives the AiServices round-trip.
      */
     interface Assistant {
-        String chat(String userMessage);
+        AiMessage chat(String userMessage);
     }
 }

--- a/src/main/java/com/devoxx/genie/service/prompt/response/streaming/StreamingResponseHandler.java
+++ b/src/main/java/com/devoxx/genie/service/prompt/response/streaming/StreamingResponseHandler.java
@@ -12,6 +12,7 @@ import com.devoxx.genie.ui.compose.model.TerminalState;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.project.Project;
 import dev.langchain4j.model.chat.response.ChatResponse;
+import dev.langchain4j.model.chat.response.PartialThinking;
 import dev.langchain4j.model.chat.response.StreamingChatResponseHandler;
 import lombok.extern.slf4j.Slf4j;
 import org.jetbrains.annotations.NotNull;
@@ -57,6 +58,7 @@ public class StreamingResponseHandler implements StreamingChatResponseHandler {
     private final java.util.concurrent.atomic.AtomicBoolean flushScheduled =
             new java.util.concurrent.atomic.AtomicBoolean(false);
     private final StringBuilder accumulatedResponse = new StringBuilder();
+    private final StringBuilder accumulatedThinking = new StringBuilder();
 
     /**
      * Creates a new streaming response handler
@@ -153,7 +155,7 @@ public class StreamingResponseHandler implements StreamingChatResponseHandler {
      * thread; only the EDT runnable touches the view, matching the pre-batching contract.
      */
     private void flushToUi() {
-        String fullText = getAccumulatedText();
+        String fullText = getVisibleAccumulatedText();
         ApplicationManager.getApplication().invokeLater(() -> {
             context.setAiMessage(dev.langchain4j.data.message.AiMessage.from(fullText));
             conversationViewController.updateAiMessageContent(context);
@@ -163,6 +165,31 @@ public class StreamingResponseHandler implements StreamingChatResponseHandler {
     private String getAccumulatedText() {
         synchronized (accumulatedResponse) {
             return accumulatedResponse.toString();
+        }
+    }
+
+    private String getAccumulatedThinking() {
+        synchronized (accumulatedThinking) {
+            return accumulatedThinking.toString();
+        }
+    }
+
+    private String getVisibleAccumulatedText() {
+        String answer = getAccumulatedText();
+        String thinking = getAccumulatedThinking();
+        if (thinking.isEmpty()) {
+            return answer;
+        }
+        return ThinkingResponseFormatter.format(thinking, answer);
+    }
+
+    @Override
+    public void onPartialThinking(PartialThinking partialThinking) {
+        if (isStopped || partialThinking == null || partialThinking.text() == null) {
+            return;
+        }
+        synchronized (accumulatedThinking) {
+            accumulatedThinking.append(partialThinking.text());
         }
     }
 
@@ -215,7 +242,7 @@ public class StreamingResponseHandler implements StreamingChatResponseHandler {
             // therefore erase all intermediate reasoning from the chat panel. Prefer the
             // accumulated text whenever we streamed partials, so the full visible turn is
             // what we render and persist.
-            String accumulatedText = getAccumulatedText();
+            String accumulatedText = getVisibleAccumulatedText();
             if (hasAddedInitialMessage && !accumulatedText.isEmpty()) {
                 context.setAiMessage(dev.langchain4j.data.message.AiMessage.from(accumulatedText));
             } else {
@@ -313,7 +340,7 @@ public class StreamingResponseHandler implements StreamingChatResponseHandler {
             // re-publishing a fresh conversation for a trailing/duplicate error callback.
             return;
         }
-        String partial = getAccumulatedText();
+        String partial = getVisibleAccumulatedText();
         if (partial.isEmpty()) {
             // Provider failed before producing any text — there is nothing worth saving.
             return;

--- a/src/main/java/com/devoxx/genie/service/prompt/response/streaming/ThinkingResponseFormatter.java
+++ b/src/main/java/com/devoxx/genie/service/prompt/response/streaming/ThinkingResponseFormatter.java
@@ -1,0 +1,64 @@
+package com.devoxx.genie.service.prompt.response.streaming;
+
+import dev.langchain4j.data.message.AiMessage;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Encodes provider thinking separately from the final answer while keeping the value
+ * transportable through the existing AiMessage.text() persistence path.
+ */
+public final class ThinkingResponseFormatter {
+
+    public static final String THINKING_START = "<!-- devoxx-genie-thinking-start -->";
+    public static final String THINKING_END = "<!-- devoxx-genie-thinking-end -->";
+
+    private ThinkingResponseFormatter() {
+    }
+
+    public static @NotNull String format(@NotNull String thinking, @NotNull String answer) {
+        if (thinking.isBlank()) {
+            return answer;
+        }
+        return THINKING_START + "\n"
+                + thinking.strip() + "\n"
+                + THINKING_END
+                + (answer.isBlank() ? "" : "\n\n" + answer);
+    }
+
+    public static @NotNull AiMessage format(@NotNull AiMessage aiMessage) {
+        String thinking = aiMessage.thinking() == null ? "" : aiMessage.thinking();
+        if (thinking.isBlank()) {
+            // Nothing to embed — keep the original message (and its attributes) intact.
+            return aiMessage;
+        }
+        String answer = aiMessage.text() == null ? "" : aiMessage.text();
+        return AiMessage.from(format(thinking, answer));
+    }
+
+    public static @NotNull String extractThinking(@NotNull String content) {
+        int start = content.indexOf(THINKING_START);
+        int end = content.indexOf(THINKING_END);
+        if (start < 0 || end < 0 || end <= start) {
+            return "";
+        }
+        int thinkingStart = start + THINKING_START.length();
+        return content.substring(thinkingStart, end).strip();
+    }
+
+    public static @NotNull String extractAnswer(@NotNull String content) {
+        int start = content.indexOf(THINKING_START);
+        int end = content.indexOf(THINKING_END);
+        if (start < 0 || end < 0 || end <= start) {
+            return content;
+        }
+        String before = content.substring(0, start).strip();
+        String after = content.substring(end + THINKING_END.length()).strip();
+        if (before.isEmpty()) {
+            return after;
+        }
+        if (after.isEmpty()) {
+            return before;
+        }
+        return before + "\n\n" + after;
+    }
+}

--- a/src/main/java/com/devoxx/genie/service/prompt/strategy/NonStreamingPromptStrategy.java
+++ b/src/main/java/com/devoxx/genie/service/prompt/strategy/NonStreamingPromptStrategy.java
@@ -4,6 +4,7 @@ import com.devoxx.genie.model.request.ChatMessageContext;
 import com.devoxx.genie.service.prompt.error.ExecutionException;
 import com.devoxx.genie.service.prompt.memory.ChatMemoryManager;
 import com.devoxx.genie.service.prompt.response.nonstreaming.NonStreamingPromptExecutionService;
+import com.devoxx.genie.service.prompt.response.streaming.ThinkingResponseFormatter;
 import com.devoxx.genie.service.prompt.result.PromptResult;
 import com.devoxx.genie.service.prompt.threading.PromptTask;
 import com.devoxx.genie.service.prompt.threading.ThreadPoolManager;
@@ -94,7 +95,7 @@ public class NonStreamingPromptStrategy extends AbstractPromptExecutionStrategy 
                 }
                 
                 log.debug("Adding AI message to prompt output panel for context {}", context.getId());
-                context.setAiMessage(response.aiMessage());
+                context.setAiMessage(ThinkingResponseFormatter.format(response.aiMessage()));
                 context.setExecutionTimeMs(System.currentTimeMillis() - startTime);
 
                 // Set token usage and cost

--- a/src/main/java/com/devoxx/genie/service/prompt/strategy/StreamingPromptStrategy.java
+++ b/src/main/java/com/devoxx/genie/service/prompt/strategy/StreamingPromptStrategy.java
@@ -181,6 +181,7 @@ public class StreamingPromptStrategy extends AbstractPromptExecutionStrategy {
 
             assistant.chat(cleanText)
                 .onPartialResponse(handler::onPartialResponse)
+                .onPartialThinking(handler::onPartialThinking)
                 .onIntermediateResponse(handler::onIntermediateResponse)
                 .onToolExecuted(this::logToolExecution)
                 .onCompleteResponse(handler::onCompleteResponse)

--- a/src/main/java/com/devoxx/genie/ui/settings/DevoxxGenieStateService.java
+++ b/src/main/java/com/devoxx/genie/ui/settings/DevoxxGenieStateService.java
@@ -272,6 +272,9 @@ public final class DevoxxGenieStateService implements PersistentStateComponent<D
     // Enable stream mode
     private Boolean streamMode = STREAM_MODE;
 
+    // Show thinking/reasoning output of reasoning models (Ollama, OpenAI-compatible providers, Mistral)
+    private Boolean showThinkingEnabled = false;
+
     // LLM settings
     private Double temperature = TEMPERATURE;
     private Double topP = TOP_P;

--- a/src/main/java/com/devoxx/genie/ui/settings/llm/LLMProvidersComponent.java
+++ b/src/main/java/com/devoxx/genie/ui/settings/llm/LLMProvidersComponent.java
@@ -105,6 +105,8 @@ public class LLMProvidersComponent extends AbstractSettingsComponent {
     @Getter
     private final JCheckBox streamModeCheckBox = new JCheckBox("", stateService.getStreamMode());
     @Getter
+    private final JCheckBox showThinkingCheckBox = new JCheckBox("", Boolean.TRUE.equals(stateService.getShowThinkingEnabled()));
+    @Getter
     private final JCheckBox ollamaEnabledCheckBox = new JCheckBox("", stateService.isOllamaEnabled());
     @Getter
     private final JCheckBox lmStudioEnabledCheckBox = new JCheckBox("", stateService.isLmStudioEnabled());
@@ -188,6 +190,8 @@ public class LLMProvidersComponent extends AbstractSettingsComponent {
 
         addSection(panel, gbc, "Large Language Model Response");
         addSettingRow(panel, gbc, "Enable Stream Mode", streamModeCheckBox);
+        addSettingRow(panel, gbc, "Show Thinking", showThinkingCheckBox);
+        addHintText(panel, gbc, "When enabled, reasoning models (Ollama, LMStudio, Jan, Llama.cpp, DeepSeek, Mistral, ...) show their thinking in a separate section before the final answer.");
 
         // Local LLM Providers section
         addSection(panel, gbc, "Local LLM Providers");

--- a/src/main/java/com/devoxx/genie/ui/settings/llm/LLMProvidersConfigurable.java
+++ b/src/main/java/com/devoxx/genie/ui/settings/llm/LLMProvidersConfigurable.java
@@ -55,6 +55,8 @@ public class LLMProvidersConfigurable implements Configurable {
         boolean isModified = false;
 
         isModified |= !stateService.getStreamMode().equals(llmSettingsComponent.getStreamModeCheckBox().isSelected());
+        isModified |= Boolean.TRUE.equals(stateService.getShowThinkingEnabled())
+                != llmSettingsComponent.getShowThinkingCheckBox().isSelected();
 
         isModified |= isFieldModified(llmSettingsComponent.getOpenAIKeyField(), stateService.getOpenAIKey());
         isModified |= isFieldModified(llmSettingsComponent.getMistralApiKeyField(), stateService.getMistralKey());
@@ -140,6 +142,7 @@ public class LLMProvidersConfigurable implements Configurable {
         DevoxxGenieStateService settings = DevoxxGenieStateService.getInstance();
 
         settings.setStreamMode(llmSettingsComponent.getStreamModeCheckBox().isSelected());
+        settings.setShowThinkingEnabled(llmSettingsComponent.getShowThinkingCheckBox().isSelected());
 
         settings.setOllamaModelUrl(llmSettingsComponent.getOllamaModelUrlField().getText());
         settings.setOllamaContextWindowOverrideEnabled(llmSettingsComponent.getOllamaContextWindowOverrideCheckBox().isSelected());
@@ -255,6 +258,7 @@ public class LLMProvidersConfigurable implements Configurable {
         DevoxxGenieStateService settings = DevoxxGenieStateService.getInstance();
 
         llmSettingsComponent.getStreamModeCheckBox().setSelected(settings.getStreamMode());
+        llmSettingsComponent.getShowThinkingCheckBox().setSelected(Boolean.TRUE.equals(settings.getShowThinkingEnabled()));
 
         llmSettingsComponent.getOllamaModelUrlField().setText(settings.getOllamaModelUrl());
         llmSettingsComponent.getOllamaContextWindowOverrideCheckBox().setSelected(Boolean.TRUE.equals(settings.getOllamaContextWindowOverrideEnabled()));

--- a/src/main/kotlin/com/devoxx/genie/ui/compose/components/AiBubble.kt
+++ b/src/main/kotlin/com/devoxx/genie/ui/compose/components/AiBubble.kt
@@ -173,6 +173,100 @@ private fun codeBlockWithCopy(isDark: Boolean): MarkdownComponent = { model ->
 }
 
 @Composable
+private fun MarkdownContent(
+    content: String,
+    textColor: Color = DevoxxGenieThemeAccessor.colors.textPrimary,
+) {
+    val colors = DevoxxGenieThemeAccessor.colors
+    val typography = DevoxxGenieThemeAccessor.typography
+    val secondaryColor = colors.textSecondary
+    val codeBg = colors.codeBackground
+    val bodySize = typography.bodyFontSize.sp
+    val codeSize = typography.codeFontSize.sp
+
+    // markdown-renderer 0.38+: text colors moved into typography TextStyles;
+    // link styling moved to MarkdownTypography.textLink.
+    val mdColors = DefaultMarkdownColors(
+        text = textColor,
+        codeBackground = codeBg,
+        inlineCodeBackground = codeBg,
+        dividerColor = secondaryColor,
+        tableBackground = Color.Transparent,
+    )
+
+    val baseStyle = TextStyle(fontSize = bodySize, color = textColor)
+    val codeStyle = TextStyle(fontSize = codeSize, fontFamily = FontFamily.Monospace, color = textColor)
+
+    val mdTypography = DefaultMarkdownTypography(
+        h1 = baseStyle.copy(fontSize = typography.bodyPlus(9f).sp, fontWeight = FontWeight.Bold),
+        h2 = baseStyle.copy(fontSize = typography.bodyPlus(7f).sp, fontWeight = FontWeight.Bold),
+        h3 = baseStyle.copy(fontSize = typography.bodyPlus(5f).sp, fontWeight = FontWeight.Bold),
+        h4 = baseStyle.copy(fontSize = typography.bodyPlus(3f).sp, fontWeight = FontWeight.SemiBold),
+        h5 = baseStyle.copy(fontSize = typography.bodyPlus(1f).sp, fontWeight = FontWeight.SemiBold),
+        h6 = baseStyle.copy(fontSize = bodySize, fontWeight = FontWeight.SemiBold),
+        text = baseStyle,
+        code = codeStyle,
+        inlineCode = codeStyle.copy(color = DevoxxBlue),
+        quote = baseStyle.copy(color = secondaryColor),
+        paragraph = baseStyle,
+        ordered = baseStyle,
+        bullet = baseStyle,
+        list = baseStyle,
+        textLink = TextLinkStyles(style = SpanStyle(color = DevoxxBlue)),
+        table = baseStyle,
+    )
+
+    SelectionContainer {
+        Markdown(
+            content = content,
+            colors = mdColors,
+            typography = mdTypography,
+            components = markdownComponents(
+                codeBlock = codeBlockWithCopy(colors.isDark),
+                codeFence = codeFenceWithCopy(colors.isDark),
+            ),
+            // Keep the previously rendered content visible while the updated markdown is
+            // re-parsed. Without this every streaming update swaps the bubble to a blank
+            // loading state first — full-text flicker.
+            retainState = true,
+        )
+    }
+}
+
+
+@Composable
+fun ThinkingBubble(
+    thinkingMarkdown: String,
+    modifier: Modifier = Modifier,
+) {
+    val colors = DevoxxGenieThemeAccessor.colors
+    val typography = DevoxxGenieThemeAccessor.typography
+    val shape = RoundedCornerShape(8.dp)
+
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(vertical = 4.dp)
+            .border(1.dp, colors.thinkingBubbleBorder, shape)
+            .background(colors.thinkingBubbleBackground, shape)
+            .padding(12.dp),
+    ) {
+        BasicText(
+            text = "🧠 Thinking",
+            style = typography.body1.copy(
+                color = colors.textPrimary,
+                fontWeight = FontWeight.Bold,
+            ),
+        )
+        Spacer(Modifier.height(8.dp))
+        MarkdownContent(
+            content = thinkingMarkdown,
+            textColor = colors.textSecondary,
+        )
+    }
+}
+
+@Composable
 fun AiBubble(
     message: MessageUiModel,
     modifier: Modifier = Modifier,
@@ -235,60 +329,7 @@ fun AiBubble(
 
         // AI Response content — rendered as Markdown
         if (message.aiResponseMarkdown.isNotBlank()) {
-            val typography = DevoxxGenieThemeAccessor.typography
-            val textColor = colors.textPrimary
-            val secondaryColor = colors.textSecondary
-            val codeBg = colors.codeBackground
-            val bodySize = typography.bodyFontSize.sp
-            val codeSize = typography.codeFontSize.sp
-
-            // markdown-renderer 0.38+: text colors moved into typography TextStyles;
-            // link styling moved to MarkdownTypography.textLink.
-            val mdColors = DefaultMarkdownColors(
-                text = textColor,
-                codeBackground = codeBg,
-                inlineCodeBackground = codeBg,
-                dividerColor = secondaryColor,
-                tableBackground = Color.Transparent,
-            )
-
-            val baseStyle = TextStyle(fontSize = bodySize, color = textColor)
-            val codeStyle = TextStyle(fontSize = codeSize, fontFamily = FontFamily.Monospace, color = textColor)
-
-            val mdTypography = DefaultMarkdownTypography(
-                h1 = baseStyle.copy(fontSize = typography.bodyPlus(9f).sp, fontWeight = FontWeight.Bold),
-                h2 = baseStyle.copy(fontSize = typography.bodyPlus(7f).sp, fontWeight = FontWeight.Bold),
-                h3 = baseStyle.copy(fontSize = typography.bodyPlus(5f).sp, fontWeight = FontWeight.Bold),
-                h4 = baseStyle.copy(fontSize = typography.bodyPlus(3f).sp, fontWeight = FontWeight.SemiBold),
-                h5 = baseStyle.copy(fontSize = typography.bodyPlus(1f).sp, fontWeight = FontWeight.SemiBold),
-                h6 = baseStyle.copy(fontSize = bodySize, fontWeight = FontWeight.SemiBold),
-                text = baseStyle,
-                code = codeStyle,
-                inlineCode = codeStyle.copy(color = DevoxxBlue),
-                quote = baseStyle.copy(color = secondaryColor),
-                paragraph = baseStyle,
-                ordered = baseStyle,
-                bullet = baseStyle,
-                list = baseStyle,
-                textLink = TextLinkStyles(style = SpanStyle(color = DevoxxBlue)),
-                table = baseStyle,
-            )
-
-            SelectionContainer {
-                Markdown(
-                    content = message.aiResponseMarkdown,
-                    colors = mdColors,
-                    typography = mdTypography,
-                    components = markdownComponents(
-                        codeBlock = codeBlockWithCopy(colors.isDark),
-                        codeFence = codeFenceWithCopy(colors.isDark),
-                    ),
-                    // Keep the previously rendered content visible while the updated
-                    // markdown is re-parsed. Without this every streaming update swaps
-                    // the bubble to a blank loading state first — full-text flicker.
-                    retainState = true,
-                )
-            }
+            MarkdownContent(content = message.aiResponseMarkdown)
 
             // In-flight affordance: once the first token replaces the ThinkingIndicator,
             // this caret is the only signal that the response is still streaming.

--- a/src/main/kotlin/com/devoxx/genie/ui/compose/components/MessagePair.kt
+++ b/src/main/kotlin/com/devoxx/genie/ui/compose/components/MessagePair.kt
@@ -35,6 +35,11 @@ fun MessagePair(
             )
         }
 
+        if (message.thinkingMarkdown.isNotBlank()) {
+            ThinkingBubble(thinkingMarkdown = message.thinkingMarkdown)
+            Spacer(Modifier.height(4.dp))
+        }
+
         // AI response bubble
         AiBubble(
             message = message,

--- a/src/main/kotlin/com/devoxx/genie/ui/compose/model/MessageUiModel.kt
+++ b/src/main/kotlin/com/devoxx/genie/ui/compose/model/MessageUiModel.kt
@@ -80,6 +80,7 @@ data class MessageUiModel(
     val id: String,
     val userPrompt: String,
     val aiResponseMarkdown: String = "",
+    val thinkingMarkdown: String = "",
     val modelName: String = "",
     val timestamp: Long = System.currentTimeMillis(),
     val executionTimeMs: Long = 0,

--- a/src/main/kotlin/com/devoxx/genie/ui/compose/theme/DevoxxGenieTheme.kt
+++ b/src/main/kotlin/com/devoxx/genie/ui/compose/theme/DevoxxGenieTheme.kt
@@ -24,6 +24,8 @@ data class DevoxxColors(
     val onSurface: Color,
     val userBubbleBackground: Color,
     val assistantBubbleBackground: Color,
+    val thinkingBubbleBackground: Color,
+    val thinkingBubbleBorder: Color,
     val textPrimary: Color,
     val textSecondary: Color,
     val codeBackground: Color,
@@ -114,6 +116,12 @@ object DevoxxGenieColors {
     fun assistantBubbleBackground(dark: Boolean): Color = if (dark) Color(0xFF1E282E) else Color(0xFFF0F7FF)
 
     @Composable
+    fun thinkingBubbleBackground(dark: Boolean): Color = if (dark) Color(0xFF25202C) else Color(0xFFF7F1FF)
+
+    @Composable
+    fun thinkingBubbleBorder(dark: Boolean): Color = if (dark) Color(0xFF7D6A9E) else Color(0xFFBCA7E8)
+
+    @Composable
     fun textPrimary(dark: Boolean): Color = if (dark) Color(0xFFE0E0E0) else Color(0xFF000000)
 
     @Composable
@@ -148,6 +156,8 @@ fun DevoxxGenieTheme(
         onSurface = DevoxxGenieColors.textPrimary(darkTheme),
         userBubbleBackground = DevoxxGenieColors.userBubbleBackground(darkTheme),
         assistantBubbleBackground = DevoxxGenieColors.assistantBubbleBackground(darkTheme),
+        thinkingBubbleBackground = DevoxxGenieColors.thinkingBubbleBackground(darkTheme),
+        thinkingBubbleBorder = DevoxxGenieColors.thinkingBubbleBorder(darkTheme),
         textPrimary = DevoxxGenieColors.textPrimary(darkTheme),
         textSecondary = DevoxxGenieColors.textSecondary(darkTheme),
         codeBackground = DevoxxGenieColors.codeBackground(darkTheme),

--- a/src/main/kotlin/com/devoxx/genie/ui/compose/viewmodel/ConversationViewModel.kt
+++ b/src/main/kotlin/com/devoxx/genie/ui/compose/viewmodel/ConversationViewModel.kt
@@ -10,6 +10,7 @@ import com.devoxx.genie.model.agent.AgentType
 import com.devoxx.genie.model.request.ChatMessageContext
 import com.devoxx.genie.service.blog.BlogFeedService
 import com.devoxx.genie.service.blog.BlogPost
+import com.devoxx.genie.service.prompt.response.streaming.ThinkingResponseFormatter
 import com.devoxx.genie.service.skill.SkillRegistry
 import com.devoxx.genie.ui.compose.model.*
 import com.devoxx.genie.ui.settings.DevoxxGenieStateService
@@ -198,7 +199,8 @@ class ConversationViewModel(
                 return@updateMessage msg
             }
             msg.copy(
-                aiResponseMarkdown = aiText,
+                aiResponseMarkdown = ThinkingResponseFormatter.extractAnswer(aiText),
+                thinkingMarkdown = ThinkingResponseFormatter.extractThinking(aiText),
                 executionTimeMs = context.executionTimeMs,
                 tokenUsage = buildTokenUsage(context) ?: msg.tokenUsage,
                 modelName = formatModelDisplayName(context.languageModel).ifEmpty { msg.modelName },
@@ -207,10 +209,12 @@ class ConversationViewModel(
     }
 
     fun addChatMessage(context: ChatMessageContext) {
+        val aiText = context.aiMessage?.text() ?: ""
         val message = MessageUiModel(
             id = context.id,
             userPrompt = context.userPrompt ?: "",
-            aiResponseMarkdown = context.aiMessage?.text() ?: "",
+            aiResponseMarkdown = ThinkingResponseFormatter.extractAnswer(aiText),
+            thinkingMarkdown = ThinkingResponseFormatter.extractThinking(aiText),
             modelName = formatModelDisplayName(context.languageModel),
             executionTimeMs = context.executionTimeMs,
             tokenUsage = buildTokenUsage(context) ?: TokenUsageInfo(),

--- a/src/test/java/com/devoxx/genie/chatmodel/cloud/deepseek/DeepSeekChatModelFactoryTest.java
+++ b/src/test/java/com/devoxx/genie/chatmodel/cloud/deepseek/DeepSeekChatModelFactoryTest.java
@@ -116,6 +116,40 @@ class DeepSeekChatModelFactoryTest {
         assertThat(result).isNotNull();
     }
 
+    private static boolean returnThinking(Object openAiModel) {
+        try {
+            java.lang.reflect.Field field = openAiModel.getClass().getDeclaredField("returnThinking");
+            field.setAccessible(true);
+            return (boolean) field.get(openAiModel);
+        } catch (ReflectiveOperationException e) {
+            throw new AssertionError("Unable to read LangChain4j OpenAI returnThinking flag", e);
+        }
+    }
+
+    @Test
+    void createChatModelEnablesThinkingWhenSettingEnabled() {
+        when(DevoxxGenieStateService.getInstance().getShowThinkingEnabled()).thenReturn(true);
+
+        DeepSeekChatModelFactory factory = new DeepSeekChatModelFactory();
+        CustomChatModel customChatModel = new CustomChatModel();
+        customChatModel.setModelName("deepseek-reasoner");
+
+        assertThat(returnThinking(factory.createChatModel(customChatModel))).isTrue();
+        assertThat(returnThinking(factory.createStreamingChatModel(customChatModel))).isTrue();
+    }
+
+    @Test
+    void createChatModelDoesNotEnableThinkingWhenSettingDisabled() {
+        when(DevoxxGenieStateService.getInstance().getShowThinkingEnabled()).thenReturn(false);
+
+        DeepSeekChatModelFactory factory = new DeepSeekChatModelFactory();
+        CustomChatModel customChatModel = new CustomChatModel();
+        customChatModel.setModelName("deepseek-reasoner");
+
+        assertThat(returnThinking(factory.createChatModel(customChatModel))).isFalse();
+        assertThat(returnThinking(factory.createStreamingChatModel(customChatModel))).isFalse();
+    }
+
     @Test
     void getModelsShouldReturnList() {
         DeepSeekChatModelFactory factory = new DeepSeekChatModelFactory();

--- a/src/test/java/com/devoxx/genie/chatmodel/cloud/mistral/MistralChatModelFactoryTest.java
+++ b/src/test/java/com/devoxx/genie/chatmodel/cloud/mistral/MistralChatModelFactoryTest.java
@@ -66,6 +66,40 @@ public class MistralChatModelFactoryTest extends AbstractLightPlatformTestCase {
     }
 
     @Test
+    void createChatModelEnablesThinkingWhenSettingEnabled() {
+        when(DevoxxGenieStateService.getInstance().getShowThinkingEnabled()).thenReturn(true);
+
+        MistralChatModelFactory factory = new MistralChatModelFactory();
+        CustomChatModel customChatModel = new CustomChatModel();
+        customChatModel.setModelName("magistral-medium-latest");
+
+        assertThat(returnThinking(factory.createChatModel(customChatModel))).isTrue();
+        assertThat(returnThinking(factory.createStreamingChatModel(customChatModel))).isTrue();
+    }
+
+    @Test
+    void createChatModelDoesNotEnableThinkingWhenSettingDisabled() {
+        when(DevoxxGenieStateService.getInstance().getShowThinkingEnabled()).thenReturn(false);
+
+        MistralChatModelFactory factory = new MistralChatModelFactory();
+        CustomChatModel customChatModel = new CustomChatModel();
+        customChatModel.setModelName("magistral-medium-latest");
+
+        assertThat(returnThinking(factory.createChatModel(customChatModel))).isFalse();
+        assertThat(returnThinking(factory.createStreamingChatModel(customChatModel))).isFalse();
+    }
+
+    private static boolean returnThinking(Object mistralModel) {
+        try {
+            java.lang.reflect.Field field = mistralModel.getClass().getDeclaredField("returnThinking");
+            field.setAccessible(true);
+            return (boolean) field.get(mistralModel);
+        } catch (ReflectiveOperationException e) {
+            throw new AssertionError("Unable to read LangChain4j Mistral returnThinking flag", e);
+        }
+    }
+
+    @Test
     public void testModelNames() {
         MistralChatModelFactory factory = new MistralChatModelFactory();
         Assertions.assertThat(factory.getModels()).isNotEmpty();

--- a/src/test/java/com/devoxx/genie/chatmodel/local/gpt4all/GPT4AllChatModelFactoryTest.java
+++ b/src/test/java/com/devoxx/genie/chatmodel/local/gpt4all/GPT4AllChatModelFactoryTest.java
@@ -69,18 +69,26 @@ public class GPT4AllChatModelFactoryTest {
 
     @Test
     public void testCreateChatModel() {
-        ChatModel model = factory.createChatModel(customChatModel);
+        try (MockedStatic<DevoxxGenieStateService> mockedSettings = mockStatic(DevoxxGenieStateService.class)) {
+            mockedSettings.when(DevoxxGenieStateService::getInstance).thenReturn(stateService);
 
-        assertNotNull(model);
-        assertTrue(model instanceof OpenAiChatModel);
+            ChatModel model = factory.createChatModel(customChatModel);
+
+            assertNotNull(model);
+            assertTrue(model instanceof OpenAiChatModel);
+        }
     }
 
     @Test
     public void testCreateStreamingChatModel() {
-        StreamingChatModel model = factory.createStreamingChatModel(customChatModel);
+        try (MockedStatic<DevoxxGenieStateService> mockedSettings = mockStatic(DevoxxGenieStateService.class)) {
+            mockedSettings.when(DevoxxGenieStateService::getInstance).thenReturn(stateService);
 
-        assertNotNull(model);
-        assertTrue(model instanceof OpenAiStreamingChatModel);
+            StreamingChatModel model = factory.createStreamingChatModel(customChatModel);
+
+            assertNotNull(model);
+            assertTrue(model instanceof OpenAiStreamingChatModel);
+        }
     }
 
     @Test

--- a/src/test/java/com/devoxx/genie/chatmodel/local/lmstudio/LMStudioChatModelFactoryTest.java
+++ b/src/test/java/com/devoxx/genie/chatmodel/local/lmstudio/LMStudioChatModelFactoryTest.java
@@ -41,6 +41,50 @@ class LMStudioChatModelFactoryTest {
         }
     }
 
+    private static boolean returnThinking(Object openAiModel) {
+        try {
+            java.lang.reflect.Field field = openAiModel.getClass().getDeclaredField("returnThinking");
+            field.setAccessible(true);
+            return (boolean) field.get(openAiModel);
+        } catch (ReflectiveOperationException e) {
+            throw new AssertionError("Unable to read LangChain4j OpenAI returnThinking flag", e);
+        }
+    }
+
+    @Test
+    void testCreateChatModelEnablesThinkingWhenSettingEnabled() {
+        try (MockedStatic<DevoxxGenieStateService> mockedSettings = Mockito.mockStatic(DevoxxGenieStateService.class)) {
+            DevoxxGenieStateService mockSettingsState = mock(DevoxxGenieStateService.class);
+            when(DevoxxGenieStateService.getInstance()).thenReturn(mockSettingsState);
+            when(mockSettingsState.getLmstudioModelUrl()).thenReturn("http://localhost:1234/v1/");
+            when(mockSettingsState.getShowThinkingEnabled()).thenReturn(true);
+
+            LMStudioChatModelFactory factory = new LMStudioChatModelFactory();
+            CustomChatModel customChatModel = new CustomChatModel();
+            customChatModel.setModelName("lmstudio");
+
+            assertThat(returnThinking(factory.createChatModel(customChatModel))).isTrue();
+            assertThat(returnThinking(factory.createStreamingChatModel(customChatModel))).isTrue();
+        }
+    }
+
+    @Test
+    void testCreateChatModelDoesNotEnableThinkingWhenSettingDisabled() {
+        try (MockedStatic<DevoxxGenieStateService> mockedSettings = Mockito.mockStatic(DevoxxGenieStateService.class)) {
+            DevoxxGenieStateService mockSettingsState = mock(DevoxxGenieStateService.class);
+            when(DevoxxGenieStateService.getInstance()).thenReturn(mockSettingsState);
+            when(mockSettingsState.getLmstudioModelUrl()).thenReturn("http://localhost:1234/v1/");
+            when(mockSettingsState.getShowThinkingEnabled()).thenReturn(false);
+
+            LMStudioChatModelFactory factory = new LMStudioChatModelFactory();
+            CustomChatModel customChatModel = new CustomChatModel();
+            customChatModel.setModelName("lmstudio");
+
+            assertThat(returnThinking(factory.createChatModel(customChatModel))).isFalse();
+            assertThat(returnThinking(factory.createStreamingChatModel(customChatModel))).isFalse();
+        }
+    }
+
     @Test
     void buildLanguageModel_usesConfiguredFallbackContextLengthWhenModelContextIsMissing() throws Exception {
         try (MockedStatic<DevoxxGenieStateService> mockedSettings = Mockito.mockStatic(DevoxxGenieStateService.class)) {

--- a/src/test/java/com/devoxx/genie/chatmodel/local/ollama/OllamaChatModelFactoryTest.java
+++ b/src/test/java/com/devoxx/genie/chatmodel/local/ollama/OllamaChatModelFactoryTest.java
@@ -8,6 +8,8 @@ import dev.langchain4j.model.ollama.OllamaChatModel;
 import dev.langchain4j.model.ollama.OllamaStreamingChatModel;
 
 import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
@@ -16,6 +18,73 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 class OllamaChatModelFactoryTest {
+
+    private static boolean returnThinking(Object ollamaModel) {
+        try {
+            Field field = ollamaModel.getClass().getSuperclass().getDeclaredField("returnThinking");
+            field.setAccessible(true);
+            return (boolean) field.get(ollamaModel);
+        } catch (ReflectiveOperationException e) {
+            throw new AssertionError("Unable to read LangChain4j Ollama returnThinking flag", e);
+        }
+    }
+
+    @Test
+    void testCreateChatModelDoesNotEnableThinkingWhenSettingDisabled() {
+        try (MockedStatic<DevoxxGenieStateService> mockedSettings = Mockito.mockStatic(DevoxxGenieStateService.class)) {
+            DevoxxGenieStateService mockSettingsState = mock(DevoxxGenieStateService.class);
+            when(DevoxxGenieStateService.getInstance()).thenReturn(mockSettingsState);
+            when(mockSettingsState.getOllamaModelUrl()).thenReturn("http://localhost:8080");
+            when(mockSettingsState.getShowThinkingEnabled()).thenReturn(false);
+
+            OllamaChatModelFactory factory = new OllamaChatModelFactory();
+            CustomChatModel customChatModel = new CustomChatModel();
+            customChatModel.setModelName("ollama");
+
+            ChatModel result = factory.createChatModel(customChatModel);
+
+            assertThat(((OllamaChatModel) result).defaultRequestParameters().think()).isNull();
+            assertThat(returnThinking(result)).isFalse();
+        }
+    }
+
+    @Test
+    void testCreateChatModelEnablesThinkingWhenSettingEnabled() {
+        try (MockedStatic<DevoxxGenieStateService> mockedSettings = Mockito.mockStatic(DevoxxGenieStateService.class)) {
+            DevoxxGenieStateService mockSettingsState = mock(DevoxxGenieStateService.class);
+            when(DevoxxGenieStateService.getInstance()).thenReturn(mockSettingsState);
+            when(mockSettingsState.getOllamaModelUrl()).thenReturn("http://localhost:8080");
+            when(mockSettingsState.getShowThinkingEnabled()).thenReturn(true);
+
+            OllamaChatModelFactory factory = new OllamaChatModelFactory();
+            CustomChatModel customChatModel = new CustomChatModel();
+            customChatModel.setModelName("ollama");
+
+            ChatModel result = factory.createChatModel(customChatModel);
+
+            assertThat(((OllamaChatModel) result).defaultRequestParameters().think()).isTrue();
+            assertThat(returnThinking(result)).isTrue();
+        }
+    }
+
+    @Test
+    void testCreateStreamingChatModelEnablesThinkingWhenSettingEnabled() {
+        try (MockedStatic<DevoxxGenieStateService> mockedSettings = Mockito.mockStatic(DevoxxGenieStateService.class)) {
+            DevoxxGenieStateService mockSettingsState = mock(DevoxxGenieStateService.class);
+            when(DevoxxGenieStateService.getInstance()).thenReturn(mockSettingsState);
+            when(mockSettingsState.getOllamaModelUrl()).thenReturn("http://localhost:8080");
+            when(mockSettingsState.getShowThinkingEnabled()).thenReturn(true);
+
+            OllamaChatModelFactory factory = new OllamaChatModelFactory();
+            CustomChatModel customChatModel = new CustomChatModel();
+            customChatModel.setModelName("ollama");
+
+            StreamingChatModel result = factory.createStreamingChatModel(customChatModel);
+
+            assertThat(((OllamaStreamingChatModel) result).defaultRequestParameters().think()).isTrue();
+            assertThat(returnThinking(result)).isTrue();
+        }
+    }
 
     @Test
     void testCreateChatModelDoesNotSendNumCtxWithoutExplicitOverride() {

--- a/src/test/java/com/devoxx/genie/service/prompt/response/nonstreaming/NonStreamingPromptExecutionServiceTest.java
+++ b/src/test/java/com/devoxx/genie/service/prompt/response/nonstreaming/NonStreamingPromptExecutionServiceTest.java
@@ -15,6 +15,8 @@ import com.intellij.openapi.application.Application;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.project.Project;
 import dev.langchain4j.data.message.UserMessage;
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.data.message.ChatMessage;
 import dev.langchain4j.memory.ChatMemory;
 import dev.langchain4j.model.chat.ChatModel;
 import dev.langchain4j.model.chat.response.ChatResponse;
@@ -29,6 +31,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 
@@ -87,11 +90,13 @@ class NonStreamingPromptExecutionServiceTest {
         fileListManagerMock.when(FileListManager::getInstance).thenReturn(mockFileListManager);
         mcpServiceMock.when(MCPService::isMCPEnabled).thenReturn(false);
         agentToolProviderMock.when(() -> AgentToolProviderFactory.createToolProvider(any())).thenReturn(null);
+        agentToolProviderMock.when(() -> AgentToolProviderFactory.createToolProvider(any(), any())).thenReturn(null);
         contextUtilMock.when(() -> ChatMessageContextUtil.hasMultimodalContent(any())).thenReturn(false);
 
         when(mockContext.getProject()).thenReturn(mockProject);
         when(mockContext.getChatModel()).thenReturn(mockChatModel);
         when(mockContext.getUserMessage()).thenReturn(UserMessage.from("test question"));
+        when(mockContext.getMemoryKey()).thenReturn("test-project-hash");
         when(mockContext.getTimeout()).thenReturn(60);
         when(mockProject.getLocationHash()).thenReturn("test-project-hash");
         when(mockChatMemoryManager.getChatMemory("test-project-hash")).thenReturn(mockChatMemory);
@@ -105,10 +110,7 @@ class NonStreamingPromptExecutionServiceTest {
         // Execute tasks synchronously
         when(mockThreadPoolManager.getPromptExecutionPool()).thenReturn(mockExecutor);
         doAnswer(invocation -> {
-            // Run inline
-            CompletableFuture.runAsync(() -> {
-                ((Runnable) invocation.getArgument(0)).run();
-            }).join();
+            ((Runnable) invocation.getArgument(0)).run();
             return null;
         }).when(mockExecutor).execute(any(Runnable.class));
 
@@ -139,6 +141,55 @@ class NonStreamingPromptExecutionServiceTest {
     @Test
     void isRunning_initiallyFalse() {
         assertThat(service.isRunning()).isFalse();
+    }
+
+
+    @Test
+    void executeQuery_withoutToolsUsesChatModelDirectlySoThinkingIsPreserved() throws Exception {
+        AiMessage aiMessage = AiMessage.builder()
+            .thinking("I should reason first.")
+            .text("The answer is 42.")
+            .build();
+        ChatResponse modelResponse = ChatResponse.builder()
+            .aiMessage(aiMessage)
+            .build();
+        when(mockChatMemory.messages()).thenReturn(List.<ChatMessage>of(UserMessage.from("test question")));
+        when(mockChatModel.chat(anyList())).thenReturn(modelResponse);
+
+        ChatResponse response = service.executeQuery(mockContext).get();
+
+        assertThat(response.aiMessage().thinking()).isEqualTo("I should reason first.");
+        assertThat(response.aiMessage().text()).isEqualTo("The answer is 42.");
+        verify(mockChatMemory).add(mockContext.getUserMessage());
+        verify(mockChatModel).chat(anyList());
+        verify(mockChatMemory).add(aiMessage);
+    }
+
+    @Test
+    void executeQuery_withToolProviderPreservesThinking() throws Exception {
+        // Agent/MCP mode routes through AiServices; the response must still carry
+        // the model's thinking so the UI can render the thinking bubble.
+        dev.langchain4j.service.tool.ToolProvider mockToolProvider =
+            mock(dev.langchain4j.service.tool.ToolProvider.class);
+        when(mockToolProvider.provideTools(any()))
+            .thenReturn(dev.langchain4j.service.tool.ToolProviderResult.builder().build());
+        agentToolProviderMock.when(() -> AgentToolProviderFactory.createToolProvider(any(), any()))
+            .thenReturn(mockToolProvider);
+        chatMemoryManagerMock.when(() -> ChatMemoryManager.buildAugmentedSystemPrompt(any()))
+            .thenReturn("You are a helpful assistant");
+
+        AiMessage aiMessage = AiMessage.builder()
+            .thinking("I should reason first.")
+            .text("The answer is 42.")
+            .build();
+        when(mockChatModel.chat(any(dev.langchain4j.model.chat.request.ChatRequest.class)))
+            .thenReturn(ChatResponse.builder().aiMessage(aiMessage).build());
+        when(mockChatMemory.messages()).thenReturn(List.<ChatMessage>of(UserMessage.from("test question")));
+
+        ChatResponse response = service.executeQuery(mockContext).get();
+
+        assertThat(response.aiMessage().thinking()).isEqualTo("I should reason first.");
+        assertThat(response.aiMessage().text()).isEqualTo("The answer is 42.");
     }
 
     @Test

--- a/src/test/java/com/devoxx/genie/service/prompt/response/streaming/StreamingResponseHandlerTest.java
+++ b/src/test/java/com/devoxx/genie/service/prompt/response/streaming/StreamingResponseHandlerTest.java
@@ -14,6 +14,7 @@ import com.intellij.util.messages.MessageBus;
 import com.intellij.util.messages.MessageBusConnection;
 import dev.langchain4j.data.message.AiMessage;
 import dev.langchain4j.model.chat.response.ChatResponse;
+import dev.langchain4j.model.chat.response.PartialThinking;
 import dev.langchain4j.model.output.TokenUsage;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -240,6 +241,30 @@ class StreamingResponseHandlerTest {
         verify(mockContext, atLeastOnce()).setAiMessage(captor.capture());
         assertThat(captor.getValue().text()).isEqualTo("Hello World");
         assertThat(onCompleteCalled.get()).isTrue();
+    }
+
+    @Test
+    void onPartialThinking_rendersThinkingBeforeAnswer() {
+        StreamingResponseHandler handler = createHandler();
+
+        handler.onPartialThinking(new PartialThinking("I should inspect this first."));
+        handler.onPartialResponse("The answer is 42.");
+
+        handler.onCompleteResponse(ChatResponse.builder()
+                .aiMessage(AiMessage.builder()
+                        .thinking("I should inspect this first.")
+                        .text("The answer is 42.")
+                        .build())
+                .build());
+
+        ArgumentCaptor<AiMessage> captor = ArgumentCaptor.forClass(AiMessage.class);
+        verify(mockContext, atLeastOnce()).setAiMessage(captor.capture());
+        assertThat(captor.getValue().text()).isEqualTo("""
+                <!-- devoxx-genie-thinking-start -->
+                I should inspect this first.
+                <!-- devoxx-genie-thinking-end -->
+
+                The answer is 42.""".stripIndent());
     }
 
     @Test

--- a/src/test/java/com/devoxx/genie/service/prompt/response/streaming/TestStreamingResponseHandler.java
+++ b/src/test/java/com/devoxx/genie/service/prompt/response/streaming/TestStreamingResponseHandler.java
@@ -26,11 +26,6 @@ public class TestStreamingResponseHandler extends StreamingResponseHandler {
         super(context, null, onCompleteCallback, onErrorCallback);
     }
 
-    @Override
-    public void onPartialResponse(String partialResponse) {
-        // Do nothing in the test implementation to avoid NullPointerException
-        // due to null viewController
-    }
 
     @Override
     public void onCompleteResponse(ChatResponse response) {

--- a/src/test/java/com/devoxx/genie/service/prompt/response/streaming/ThinkingResponseFormatterTest.java
+++ b/src/test/java/com/devoxx/genie/service/prompt/response/streaming/ThinkingResponseFormatterTest.java
@@ -1,0 +1,62 @@
+package com.devoxx.genie.service.prompt.response.streaming;
+
+import dev.langchain4j.data.message.AiMessage;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ThinkingResponseFormatterTest {
+
+    @Test
+    void format_withThinkingAndAnswer_roundTripsThroughExtractors() {
+        String content = ThinkingResponseFormatter.format("I should reason first.", "The answer is 42.");
+
+        assertThat(ThinkingResponseFormatter.extractThinking(content)).isEqualTo("I should reason first.");
+        assertThat(ThinkingResponseFormatter.extractAnswer(content)).isEqualTo("The answer is 42.");
+    }
+
+    @Test
+    void format_withBlankThinking_returnsAnswerUnchanged() {
+        assertThat(ThinkingResponseFormatter.format("  ", "The answer is 42."))
+                .isEqualTo("The answer is 42.");
+    }
+
+    @Test
+    void format_aiMessageWithThinking_embedsMarkers() {
+        AiMessage aiMessage = AiMessage.builder()
+                .thinking("I should reason first.")
+                .text("The answer is 42.")
+                .build();
+
+        AiMessage formatted = ThinkingResponseFormatter.format(aiMessage);
+
+        assertThat(ThinkingResponseFormatter.extractThinking(formatted.text())).isEqualTo("I should reason first.");
+        assertThat(ThinkingResponseFormatter.extractAnswer(formatted.text())).isEqualTo("The answer is 42.");
+    }
+
+    @Test
+    void format_aiMessageWithoutThinking_returnsSameMessage() {
+        AiMessage aiMessage = AiMessage.from("The answer is 42.");
+
+        assertThat(ThinkingResponseFormatter.format(aiMessage)).isSameAs(aiMessage);
+    }
+
+    @Test
+    void format_aiMessageWithThinkingButNullText_doesNotThrow() {
+        AiMessage aiMessage = AiMessage.builder()
+                .thinking("Only reasoning, no answer yet.")
+                .build();
+
+        AiMessage formatted = ThinkingResponseFormatter.format(aiMessage);
+
+        assertThat(ThinkingResponseFormatter.extractThinking(formatted.text()))
+                .isEqualTo("Only reasoning, no answer yet.");
+        assertThat(ThinkingResponseFormatter.extractAnswer(formatted.text())).isEmpty();
+    }
+
+    @Test
+    void extractors_withPlainContent_returnAnswerOnly() {
+        assertThat(ThinkingResponseFormatter.extractThinking("plain answer")).isEmpty();
+        assertThat(ThinkingResponseFormatter.extractAnswer("plain answer")).isEqualTo("plain answer");
+    }
+}

--- a/src/test/java/com/devoxx/genie/service/prompt/strategy/NonStreamingPromptStrategyTest.java
+++ b/src/test/java/com/devoxx/genie/service/prompt/strategy/NonStreamingPromptStrategyTest.java
@@ -221,6 +221,41 @@ class NonStreamingPromptStrategyTest {
         verify(mockPromptExecutionService).executeQuery(mockChatMessageContext);
     }
 
+
+    @Test
+    void executeStrategySpecific_rendersNonStreamingThinkingBeforeAnswer() {
+        doAnswer(invocation -> {
+            ((Runnable) invocation.getArgument(0)).run();
+            return null;
+        }).when(mockExecutor).execute(any(Runnable.class));
+
+        ChatResponse response = ChatResponse.builder()
+            .aiMessage(AiMessage.builder()
+                .thinking("I should reason first.")
+                .text("The answer is 42.")
+                .build())
+            .build();
+        when(mockPromptExecutionService.executeQuery(any()))
+            .thenReturn(CompletableFuture.completedFuture(response));
+
+        when(mockPanel.getConversationPanel()).thenReturn(null);
+
+        var mockMessageBus = mock(com.intellij.util.messages.MessageBus.class);
+        when(mockProject.getMessageBus()).thenReturn(mockMessageBus);
+        var mockPublisher = mock(ConversationEventListener.class);
+        when(mockMessageBus.syncPublisher(com.devoxx.genie.ui.topic.AppTopics.CONVERSATION_TOPIC))
+            .thenReturn(mockPublisher);
+
+        strategy.executeStrategySpecific(mockChatMessageContext, mockPanel, mockResultTask);
+
+        verify(mockChatMessageContext).setAiMessage(argThat(message -> message.text().equals("""
+                <!-- devoxx-genie-thinking-start -->
+                I should reason first.
+                <!-- devoxx-genie-thinking-end -->
+
+                The answer is 42.""".stripIndent())));
+    }
+
     @Test
     void executeStrategySpecific_withNullResponse_completesWithFailure() {
         doAnswer(invocation -> {

--- a/src/test/java/com/devoxx/genie/service/prompt/strategy/StreamingPromptStrategyTest.java
+++ b/src/test/java/com/devoxx/genie/service/prompt/strategy/StreamingPromptStrategyTest.java
@@ -6,6 +6,8 @@ import com.devoxx.genie.model.request.ChatMessageContext;
 import com.devoxx.genie.service.FileListManager;
 import com.devoxx.genie.service.MessageCreationService;
 import com.devoxx.genie.service.agent.AgentLoopTracker;
+import com.devoxx.genie.service.agent.AgentToolProviderFactory;
+import com.devoxx.genie.service.mcp.MCPExecutionService;
 import com.devoxx.genie.service.prompt.memory.ChatMemoryManager;
 import com.devoxx.genie.service.prompt.memory.ChatMemoryService;
 import com.devoxx.genie.service.prompt.result.PromptResult;
@@ -16,7 +18,13 @@ import com.devoxx.genie.ui.util.NotificationUtil;
 import com.intellij.openapi.application.Application;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.project.Project;
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.memory.chat.MessageWindowChatMemory;
 import dev.langchain4j.model.chat.StreamingChatModel;
+import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import dev.langchain4j.model.chat.response.PartialThinking;
+import dev.langchain4j.model.chat.response.StreamingChatResponseHandler;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -173,6 +181,61 @@ class StreamingPromptStrategyTest {
 
         // With early cancellation, the executor should not have started real work
         // The handler should have been stopped
+    }
+
+    @Test
+    void executeStrategySpecific_subscribesToPartialThinkingFromAiServicesTokenStream() {
+        StreamingChatModel thinkingStreamingModel = new StreamingChatModel() {
+            @Override
+            public void doChat(ChatRequest chatRequest, StreamingChatResponseHandler handler) {
+                handler.onPartialThinking(new PartialThinking("I should reason first."));
+                handler.onPartialResponse("The answer is 42.");
+                handler.onCompleteResponse(ChatResponse.builder()
+                        .aiMessage(AiMessage.builder()
+                                .thinking("I should reason first.")
+                                .text("The answer is 42.")
+                                .build())
+                        .build());
+            }
+        };
+
+        when(mockContext.getStreamingChatModel()).thenReturn(thinkingStreamingModel);
+        when(mockContext.getMemoryKey()).thenReturn("test-memory-key");
+        when(mockContext.getUserPrompt()).thenReturn("test question");
+        when(mockContext.getUserMessage()).thenReturn(
+                dev.langchain4j.data.message.UserMessage.from("test question"));
+        when(mockChatMemoryManager.getChatMemory("test-memory-key"))
+                .thenReturn(MessageWindowChatMemory.withMaxMessages(10));
+        doAnswer(invocation -> {
+            ((Runnable) invocation.getArgument(0)).run();
+            return null;
+        }).when(mockExecutor).execute(any(Runnable.class));
+        var mockMessageBus = mock(com.intellij.util.messages.MessageBus.class);
+        var mockPublisher = mock(com.devoxx.genie.ui.listener.ConversationEventListener.class);
+        when(mockProject.getMessageBus()).thenReturn(mockMessageBus);
+        when(mockMessageBus.syncPublisher(com.devoxx.genie.ui.topic.AppTopics.CONVERSATION_TOPIC))
+                .thenReturn(mockPublisher);
+
+        try (MockedStatic<AgentToolProviderFactory> agentToolProviderMock = mockStatic(AgentToolProviderFactory.class);
+             MockedStatic<MCPExecutionService> mcpExecutionServiceMock = mockStatic(MCPExecutionService.class)) {
+            MCPExecutionService mcpExecutionService = mock(MCPExecutionService.class);
+            agentToolProviderMock.when(() -> AgentToolProviderFactory.createToolProvider(any(), any()))
+                    .thenReturn(null);
+            mcpExecutionServiceMock.when(MCPExecutionService::getInstance).thenReturn(mcpExecutionService);
+            when(mcpExecutionService.createMCPToolProvider(any(), any())).thenReturn(null);
+
+            strategy.executeStrategySpecific(mockContext, mockPanel, mockResultTask);
+        }
+
+        org.mockito.ArgumentCaptor<AiMessage> captor =
+                org.mockito.ArgumentCaptor.forClass(AiMessage.class);
+        verify(mockContext, atLeastOnce()).setAiMessage(captor.capture());
+        assertThat(captor.getValue().text()).isEqualTo("""
+                <!-- devoxx-genie-thinking-start -->
+                I should reason first.
+                <!-- devoxx-genie-thinking-end -->
+
+                The answer is 42.""".stripIndent());
     }
 
     /**

--- a/src/test/java/com/devoxx/genie/ui/settings/DevoxxGenieStateServiceTest.java
+++ b/src/test/java/com/devoxx/genie/ui/settings/DevoxxGenieStateServiceTest.java
@@ -80,6 +80,7 @@ class DevoxxGenieStateServiceTest {
             assertThat(stateService.getRagActivated()).isFalse();
             assertThat(stateService.getWebSearchActivated()).isFalse();
             assertThat(stateService.getStreamMode()).isEqualTo(STREAM_MODE);
+            assertThat(stateService.getShowThinkingEnabled()).isFalse();
             assertThat(stateService.getExcludeJavaDoc()).isFalse();
             assertThat(stateService.getUseGitIgnore()).isTrue();
         }

--- a/src/test/java/com/devoxx/genie/ui/settings/llm/LLMProvidersConfigurableTest.java
+++ b/src/test/java/com/devoxx/genie/ui/settings/llm/LLMProvidersConfigurableTest.java
@@ -108,6 +108,29 @@ class LLMProvidersConfigurableTest {
         assertThat(getSettingsComponent().getOllamaContextWindowOverrideCheckBox().isSelected()).isTrue();
     }
 
+
+    @Test
+    void shouldApplyShowThinkingSetting() {
+        LLMProvidersComponent component = getSettingsComponent();
+
+        component.getShowThinkingCheckBox().setSelected(true);
+
+        assertThat(configurable.isModified()).isTrue();
+
+        configurable.apply();
+
+        assertThat(stateService.getShowThinkingEnabled()).isTrue();
+    }
+
+    @Test
+    void shouldResetShowThinkingSetting() {
+        stateService.setShowThinkingEnabled(true);
+
+        configurable.reset();
+
+        assertThat(getSettingsComponent().getShowThinkingCheckBox().isSelected()).isTrue();
+    }
+
     @Nested
     class IsAnyApiKeyEnabled {
 

--- a/src/test/kotlin/com/devoxx/genie/ui/compose/viewmodel/ConversationViewModelThinkingTest.kt
+++ b/src/test/kotlin/com/devoxx/genie/ui/compose/viewmodel/ConversationViewModelThinkingTest.kt
@@ -1,0 +1,56 @@
+package com.devoxx.genie.ui.compose.viewmodel
+
+import com.devoxx.genie.model.request.ChatMessageContext
+import com.devoxx.genie.ui.compose.model.ConversationState
+import dev.langchain4j.data.message.AiMessage
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class ConversationViewModelThinkingTest {
+
+    @Test
+    fun `update ai content splits thinking marker into dedicated model field`() {
+        val viewModel = ConversationViewModel()
+        viewModel.addUserPromptMessage(ChatMessageContext.builder().id("msg-1").userPrompt("hi").build())
+
+        viewModel.updateAiMessageContent(
+            ChatMessageContext.builder()
+                .id("msg-1")
+                .aiMessage(AiMessage.from("""
+                    <!-- devoxx-genie-thinking-start -->
+                    I should inspect this first.
+                    <!-- devoxx-genie-thinking-end -->
+
+                    The answer is 42.
+                """.trimIndent()))
+                .build()
+        )
+
+        val msg = (viewModel.state as ConversationState.Chat).messages.single()
+        assertThat(msg.thinkingMarkdown).isEqualTo("I should inspect this first.")
+        assertThat(msg.aiResponseMarkdown).isEqualTo("The answer is 42.")
+    }
+
+    @Test
+    fun `restored chat message splits thinking marker into dedicated model field`() {
+        val viewModel = ConversationViewModel()
+
+        viewModel.addChatMessage(
+            ChatMessageContext.builder()
+                .id("msg-1")
+                .userPrompt("hi")
+                .aiMessage(AiMessage.from("""
+                    <!-- devoxx-genie-thinking-start -->
+                    Think separately.
+                    <!-- devoxx-genie-thinking-end -->
+
+                    Final answer.
+                """.trimIndent()))
+                .build()
+        )
+
+        val msg = (viewModel.state as ConversationState.Chat).messages.single()
+        assertThat(msg.thinkingMarkdown).isEqualTo("Think separately.")
+        assertThat(msg.aiResponseMarkdown).isEqualTo("Final answer.")
+    }
+}


### PR DESCRIPTION
## Summary
- Adds an opt-in **"Show Thinking"** setting (default off) that renders reasoning-model thinking as a dedicated, theme-aware bubble above the answer — in both streaming and non-streaming mode (task-240).
- Fixes the non-streaming gap: the AiServices `Assistant` now returns `AiMessage` instead of `String`, since langchain4j discards `AiMessage.thinking()` for `String` return types; the no-tool path calls `ChatModel.chat(...)` directly.
- Generalizes the setting beyond Ollama: `returnThinking` is applied to all OpenAI-compatible factories (LMStudio, Jan, GPT4All, Exo, llama.cpp, CustomOpenAI, OpenAI, DeepSeek, DeepInfra, OpenRouter, Groq, Grok, GLM, Kimi, Nvidia) and Mistral. Anthropic/Gemini/Bedrock are excluded for now (extended thinking there requires a token budget → cost impact; follow-up task).

## Test plan
- [x] Full `./gradlew test` suite passes (3,326 tests)
- [x] New TDD coverage: `ThinkingResponseFormatterTest`, thinking preservation through the AiServices tool path (`NonStreamingPromptExecutionServiceTest`), factory `returnThinking` wiring (LMStudio/DeepSeek/Mistral/Ollama), settings persistence and apply/reset
- [ ] Manual `runIde` check: Ollama reasoning model with streaming ON and OFF shows the thinking bubble
- [ ] Manual check with a non-Ollama provider (e.g. LMStudio or DeepSeek reasoner)

🤖 Generated with [Claude Code](https://claude.com/claude-code)