### PR TITLE
fix: respect user-configured tool-call limits above 100

### DIFF
--- a/src/main/java/com/devoxx/genie/model/Constant.java
+++ b/src/main/java/com/devoxx/genie/model/Constant.java
@@ -70,6 +70,17 @@ public class Constant {
      */
     public static final int AGENT_MAX_TOOL_CALLS_UPPER_BOUND = 500;
     /**
+     * Extra Langchain4j tool-calling round trips granted beyond the configured max
+     * tool calls (issue #1188). Langchain4j's {@code ToolService} defaults
+     * {@code maxToolCallingRoundTrips} to 100 and kills the run with an execution
+     * error when exceeded, so every tool-using AiServices builder must override it
+     * with the configured limit plus this margin. The margin gives the LLM room to
+     * wrap up gracefully after {@code AgentLoopTracker} starts short-circuiting
+     * tool calls with the loop-limit message, while the Langchain4j limit remains
+     * a hard backstop against a model that never stops calling tools.
+     */
+    public static final int AGENT_LOOP_ROUND_TRIP_GRACE = 10;
+    /**
      * Wall-clock cap (seconds) for a single MCP/agent prompt conversation.
      * Simple (non-agent, non-MCP) prompts use the per-request timeout instead. The agent cap is
      * a *safety net* against silent hangs (e.g., an MCP tool that never returns); each individual

--- a/src/main/java/com/devoxx/genie/service/agent/AgentLoopTracker.java
+++ b/src/main/java/com/devoxx/genie/service/agent/AgentLoopTracker.java
@@ -1,5 +1,6 @@
 package com.devoxx.genie.service.agent;
 
+import com.devoxx.genie.model.Constant;
 import com.devoxx.genie.model.activity.ActivityMessage;
 import com.devoxx.genie.model.activity.ActivitySource;
 import com.devoxx.genie.model.agent.AgentType;
@@ -253,6 +254,19 @@ public class AgentLoopTracker implements ToolProvider {
 
     public boolean isCancelled() {
         return cancelled.get();
+    }
+
+    /**
+     * The value to pass to {@code AiServices.builder(...).maxToolCallingRoundTrips(...)}
+     * wherever this tracker is used as the tool provider (issue #1188). Langchain4j
+     * defaults that limit to 100 round trips and throws a runtime error when exceeded,
+     * which silently overrode user-configured limits above 100. One round trip executes
+     * at least one tool call, so this tracker's graceful limit always fires first; the
+     * grace margin leaves the LLM a few extra round trips to deliver its wrap-up answer,
+     * with the Langchain4j limit remaining as a hard backstop against infinite loops.
+     */
+    public int getMaxToolCallingRoundTrips() {
+        return maxToolCalls + Constant.AGENT_LOOP_ROUND_TRIP_GRACE;
     }
 
     public int getCallCount() {

--- a/src/main/java/com/devoxx/genie/service/agent/SubAgentRunner.java
+++ b/src/main/java/com/devoxx/genie/service/agent/SubAgentRunner.java
@@ -97,6 +97,9 @@ public class SubAgentRunner {
             SubAssistant assistant = AiServices.builder(SubAssistant.class)
                     .chatModel(model)
                     .toolProvider(tracker)
+                    // Issue #1188: override Langchain4j's default of 100 round trips so the
+                    // configured sub-agent tool-call limit is the one that actually applies.
+                    .maxToolCallingRoundTrips(tracker.getMaxToolCallingRoundTrips())
                     .chatMemoryProvider(memoryId -> memory)
                     .systemMessageProvider(memoryId -> SYSTEM_PROMPT)
                     .build();

--- a/src/main/java/com/devoxx/genie/service/prompt/response/nonstreaming/NonStreamingPromptExecutionService.java
+++ b/src/main/java/com/devoxx/genie/service/prompt/response/nonstreaming/NonStreamingPromptExecutionService.java
@@ -227,12 +227,17 @@ public class NonStreamingPromptExecutionService {
             }
 
             log.debug("Tool provider created for non-streaming prompt");
-            assistant = AiServices.builder(Assistant.class)
+            var assistantBuilder = AiServices.builder(Assistant.class)
                     .chatModel(chatModel)
                     .chatMemoryProvider(memoryId -> chatMemory)
                     .systemMessageProvider(memoryId -> buildToolSystemPrompt(project))
-                    .toolProvider(toolProvider)
-                    .build();
+                    .toolProvider(toolProvider);
+            if (toolProvider instanceof AgentLoopTracker tracker) {
+                // Issue #1188: Langchain4j defaults maxToolCallingRoundTrips to 100,
+                // which silently overrides user-configured tool-call limits above 100.
+                assistantBuilder.maxToolCallingRoundTrips(tracker.getMaxToolCallingRoundTrips());
+            }
+            assistant = assistantBuilder.build();
 
             AiMessage queryResponse = assistant.chat(cleanText);
 

--- a/src/main/java/com/devoxx/genie/service/prompt/strategy/StreamingPromptStrategy.java
+++ b/src/main/java/com/devoxx/genie/service/prompt/strategy/StreamingPromptStrategy.java
@@ -235,6 +235,11 @@ public class StreamingPromptStrategy extends AbstractPromptExecutionStrategy {
 
         if (toolProvider != null) {
             builder.toolProvider(toolProvider);
+            if (toolProvider instanceof AgentLoopTracker tracker) {
+                // Issue #1188: Langchain4j defaults maxToolCallingRoundTrips to 100,
+                // which silently overrides user-configured tool-call limits above 100.
+                builder.maxToolCallingRoundTrips(tracker.getMaxToolCallingRoundTrips());
+            }
         }
 
         return builder.build();

--- a/src/test/java/com/devoxx/genie/service/agent/AgentLoopRoundTripLimitTest.java
+++ b/src/test/java/com/devoxx/genie/service/agent/AgentLoopRoundTripLimitTest.java
@@ -1,0 +1,149 @@
+package com.devoxx.genie.service.agent;
+
+import dev.langchain4j.agent.tool.ToolExecutionRequest;
+import dev.langchain4j.agent.tool.ToolSpecification;
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.data.message.ChatMessage;
+import dev.langchain4j.data.message.ToolExecutionResultMessage;
+import dev.langchain4j.memory.chat.MessageWindowChatMemory;
+import dev.langchain4j.model.chat.ChatModel;
+import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.model.chat.request.json.JsonObjectSchema;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import dev.langchain4j.service.AiServices;
+import dev.langchain4j.service.tool.ToolExecutor;
+import dev.langchain4j.service.tool.ToolProvider;
+import dev.langchain4j.service.tool.ToolProviderResult;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Reproduces issue #1188: the user-configurable agent tool-call limit (up to 500)
+ * was silently capped at 100 because Langchain4j's {@code ToolService} defaults
+ * {@code maxToolCallingRoundTrips} to 100 and kills the run with
+ * "Something is wrong, exceeded 100 tool calling round trips" before the plugin's
+ * own {@link AgentLoopTracker} limit is ever reached.
+ *
+ * <p>The fix threads the tracker's limit (plus a wrap-up grace margin) into every
+ * tool-using {@code AiServices} builder via {@link AgentLoopTracker#getMaxToolCallingRoundTrips()}.
+ */
+class AgentLoopRoundTripLimitTest {
+
+    private static final int TRACKER_LIMIT_ABOVE_LC4J_DEFAULT = 120;
+
+    interface Assistant {
+        String chat(String userMessage);
+    }
+
+    /**
+     * Fake model that keeps requesting the {@code read_file} tool until either it has
+     * issued the requested number of tool calls or the tracker tells it to wrap up,
+     * then returns a final text answer.
+     */
+    private static final class ToolLoopingChatModel implements ChatModel {
+        private final int toolCallsToAttempt;
+        private int issued = 0;
+
+        private ToolLoopingChatModel(int toolCallsToAttempt) {
+            this.toolCallsToAttempt = toolCallsToAttempt;
+        }
+
+        @Override
+        public ChatResponse doChat(ChatRequest request) {
+            List<ChatMessage> messages = request.messages();
+            ChatMessage last = messages.get(messages.size() - 1);
+            boolean askedToWrapUp = last instanceof ToolExecutionResultMessage toolResult
+                    && toolResult.text().contains("Agent loop limit reached");
+            if (askedToWrapUp || issued >= toolCallsToAttempt) {
+                return ChatResponse.builder()
+                        .aiMessage(AiMessage.from("done after " + issued + " tool calls"))
+                        .build();
+            }
+            issued++;
+            return ChatResponse.builder()
+                    .aiMessage(AiMessage.from(ToolExecutionRequest.builder()
+                            .id(String.valueOf(issued))
+                            .name("read_file")
+                            .arguments("{}")
+                            .build()))
+                    .build();
+        }
+    }
+
+    private static ToolProvider mockToolProvider() {
+        ToolExecutor executor = (req, id) -> "file content";
+        ToolSpecification spec = ToolSpecification.builder()
+                .name("read_file")
+                .description("Reads a file")
+                .parameters(JsonObjectSchema.builder().build())
+                .build();
+        return req -> ToolProviderResult.builder().add(spec, executor).build();
+    }
+
+    @Test
+    void trackerLimitAbove100_completesWhenRoundTripLimitFollowsTrackerLimit() {
+        AgentLoopTracker tracker = new AgentLoopTracker(mockToolProvider(), TRACKER_LIMIT_ABOVE_LC4J_DEFAULT);
+
+        Assistant assistant = AiServices.builder(Assistant.class)
+                .chatModel(new ToolLoopingChatModel(TRACKER_LIMIT_ABOVE_LC4J_DEFAULT))
+                .chatMemoryProvider(memoryId -> MessageWindowChatMemory.withMaxMessages(1000))
+                .toolProvider(tracker)
+                .maxToolCallingRoundTrips(tracker.getMaxToolCallingRoundTrips())
+                .build();
+
+        String answer = assistant.chat("do lots of tool calls");
+
+        assertThat(answer).isEqualTo("done after " + TRACKER_LIMIT_ABOVE_LC4J_DEFAULT + " tool calls");
+        assertThat(tracker.getCallCount()).isEqualTo(TRACKER_LIMIT_ABOVE_LC4J_DEFAULT);
+    }
+
+    @Test
+    void modelThatOverrunsTrackerLimit_isWrappedUpGracefullyWithinGraceMargin() {
+        AgentLoopTracker tracker = new AgentLoopTracker(mockToolProvider(), TRACKER_LIMIT_ABOVE_LC4J_DEFAULT);
+
+        // Model tries more calls than the tracker allows: calls beyond the limit get the
+        // "Agent loop limit reached" error string and the model then wraps up. The extra
+        // round trip for the wrap-up must fit within the grace margin.
+        Assistant assistant = AiServices.builder(Assistant.class)
+                .chatModel(new ToolLoopingChatModel(TRACKER_LIMIT_ABOVE_LC4J_DEFAULT + 50))
+                .chatMemoryProvider(memoryId -> MessageWindowChatMemory.withMaxMessages(1000))
+                .toolProvider(tracker)
+                .maxToolCallingRoundTrips(tracker.getMaxToolCallingRoundTrips())
+                .build();
+
+        String answer = assistant.chat("do lots of tool calls");
+
+        assertThat(answer).startsWith("done after");
+    }
+
+    /**
+     * Characterization of the issue #1188 root cause: without the explicit override,
+     * Langchain4j's default of 100 round trips kills the run with an execution error
+     * even though the plugin's own limit (e.g. 500) has not been reached. This test
+     * documents why the {@code maxToolCallingRoundTrips} override must not be removed.
+     */
+    @Test
+    void withoutRoundTripOverride_langchain4jKillsLoopAt100() {
+        AgentLoopTracker tracker = new AgentLoopTracker(mockToolProvider(), TRACKER_LIMIT_ABOVE_LC4J_DEFAULT);
+
+        Assistant assistant = AiServices.builder(Assistant.class)
+                .chatModel(new ToolLoopingChatModel(TRACKER_LIMIT_ABOVE_LC4J_DEFAULT))
+                .chatMemoryProvider(memoryId -> MessageWindowChatMemory.withMaxMessages(1000))
+                .toolProvider(tracker)
+                .build();
+
+        assertThatThrownBy(() -> assistant.chat("do lots of tool calls"))
+                .hasMessageContaining("100 tool calling round trips");
+    }
+
+    @Test
+    void roundTripLimit_exceedsTrackerLimitByGraceMargin() {
+        AgentLoopTracker tracker = new AgentLoopTracker(mockToolProvider(), 500);
+
+        assertThat(tracker.getMaxToolCallingRoundTrips()).isGreaterThan(500);
+    }
+}


### PR DESCRIPTION
Fixes #1188

## Problem

Setting the agent max tool-calls limit above 100 (raised to 500 in #1163) had no effect: runs still died at tool call 100 with an execution error ("Something is wrong, exceeded 100 tool calling round trips").

## Root cause

Langchain4j's `ToolService` defaults `maxToolCallingRoundTrips` to 100 and throws when exceeded. The plugin's own `AgentLoopTracker` enforces the user-configured limit gracefully (it returns a "wrap up now" message to the LLM instead of throwing), but none of the tool-using `AiServices` builders overrode Langchain4j's internal default — so the hardcoded 100 always fired first for limits above 100.

## Fix

- New `AgentLoopTracker.getMaxToolCallingRoundTrips()`: the configured max tool calls plus a grace margin (`Constant.AGENT_LOOP_ROUND_TRIP_GRACE = 10`). One round trip executes at least one tool call, so the tracker's graceful limit always fires first; the margin leaves the LLM room to deliver its wrap-up answer, while the Langchain4j limit remains a hard backstop against runaway loops.
- Wired `.maxToolCallingRoundTrips(...)` into all three tool-using `AiServices` builders: `NonStreamingPromptExecutionService`, `StreamingPromptStrategy`, and `SubAgentRunner` (sub-agents were affected too — their default limit of 200 also exceeded 100).
- MCP-only mode (agent off) is unchanged and keeps the Langchain4j default, as it has no user-configurable limit.

## Tests

New `AgentLoopRoundTripLimitTest` drives a real Langchain4j tool loop with a fake model:
- a tracker limit of 120 now completes all 120 tool calls,
- a model that overruns the tracker limit is wrapped up gracefully within the grace margin,
- a characterization test documents that removing the override reintroduces the 100-cap bug.

Full test suite and `./gradlew build` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)