### PR TITLE
fix: handle null-text AI responses from OpenAI-compatible providers

### DIFF
--- a/src/main/java/com/devoxx/genie/service/ChatService.java
+++ b/src/main/java/com/devoxx/genie/service/ChatService.java
@@ -100,7 +100,10 @@ public class ChatService implements ConversationEventListener {
         // Add the new messages to the conversation
         String currentTime = LocalDateTime.now().toString();
         conversation.getMessages().add(new ChatMessage(true, chatMessageContext.getUserPrompt(), currentTime));
-        conversation.getMessages().add(new ChatMessage(false, chatMessageContext.getAiMessage().text(), currentTime));
+        // Providers can return a null-text response (issue #1176) — persist empty content
+        // so a later history restore never feeds null into AiMessage.from().
+        String aiText = chatMessageContext.getAiMessage().text();
+        conversation.getMessages().add(new ChatMessage(false, aiText == null ? "" : aiText, currentTime));
 
         // Save or update the conversation
         storageService.addConversation(project, conversation);

--- a/src/main/java/com/devoxx/genie/service/prompt/response/streaming/ThinkingResponseFormatter.java
+++ b/src/main/java/com/devoxx/genie/service/prompt/response/streaming/ThinkingResponseFormatter.java
@@ -29,7 +29,9 @@ public final class ThinkingResponseFormatter {
         String thinking = aiMessage.thinking() == null ? "" : aiMessage.thinking();
         if (thinking.isBlank()) {
             // Nothing to embed — keep the original message (and its attributes) intact.
-            return aiMessage;
+            // OpenAI-compatible providers can return a final message with null content
+            // (issue #1176); normalize so downstream text() consumers never see null.
+            return aiMessage.text() == null ? aiMessage.withText("") : aiMessage;
         }
         String answer = aiMessage.text() == null ? "" : aiMessage.text();
         return AiMessage.from(format(thinking, answer));

--- a/src/main/java/com/devoxx/genie/ui/panel/conversation/ConversationHistoryManager.java
+++ b/src/main/java/com/devoxx/genie/ui/panel/conversation/ConversationHistoryManager.java
@@ -170,7 +170,7 @@ public class ConversationHistoryManager {
         if (!currentMessage.isUser()) {
             log.warn("Found unpaired AI message at position {}", messageIndex);
             context.setUserPrompt("");
-            context.setAiMessage(AiMessage.from(currentMessage.getContent()));
+            context.setAiMessage(toAiMessage(currentMessage.getContent()));
             messageRenderer.addCompleteChatMessage(context);
             return messageIndex + 1;
         }
@@ -179,13 +179,21 @@ public class ConversationHistoryManager {
 
         if (messageIndex + 1 < messages.size() && !messages.get(messageIndex + 1).isUser()) {
             ChatMessage aiMessage = messages.get(messageIndex + 1);
-            context.setAiMessage(AiMessage.from(aiMessage.getContent()));
+            context.setAiMessage(toAiMessage(aiMessage.getContent()));
             messageRenderer.addCompleteChatMessage(context);
             return messageIndex + 2;
         }
 
         messageRenderer.addUserMessageOnly(context);
         return messageIndex + 1;
+    }
+
+    /**
+     * Older conversations may have been persisted with null AI content when the provider
+     * returned a null-text response (issue #1176) — never feed null into AiMessage.from().
+     */
+    private static @NotNull AiMessage toAiMessage(String content) {
+        return AiMessage.from(content == null ? "" : content);
     }
 
     /**

--- a/src/test/java/com/devoxx/genie/service/ChatServiceTest.java
+++ b/src/test/java/com/devoxx/genie/service/ChatServiceTest.java
@@ -120,6 +120,33 @@ class ChatServiceTest {
     }
 
     @Test
+    void testOnNewConversation_NullAiText_PersistsEmptyContent() {
+        // Issue #1176: providers can produce a null-text AiMessage; persisting null
+        // content would crash a later history restore with "text cannot be null".
+        when(languageModel.getModelName()).thenReturn("gpt-4");
+        when(languageModel.isApiKeyUsed()).thenReturn(true);
+        when(languageModel.getProvider()).thenReturn(ModelProvider.OpenAI);
+        when(aiMessage.text()).thenReturn(null);
+
+        ChatMessageContext context = ChatMessageContext.builder()
+                .project(project)
+                .userPrompt("Edit this file")
+                .languageModel(languageModel)
+                .aiMessage(aiMessage)
+                .executionTimeMs(150)
+                .build();
+
+        chatService.onNewConversation(context);
+
+        ArgumentCaptor<Conversation> conversationCaptor = ArgumentCaptor.forClass(Conversation.class);
+        verify(storageService).addConversation(eq(project), conversationCaptor.capture());
+
+        Conversation savedConversation = conversationCaptor.getValue();
+        assertThat(savedConversation.getMessages()).hasSize(2);
+        assertThat(savedConversation.getMessages().get(1).getContent()).isEmpty();
+    }
+
+    @Test
     void testOnNewConversation_AppendsToExistingConversation() {
         chatService.setConversationManager(conversationManager);
 

--- a/src/test/java/com/devoxx/genie/service/prompt/response/streaming/ThinkingResponseFormatterTest.java
+++ b/src/test/java/com/devoxx/genie/service/prompt/response/streaming/ThinkingResponseFormatterTest.java
@@ -55,6 +55,17 @@ class ThinkingResponseFormatterTest {
     }
 
     @Test
+    void format_aiMessageWithNullTextAndNoThinking_normalizesTextToEmpty() {
+        // Issue #1176: OpenAI-compatible providers can return a final assistant message
+        // with null content (e.g. reasoning models or empty replies after tool calls).
+        AiMessage aiMessage = AiMessage.builder().build();
+
+        AiMessage formatted = ThinkingResponseFormatter.format(aiMessage);
+
+        assertThat(formatted.text()).isEmpty();
+    }
+
+    @Test
     void extractors_withPlainContent_returnAnswerOnly() {
         assertThat(ThinkingResponseFormatter.extractThinking("plain answer")).isEmpty();
         assertThat(ThinkingResponseFormatter.extractAnswer("plain answer")).isEqualTo("plain answer");

--- a/src/test/java/com/devoxx/genie/ui/panel/conversation/ConversationHistoryManagerTest.java
+++ b/src/test/java/com/devoxx/genie/ui/panel/conversation/ConversationHistoryManagerTest.java
@@ -160,6 +160,27 @@ class ConversationHistoryManagerTest {
     }
 
     @Test
+    void testRestoreConversation_NullAiMessageContent_RestoresWithEmptyText() {
+        // Issue #1176: conversations persisted while the provider returned a null-text
+        // response must not crash history restore with "text cannot be null".
+        Conversation conversation = createConversation("conv-null", "OpenAI", "gpt-4");
+        conversation.setExecutionTimeMs(500);
+
+        List<ChatMessage> messages = new ArrayList<>();
+        messages.add(createChatMessage(true, "Edit this file"));
+        messages.add(createChatMessage(false, null));
+        conversation.setMessages(messages);
+
+        when(messageRenderer.isInitialized()).thenReturn(true);
+
+        manager.restoreConversation(conversation);
+
+        ArgumentCaptor<ChatMessageContext> captor = ArgumentCaptor.forClass(ChatMessageContext.class);
+        verify(messageRenderer).addCompleteChatMessage(captor.capture());
+        assertThat(captor.getValue().getAiMessage().text()).isEmpty();
+    }
+
+    @Test
     void testRestoreConversation_ContextHasStableMessageIds() {
         Conversation conversation = createConversation("conv-7", "OpenAI", "gpt-4");
         conversation.setExecutionTimeMs(1000);


### PR DESCRIPTION
## Summary
- Fixes #1176 — "Provider unavailable: text cannot be null" when an OpenAI-compatible model returns a final assistant message with null content (e.g. reasoning models, or empty replies after tool-call file edits).
- The exact 1.8.9 crash site was already removed by the Show Thinking refactor (f2ec98e9), but the null text still flowed through unguarded: responses were silently dropped in the Compose UI, null content was persisted to conversation history, and reopening such a conversation crashed with the same `IllegalArgumentException` in `ConversationHistoryManager`.
- Guards added at all three points: `ThinkingResponseFormatter` normalizes null text to empty (preserving thinking/attributes via `withText`), `ChatService` persists empty content instead of null, and `ConversationHistoryManager` restores null content safely — covering conversations already stored with null content by earlier builds.

## Test plan
- [x] Reproducing tests written first (TDD): history restore test failed with the exact `IllegalArgumentException: text cannot be null` from the issue's stack trace before the fix
- [x] New tests: `ThinkingResponseFormatterTest.format_aiMessageWithNullTextAndNoThinking_normalizesTextToEmpty`, `ConversationHistoryManagerTest.testRestoreConversation_NullAiMessageContent_RestoresWithEmptyText`, `ChatServiceTest.testOnNewConversation_NullAiText_PersistsEmptyContent`
- [x] Full `./gradlew test` suite green

🤖 Generated with [Claude Code](https://claude.com/claude-code)