### PR TITLE
feat: configurable context window and cost for Custom OpenAI provider

### DIFF
--- a/src/main/java/com/devoxx/genie/chatmodel/local/customopenai/CustomOpenAIChatModelFactory.java
+++ b/src/main/java/com/devoxx/genie/chatmodel/local/customopenai/CustomOpenAIChatModelFactory.java
@@ -170,8 +170,9 @@ public class CustomOpenAIChatModelFactory implements ChatModelFactory {
                             .provider(ModelProvider.CustomOpenAI)
                             .modelName(model.getId())
                             .displayName(model.getId())
-                            .inputCost(0)
-                            .outputCost(0)
+                            .inputCost(CustomOpenAICost.resolve(state.getCustomOpenAIInputCost()))
+                            .outputCost(CustomOpenAICost.resolve(state.getCustomOpenAIOutputCost()))
+                            .inputMaxTokens(CustomOpenAIContextWindow.resolve(state.getCustomOpenAIContextWindow()))
                             .apiKeyUsed(state.isCustomOpenAIApiKeyEnabled())
                             .build())
                     .collect(Collectors.toList());

--- a/src/main/java/com/devoxx/genie/chatmodel/local/customopenai/CustomOpenAIContextWindow.java
+++ b/src/main/java/com/devoxx/genie/chatmodel/local/customopenai/CustomOpenAIContextWindow.java
@@ -1,0 +1,27 @@
+package com.devoxx.genie.chatmodel.local.customopenai;
+
+/**
+ * Resolves the context window (input max tokens) to use for the Custom OpenAI-compatible provider.
+ *
+ * <p>Custom / internal OpenAI-compatible servers do not expose their context length via the
+ * {@code /models} endpoint, so DevoxxGenie previously assumed a hardcoded {@value #DEFAULT_CONTEXT_WINDOW}
+ * token window. That drove the token-usage bar red as soon as a modest amount of project context was
+ * added, even when the backing model actually supported a far larger window. Users can now override the
+ * value in Settings; when nothing is configured we fall back to the historical default.</p>
+ */
+public final class CustomOpenAIContextWindow {
+
+    /** Historical default used when the user has not configured a context window. */
+    public static final int DEFAULT_CONTEXT_WINDOW = 4096;
+
+    private CustomOpenAIContextWindow() {
+    }
+
+    /**
+     * @param configured the user-configured context window, or {@code null} when unset
+     * @return the configured value when it is a positive number, otherwise {@link #DEFAULT_CONTEXT_WINDOW}
+     */
+    public static int resolve(Integer configured) {
+        return (configured != null && configured > 0) ? configured : DEFAULT_CONTEXT_WINDOW;
+    }
+}

--- a/src/main/java/com/devoxx/genie/chatmodel/local/customopenai/CustomOpenAICost.java
+++ b/src/main/java/com/devoxx/genie/chatmodel/local/customopenai/CustomOpenAICost.java
@@ -1,0 +1,27 @@
+package com.devoxx.genie.chatmodel.local.customopenai;
+
+/**
+ * Resolves the input/output cost (dollars per 1,000,000 tokens) to use for the Custom OpenAI-compatible
+ * provider.
+ *
+ * <p>Custom / internal OpenAI-compatible servers do not report pricing, so DevoxxGenie previously assumed
+ * a cost of {@code 0}, which hid the cost figure in the conversation bubbles. Users can now configure the
+ * per-1M-token input and output cost in Settings; when nothing (or a negative value) is configured we fall
+ * back to {@code 0} (free / cost hidden), matching the historical behaviour.</p>
+ *
+ * <p>The unit convention (dollars per 1M tokens) mirrors {@code LanguageModel.inputCost/outputCost} as used
+ * in {@code ChatMessageContext.setTokenUsageAndCost}, which divides {@code tokens * cost} by 1,000,000.</p>
+ */
+public final class CustomOpenAICost {
+
+    private CustomOpenAICost() {
+    }
+
+    /**
+     * @param configured the user-configured cost per 1M tokens, or {@code null} when unset
+     * @return the configured value when it is a non-negative number, otherwise {@code 0.0}
+     */
+    public static double resolve(Double configured) {
+        return (configured != null && configured > 0) ? configured : 0.0;
+    }
+}

--- a/src/main/java/com/devoxx/genie/controller/ActionButtonsPanelController.java
+++ b/src/main/java/com/devoxx/genie/controller/ActionButtonsPanelController.java
@@ -1,6 +1,8 @@
 package com.devoxx.genie.controller;
 
 import com.devoxx.genie.chatmodel.ChatModelProvider;
+import com.devoxx.genie.chatmodel.local.customopenai.CustomOpenAIContextWindow;
+import com.devoxx.genie.chatmodel.local.customopenai.CustomOpenAICost;
 import com.devoxx.genie.controller.listener.PromptExecutionListener;
 import com.devoxx.genie.model.ChatContextParameters;
 import com.devoxx.genie.model.LanguageModel;
@@ -217,9 +219,9 @@ public class ActionButtonsPanelController implements PromptExecutionListener {
                 .provider(provider)
                 .apiKeyUsed(true)
                 .modelName(!customModelName.isBlank() ? customModelName : "na")
-                .inputCost(0)
-                .outputCost(0)
-                .inputMaxTokens(4096)
+                .inputCost(CustomOpenAICost.resolve(stateService.getCustomOpenAIInputCost()))
+                .outputCost(CustomOpenAICost.resolve(stateService.getCustomOpenAIOutputCost()))
+                .inputMaxTokens(CustomOpenAIContextWindow.resolve(stateService.getCustomOpenAIContextWindow()))
                 .build();
     }
 

--- a/src/main/java/com/devoxx/genie/service/DevoxxGenieSettingsService.java
+++ b/src/main/java/com/devoxx/genie/service/DevoxxGenieSettingsService.java
@@ -240,4 +240,16 @@ public interface DevoxxGenieSettingsService {
     void setCustomOpenAIModelName(String text);
 
     String getCustomOpenAIModelName();
+
+    void setCustomOpenAIContextWindow(Integer contextWindow);
+
+    Integer getCustomOpenAIContextWindow();
+
+    void setCustomOpenAIInputCost(Double inputCost);
+
+    Double getCustomOpenAIInputCost();
+
+    void setCustomOpenAIOutputCost(Double outputCost);
+
+    Double getCustomOpenAIOutputCost();
 }

--- a/src/main/java/com/devoxx/genie/ui/settings/DevoxxGenieStateService.java
+++ b/src/main/java/com/devoxx/genie/ui/settings/DevoxxGenieStateService.java
@@ -126,6 +126,11 @@ public final class DevoxxGenieStateService implements PersistentStateComponent<D
     // Local custom OpenAI-compliant LLM fields
     private String customOpenAIUrl = "";
     private String customOpenAIModelName = "";
+    // Null means "use the default context window"; a positive value overrides it for token calc / usage bar.
+    private Integer customOpenAIContextWindow;
+    // Cost in dollars per 1,000,000 tokens; null/0 means "no cost" (cost figure hidden in the bubble).
+    private Double customOpenAIInputCost;
+    private Double customOpenAIOutputCost;
     @Getter(AccessLevel.NONE) @Setter(AccessLevel.NONE) @OptionTag("customOpenAIApiKey")
     private String customOpenAIApiKey = "";
 

--- a/src/main/java/com/devoxx/genie/ui/settings/llm/LLMProvidersComponent.java
+++ b/src/main/java/com/devoxx/genie/ui/settings/llm/LLMProvidersComponent.java
@@ -1,5 +1,6 @@
 package com.devoxx.genie.ui.settings.llm;
 
+import com.devoxx.genie.chatmodel.local.customopenai.CustomOpenAIContextWindow;
 import com.devoxx.genie.model.enumarations.AwsBedrockAuthMode;
 import com.devoxx.genie.service.PropertiesService;
 import com.devoxx.genie.ui.settings.AbstractSettingsComponent;
@@ -62,6 +63,28 @@ public class LLMProvidersComponent extends AbstractSettingsComponent {
     private final JTextField customOpenAIModelNameField = new JTextField(stateService.getCustomOpenAIModelName());
     @Getter
     private final JPasswordField customOpenAIApiKeyField = new JPasswordField(stateService.getCustomOpenAIApiKey());
+    @Getter
+    private final JCheckBox customOpenAIContextWindowEnabledCheckBox = new JCheckBox("", stateService.getCustomOpenAIContextWindow() != null);
+    @Getter
+    private final JBIntSpinner customOpenAIContextWindowField = new JBIntSpinner(
+            new UINumericRange(
+                    stateService.getCustomOpenAIContextWindow() != null
+                            ? stateService.getCustomOpenAIContextWindow()
+                            : CustomOpenAIContextWindow.DEFAULT_CONTEXT_WINDOW,
+                    1,
+                    2_000_000
+            )
+    );
+    @Getter
+    private final JSpinner customOpenAIInputCostField = new JSpinner(
+            new SpinnerNumberModel(
+                    stateService.getCustomOpenAIInputCost() != null ? stateService.getCustomOpenAIInputCost() : 0.0d,
+                    0.0d, 1_000_000.0d, 0.01d));
+    @Getter
+    private final JSpinner customOpenAIOutputCostField = new JSpinner(
+            new SpinnerNumberModel(
+                    stateService.getCustomOpenAIOutputCost() != null ? stateService.getCustomOpenAIOutputCost() : 0.0d,
+                    0.0d, 1_000_000.0d, 0.01d));
     @Getter
     private final JPasswordField openAIKeyField = new JPasswordField(stateService.getOpenAIKey());
     @Getter
@@ -220,6 +243,11 @@ public class LLMProvidersComponent extends AbstractSettingsComponent {
         addProviderSettingRow(panel, gbc, "Custom OpenAI API Key", enableCustomOpenAIApiKeyCheckBox, customOpenAIApiKeyField);
         addProviderSettingRow(panel, gbc, "Custom OpenAI HTTP 1.1", customOpenAIForceHttp11CheckBox);
         addHintText(panel, gbc, "Use HTTP/2 when unchecked");
+        addProviderSettingRow(panel, gbc, "Custom OpenAI Context Window", customOpenAIContextWindowEnabledCheckBox, customOpenAIContextWindowField);
+        addHintText(panel, gbc, "Token window used for the usage bar and token calculation. When unchecked, DevoxxGenie assumes " + CustomOpenAIContextWindow.DEFAULT_CONTEXT_WINDOW + " tokens. Set this to your internal model's real context size to avoid a false red 'context exceeded' warning (the request is sent either way).");
+        addSettingRow(panel, gbc, "Custom OpenAI Input Cost", customOpenAIInputCostField);
+        addSettingRow(panel, gbc, "Custom OpenAI Output Cost", customOpenAIOutputCostField);
+        addHintText(panel, gbc, "Cost in US dollars per 1,000,000 tokens (e.g. 3 for $3/1M input, 15 for $15/1M output). Leave at 0 to hide the cost. When set, the estimated cost is shown in each AI response bubble.");
         // Cloud LLM Providers section
         addSection(panel, gbc, "Cloud LLM Providers");
         addProviderSettingRow(panel, gbc, "OpenAI API Key", openAIEnabledCheckBox,
@@ -290,6 +318,7 @@ public class LLMProvidersComponent extends AbstractSettingsComponent {
         customOpenAIUrlEnabledCheckBox.addItemListener(e -> updateUrlFieldState(customOpenAIUrlEnabledCheckBox, customOpenAIUrlField));
         customOpenAIModelNameEnabledCheckBox.addItemListener(e -> updateUrlFieldState(customOpenAIModelNameEnabledCheckBox, customOpenAIModelNameField));
         enableCustomOpenAIApiKeyCheckBox.addItemListener(e -> updateUrlFieldState(enableCustomOpenAIApiKeyCheckBox, customOpenAIApiKeyField));
+        customOpenAIContextWindowEnabledCheckBox.addItemListener(e -> updateUrlFieldState(customOpenAIContextWindowEnabledCheckBox, customOpenAIContextWindowField));
 
         openAIEnabledCheckBox.addItemListener(e -> updateUrlFieldState(openAIEnabledCheckBox, openAIKeyField));
         mistralEnabledCheckBox.addItemListener(e -> updateUrlFieldState(mistralEnabledCheckBox, mistralApiKeyField));

--- a/src/main/java/com/devoxx/genie/ui/settings/llm/LLMProvidersConfigurable.java
+++ b/src/main/java/com/devoxx/genie/ui/settings/llm/LLMProvidersConfigurable.java
@@ -5,6 +5,7 @@ import com.devoxx.genie.ui.topic.AppTopics;
 import com.intellij.openapi.options.Configurable;
 import com.intellij.openapi.project.Project;
 import org.jetbrains.annotations.Nls;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import javax.swing.*;
@@ -88,6 +89,13 @@ public class LLMProvidersConfigurable implements Configurable {
         isModified |= isFieldModified(llmSettingsComponent.getCustomOpenAIUrlField(), stateService.getCustomOpenAIUrl());
         isModified |= isFieldModified(llmSettingsComponent.getCustomOpenAIModelNameField(), stateService.getCustomOpenAIModelName());
         isModified |= isFieldModified(llmSettingsComponent.getCustomOpenAIApiKeyField(), stateService.getCustomOpenAIApiKey());
+        isModified |= (stateService.getCustomOpenAIContextWindow() != null) != llmSettingsComponent.getCustomOpenAIContextWindowEnabledCheckBox().isSelected();
+        if (llmSettingsComponent.getCustomOpenAIContextWindowEnabledCheckBox().isSelected()) {
+            Integer savedContextWindow = stateService.getCustomOpenAIContextWindow();
+            isModified |= savedContextWindow == null || !savedContextWindow.equals(llmSettingsComponent.getCustomOpenAIContextWindowField().getNumber());
+        }
+        isModified |= costFieldModified(stateService.getCustomOpenAIInputCost(), llmSettingsComponent.getCustomOpenAIInputCostField());
+        isModified |= costFieldModified(stateService.getCustomOpenAIOutputCost(), llmSettingsComponent.getCustomOpenAIOutputCostField());
 
         isModified |= !stateService.getShowAzureOpenAIFields().equals(llmSettingsComponent.getEnableAzureOpenAICheckBox().isSelected());
         isModified |= isFieldModified(llmSettingsComponent.getAzureOpenAIEndpointField(), stateService.getAzureOpenAIEndpoint());
@@ -161,6 +169,13 @@ public class LLMProvidersConfigurable implements Configurable {
         settings.setCustomOpenAIApiKey(new String(llmSettingsComponent.getCustomOpenAIApiKeyField().getPassword()));
         settings.setCustomOpenAIApiKeyEnabled(llmSettingsComponent.getEnableCustomOpenAIApiKeyCheckBox().isSelected());
         settings.setCustomOpenAIForceHttp11(llmSettingsComponent.getCustomOpenAIForceHttp11CheckBox().isSelected());
+        settings.setCustomOpenAIContextWindow(
+                llmSettingsComponent.getCustomOpenAIContextWindowEnabledCheckBox().isSelected()
+                        ? llmSettingsComponent.getCustomOpenAIContextWindowField().getNumber()
+                        : null
+        );
+        settings.setCustomOpenAIInputCost(costFieldValue(llmSettingsComponent.getCustomOpenAIInputCostField()));
+        settings.setCustomOpenAIOutputCost(costFieldValue(llmSettingsComponent.getCustomOpenAIOutputCostField()));
 
         settings.setOpenAIKey(new String(llmSettingsComponent.getOpenAIKeyField().getPassword()));
         settings.setMistralKey(new String(llmSettingsComponent.getMistralApiKeyField().getPassword()));
@@ -222,6 +237,28 @@ public class LLMProvidersConfigurable implements Configurable {
         }
     }
 
+    /**
+     * A cost spinner is "modified" when its value differs from the stored setting, treating a null
+     * stored value as 0 (the "no cost" / hidden state).
+     */
+    private static boolean costFieldModified(Double storedCost, @NotNull JSpinner field) {
+        double stored = storedCost != null ? storedCost : 0.0d;
+        return Double.compare(stored, spinnerDouble(field)) != 0;
+    }
+
+    /**
+     * Reads a cost spinner value, normalising 0 (or below) to {@code null} so an unset cost is not
+     * persisted as an explicit 0 — keeping the "no cost configured" semantics.
+     */
+    private static Double costFieldValue(@NotNull JSpinner field) {
+        double value = spinnerDouble(field);
+        return value > 0 ? value : null;
+    }
+
+    private static double spinnerDouble(@NotNull JSpinner field) {
+        return ((Number) field.getValue()).doubleValue();
+    }
+
     private boolean isAnyApiKeyEnabled(DevoxxGenieStateService settings) {
         return hasEnabledMainCloudKey(settings) || hasEnabledAuxCloudKey(settings) || hasEnabledAwsOrAzureKey(settings);
     }
@@ -275,6 +312,15 @@ public class LLMProvidersConfigurable implements Configurable {
         llmSettingsComponent.getCustomOpenAIUrlField().setText(settings.getCustomOpenAIUrl());
         llmSettingsComponent.getCustomOpenAIModelNameField().setText(settings.getCustomOpenAIModelName());
         llmSettingsComponent.getCustomOpenAIApiKeyField().setText(settings.getCustomOpenAIApiKey());
+        llmSettingsComponent.getCustomOpenAIContextWindowEnabledCheckBox().setSelected(settings.getCustomOpenAIContextWindow() != null);
+        llmSettingsComponent.getCustomOpenAIContextWindowField().setNumber(
+                settings.getCustomOpenAIContextWindow() != null
+                        ? settings.getCustomOpenAIContextWindow()
+                        : com.devoxx.genie.chatmodel.local.customopenai.CustomOpenAIContextWindow.DEFAULT_CONTEXT_WINDOW
+        );
+        llmSettingsComponent.getCustomOpenAIContextWindowField().setEnabled(settings.getCustomOpenAIContextWindow() != null);
+        llmSettingsComponent.getCustomOpenAIInputCostField().setValue(settings.getCustomOpenAIInputCost() != null ? settings.getCustomOpenAIInputCost() : 0.0d);
+        llmSettingsComponent.getCustomOpenAIOutputCostField().setValue(settings.getCustomOpenAIOutputCost() != null ? settings.getCustomOpenAIOutputCost() : 0.0d);
 
         llmSettingsComponent.getOpenAIKeyField().setText(settings.getOpenAIKey());
         llmSettingsComponent.getMistralApiKeyField().setText(settings.getMistralKey());

--- a/src/test/java/com/devoxx/genie/chatmodel/local/customopenai/CustomOpenAIContextWindowTest.java
+++ b/src/test/java/com/devoxx/genie/chatmodel/local/customopenai/CustomOpenAIContextWindowTest.java
@@ -1,0 +1,28 @@
+package com.devoxx.genie.chatmodel.local.customopenai;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CustomOpenAIContextWindowTest {
+
+    @Test
+    void resolve_returnsDefault_whenNull() {
+        assertThat(CustomOpenAIContextWindow.resolve(null))
+                .isEqualTo(CustomOpenAIContextWindow.DEFAULT_CONTEXT_WINDOW);
+    }
+
+    @Test
+    void resolve_returnsDefault_whenZeroOrNegative() {
+        assertThat(CustomOpenAIContextWindow.resolve(0))
+                .isEqualTo(CustomOpenAIContextWindow.DEFAULT_CONTEXT_WINDOW);
+        assertThat(CustomOpenAIContextWindow.resolve(-1))
+                .isEqualTo(CustomOpenAIContextWindow.DEFAULT_CONTEXT_WINDOW);
+    }
+
+    @Test
+    void resolve_returnsConfiguredValue_whenPositive() {
+        assertThat(CustomOpenAIContextWindow.resolve(32_000)).isEqualTo(32_000);
+        assertThat(CustomOpenAIContextWindow.resolve(1)).isEqualTo(1);
+    }
+}

--- a/src/test/java/com/devoxx/genie/chatmodel/local/customopenai/CustomOpenAICostCalculationTest.java
+++ b/src/test/java/com/devoxx/genie/chatmodel/local/customopenai/CustomOpenAICostCalculationTest.java
@@ -1,0 +1,57 @@
+package com.devoxx.genie.chatmodel.local.customopenai;
+
+import com.devoxx.genie.model.LanguageModel;
+import com.devoxx.genie.model.enumarations.ModelProvider;
+import com.devoxx.genie.model.request.ChatMessageContext;
+import dev.langchain4j.model.output.TokenUsage;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * End-to-end check that a Custom OpenAI model carrying user-configured input/output costs produces a
+ * non-zero cost on the {@link ChatMessageContext} — the value the conversation bubble renders when
+ * {@code cost > 0}. Guards the wiring in {@code CustomOpenAIChatModelFactory} /
+ * {@code ActionButtonsPanelController} that populates {@code inputCost}/{@code outputCost}.
+ */
+class CustomOpenAICostCalculationTest {
+
+    @Test
+    void configuredCosts_produceNonZeroBubbleCost() {
+        // Cost values as they would be built from the settings (dollars per 1M tokens).
+        LanguageModel model = LanguageModel.builder()
+                .provider(ModelProvider.CustomOpenAI)
+                .modelName("internal-model")
+                .inputCost(CustomOpenAICost.resolve(3.0))    // $3 / 1M input
+                .outputCost(CustomOpenAICost.resolve(15.0))  // $15 / 1M output
+                .inputMaxTokens(CustomOpenAIContextWindow.resolve(32_000))
+                .build();
+
+        ChatMessageContext context = ChatMessageContext.builder()
+                .languageModel(model)
+                .build();
+
+        context.setTokenUsageAndCost(new TokenUsage(1_000_000, 500_000));
+
+        // 1_000_000 * 3 / 1e6 + 500_000 * 15 / 1e6 = 3 + 7.5 = 10.5
+        assertThat(context.getCost()).isEqualTo(10.5);
+    }
+
+    @Test
+    void unconfiguredCosts_leaveCostZero() {
+        LanguageModel model = LanguageModel.builder()
+                .provider(ModelProvider.CustomOpenAI)
+                .modelName("internal-model")
+                .inputCost(CustomOpenAICost.resolve(null))
+                .outputCost(CustomOpenAICost.resolve(null))
+                .build();
+
+        ChatMessageContext context = ChatMessageContext.builder()
+                .languageModel(model)
+                .build();
+
+        context.setTokenUsageAndCost(new TokenUsage(1_000_000, 500_000));
+
+        assertThat(context.getCost()).isZero();
+    }
+}

--- a/src/test/java/com/devoxx/genie/chatmodel/local/customopenai/CustomOpenAICostTest.java
+++ b/src/test/java/com/devoxx/genie/chatmodel/local/customopenai/CustomOpenAICostTest.java
@@ -1,0 +1,24 @@
+package com.devoxx.genie.chatmodel.local.customopenai;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CustomOpenAICostTest {
+
+    @Test
+    void resolve_returnsZero_whenNull() {
+        assertThat(CustomOpenAICost.resolve(null)).isZero();
+    }
+
+    @Test
+    void resolve_returnsZero_whenNegative() {
+        assertThat(CustomOpenAICost.resolve(-1.0)).isZero();
+    }
+
+    @Test
+    void resolve_returnsConfiguredValue_whenPositive() {
+        assertThat(CustomOpenAICost.resolve(3.0)).isEqualTo(3.0);
+        assertThat(CustomOpenAICost.resolve(0.15)).isEqualTo(0.15);
+    }
+}

--- a/src/test/java/com/devoxx/genie/ui/settings/llm/LLMProvidersConfigurableTest.java
+++ b/src/test/java/com/devoxx/genie/ui/settings/llm/LLMProvidersConfigurableTest.java
@@ -110,6 +110,80 @@ class LLMProvidersConfigurableTest {
 
 
     @Test
+    void shouldApplyCustomOpenAIContextWindowSetting() {
+        LLMProvidersComponent component = getSettingsComponent();
+
+        component.getCustomOpenAIContextWindowEnabledCheckBox().setSelected(true);
+        component.getCustomOpenAIContextWindowField().setNumber(32_000);
+
+        assertThat(configurable.isModified()).isTrue();
+
+        configurable.apply();
+
+        assertThat(stateService.getCustomOpenAIContextWindow()).isEqualTo(32_000);
+    }
+
+    @Test
+    void shouldClearCustomOpenAIContextWindowWhenDisabled() {
+        stateService.setCustomOpenAIContextWindow(32_000);
+        LLMProvidersComponent component = getSettingsComponent();
+        component.getCustomOpenAIContextWindowEnabledCheckBox().setSelected(false);
+
+        configurable.apply();
+
+        assertThat(stateService.getCustomOpenAIContextWindow()).isNull();
+    }
+
+    @Test
+    void shouldResetCustomOpenAIContextWindowSetting() {
+        stateService.setCustomOpenAIContextWindow(64_000);
+
+        configurable.reset();
+
+        LLMProvidersComponent component = getSettingsComponent();
+        assertThat(component.getCustomOpenAIContextWindowEnabledCheckBox().isSelected()).isTrue();
+        assertThat(component.getCustomOpenAIContextWindowField().getNumber()).isEqualTo(64_000);
+    }
+
+    @Test
+    void shouldApplyCustomOpenAICostSettings() {
+        LLMProvidersComponent component = getSettingsComponent();
+
+        component.getCustomOpenAIInputCostField().setValue(3.0d);
+        component.getCustomOpenAIOutputCostField().setValue(15.0d);
+
+        assertThat(configurable.isModified()).isTrue();
+
+        configurable.apply();
+
+        assertThat(stateService.getCustomOpenAIInputCost()).isEqualTo(3.0d);
+        assertThat(stateService.getCustomOpenAIOutputCost()).isEqualTo(15.0d);
+    }
+
+    @Test
+    void shouldStoreNullCustomOpenAICostWhenZero() {
+        stateService.setCustomOpenAIInputCost(3.0d);
+        LLMProvidersComponent component = getSettingsComponent();
+        component.getCustomOpenAIInputCostField().setValue(0.0d);
+
+        configurable.apply();
+
+        assertThat(stateService.getCustomOpenAIInputCost()).isNull();
+    }
+
+    @Test
+    void shouldResetCustomOpenAICostSettings() {
+        stateService.setCustomOpenAIInputCost(3.0d);
+        stateService.setCustomOpenAIOutputCost(15.0d);
+
+        configurable.reset();
+
+        LLMProvidersComponent component = getSettingsComponent();
+        assertThat(((Number) component.getCustomOpenAIInputCostField().getValue()).doubleValue()).isEqualTo(3.0d);
+        assertThat(((Number) component.getCustomOpenAIOutputCostField().getValue()).doubleValue()).isEqualTo(15.0d);
+    }
+
+    @Test
     void shouldApplyShowThinkingSetting() {
         LLMProvidersComponent component = getSettingsComponent();
 


### PR DESCRIPTION
## Summary
- Adds **Custom OpenAI Context Window** and **Input/Output Cost** settings (Settings → Large Language Models), so internal/OpenAI-compatible models no longer assume a hardcoded 4096-token window and $0 cost.
- Configured context window drives the token-usage bar (avoids the false red "context exceeded" warning; the request was always sent regardless), and configured costs (dollars per 1M tokens) make the estimated cost show in each AI response bubble.
- Values are wired into both `LanguageModel` build sites for the provider; cost calc + bubble rendering were already provider-agnostic, so populating `inputCost`/`outputCost` is sufficient. Leaving costs at 0 keeps them hidden as before.

Addresses discussion [#1186](https://github.com/devoxx/DevoxxGenieIDEAPlugin/discussions/1186).

## Test plan
- [x] `CustomOpenAIContextWindowTest` / `CustomOpenAICostTest` — resolution helper semantics (null/negative → default/0)
- [x] `CustomOpenAICostCalculationTest` — end-to-end: configured costs yield non-zero `ChatMessageContext.cost`; unset stays 0
- [x] `LLMProvidersConfigurableTest` — apply/reset/isModified + zero-clears-to-null for the new fields
- [x] Full `./gradlew test` suite green; `compileJava`/`compileTestJava` clean on JDK 21
- [ ] Manual: set context window + costs in Settings, run a Custom OpenAI prompt, confirm the usage bar reflects the window and the cost appears in the response bubble

🤖 Generated with [Claude Code](https://claude.com/claude-code)