### PR TITLE
fix: prevent dangling tool_calls from corrupting agent conversations (#1193)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -235,7 +235,7 @@ Key services under `service/`:
 
 - Java minimum: JDK 17
 - IntelliJ minimum: 2023.3.4
-- Langchain4J version: 1.14.0 (beta: 1.14.0-beta24 for MCP/Chroma/web search/reactor)
+- Langchain4J version: 1.17.1 (beta: 1.17.1-beta27 for MCP/Chroma/web search/reactor)
 - Uses Lombok for boilerplate reduction
 - Shadow plugin for fat JAR creation with dependency merging
 

--- a/src/main/java/com/devoxx/genie/service/agent/SubAgentRunner.java
+++ b/src/main/java/com/devoxx/genie/service/agent/SubAgentRunner.java
@@ -94,14 +94,14 @@ public class SubAgentRunner {
                 return SUB_AGENT + (agentIndex + 1) + " cancelled.";
             }
 
-            SubAssistant assistant = AiServices.builder(SubAssistant.class)
-                    .chatModel(model)
-                    .toolProvider(tracker)
-                    // Issue #1188: override Langchain4j's default of 100 round trips so the
-                    // configured sub-agent tool-call limit is the one that actually applies.
-                    .maxToolCallingRoundTrips(tracker.getMaxToolCallingRoundTrips())
-                    .chatMemoryProvider(memoryId -> memory)
-                    .systemMessageProvider(memoryId -> SYSTEM_PROMPT)
+            SubAssistant assistant = ToolErrorRecovery.configure(AiServices.builder(SubAssistant.class)
+                            .chatModel(model)
+                            .toolProvider(tracker)
+                            // Issue #1188: override Langchain4j's default of 100 round trips so the
+                            // configured sub-agent tool-call limit is the one that actually applies.
+                            .maxToolCallingRoundTrips(tracker.getMaxToolCallingRoundTrips())
+                            .chatMemoryProvider(memoryId -> memory)
+                            .systemMessageProvider(memoryId -> SYSTEM_PROMPT))
                     .build();
 
             String prompt = "Investigate the following in the project codebase:\n\n" + query +

--- a/src/main/java/com/devoxx/genie/service/agent/ToolErrorRecovery.java
+++ b/src/main/java/com/devoxx/genie/service/agent/ToolErrorRecovery.java
@@ -1,0 +1,45 @@
+package com.devoxx.genie.service.agent;
+
+import dev.langchain4j.data.message.ToolExecutionResultMessage;
+import dev.langchain4j.service.AiServices;
+import dev.langchain4j.service.tool.ToolErrorHandlerResult;
+
+/**
+ * Configures tool-error recovery on tool-using {@link AiServices} builders (issue #1193).
+ *
+ * <p>Langchain4j's defaults <em>throw</em> when the model requests a tool that isn't
+ * registered ({@code HallucinatedToolNameStrategy.THROW_EXCEPTION}) or sends unparsable
+ * arguments (default {@code ToolArgumentsErrorHandler} rethrows). Both throws happen
+ * <em>after</em> the AiMessage(tool_calls) has been written to chat memory but
+ * <em>before</em> any tool result is written, leaving a dangling tool_use tail that
+ * makes OpenAI-compatible providers (DeepSeek, OpenAI, …) reject every subsequent
+ * request with "An assistant message with 'tool_calls' must be followed by tool
+ * messages responding to each 'tool_call_id'".
+ *
+ * <p>Instead of throwing, return the error as a tool result: chat memory stays
+ * consistent and the model gets feedback so it can self-correct (e.g. pick an
+ * existing tool or fix its arguments).
+ */
+public final class ToolErrorRecovery {
+
+    private ToolErrorRecovery() {
+    }
+
+    /**
+     * Applies the recovery strategies to the given builder. Must be called on every
+     * tool-using {@code AiServices} builder (streaming, non-streaming, sub-agent).
+     *
+     * @param builder the builder to configure
+     * @return the same builder, for chaining
+     */
+    public static <T> AiServices<T> configure(AiServices<T> builder) {
+        return builder
+                .hallucinatedToolNameStrategy(toolRequest -> ToolExecutionResultMessage.from(
+                        toolRequest,
+                        "Error: there is no tool called '" + toolRequest.name()
+                                + "'. Only use the tools that were provided to you."))
+                .toolArgumentsErrorHandler((error, errorContext) -> ToolErrorHandlerResult.text(
+                        "Error: invalid arguments for tool '"
+                                + errorContext.toolExecutionRequest().name() + "': " + error.getMessage()));
+    }
+}

--- a/src/main/java/com/devoxx/genie/service/prompt/memory/ChatMemoryManager.java
+++ b/src/main/java/com/devoxx/genie/service/prompt/memory/ChatMemoryManager.java
@@ -95,6 +95,12 @@ public class ChatMemoryManager {
                 initializeMemoryByKey(memoryKey);
             }
 
+            // Issue #1193: a tool loop that died between writing the AiMessage(tool_calls)
+            // and its tool results (hallucinated tool name, round-trip limit, streaming
+            // error) leaves a dangling tool_use tail that makes OpenAI-compatible providers
+            // reject every subsequent request. Heal the conversation before each new prompt.
+            sanitizeOrphanedToolMessages(memoryKey);
+
             if (chatMemoryService.isEmptyByKey(memoryKey)) {
                 log.debug("Preparing memory with initial system message if needed");
 

--- a/src/main/java/com/devoxx/genie/service/prompt/response/nonstreaming/NonStreamingPromptExecutionService.java
+++ b/src/main/java/com/devoxx/genie/service/prompt/response/nonstreaming/NonStreamingPromptExecutionService.java
@@ -5,6 +5,7 @@ import com.devoxx.genie.model.request.ChatMessageContext;
 import com.devoxx.genie.service.FileListManager;
 import com.devoxx.genie.service.agent.AgentLoopTracker;
 import com.devoxx.genie.service.agent.AgentToolProviderFactory;
+import com.devoxx.genie.service.agent.ToolErrorRecovery;
 import com.devoxx.genie.service.analytics.FeatureUsageTracker;
 import com.devoxx.genie.service.mcp.MCPExecutionService;
 import com.devoxx.genie.service.mcp.MCPService;
@@ -232,6 +233,9 @@ public class NonStreamingPromptExecutionService {
                     .chatMemoryProvider(memoryId -> chatMemory)
                     .systemMessageProvider(memoryId -> buildToolSystemPrompt(project))
                     .toolProvider(toolProvider);
+            // Issue #1193: turn hallucinated-tool-name / bad-arguments throws into
+            // error tool-results so chat memory never ends up with a dangling tool_use.
+            ToolErrorRecovery.configure(assistantBuilder);
             if (toolProvider instanceof AgentLoopTracker tracker) {
                 // Issue #1188: Langchain4j defaults maxToolCallingRoundTrips to 100,
                 // which silently overrides user-configured tool-call limits above 100.

--- a/src/main/java/com/devoxx/genie/service/prompt/strategy/StreamingPromptStrategy.java
+++ b/src/main/java/com/devoxx/genie/service/prompt/strategy/StreamingPromptStrategy.java
@@ -5,6 +5,7 @@ import com.devoxx.genie.service.FileListManager;
 import com.devoxx.genie.service.MessageCreationService;
 import com.devoxx.genie.service.agent.AgentLoopTracker;
 import com.devoxx.genie.service.agent.AgentToolProviderFactory;
+import com.devoxx.genie.service.agent.ToolErrorRecovery;
 import com.devoxx.genie.service.analytics.FeatureUsageTracker;
 import com.devoxx.genie.service.mcp.MCPExecutionService;
 import com.devoxx.genie.service.prompt.error.ModelException;
@@ -235,6 +236,9 @@ public class StreamingPromptStrategy extends AbstractPromptExecutionStrategy {
 
         if (toolProvider != null) {
             builder.toolProvider(toolProvider);
+            // Issue #1193: turn hallucinated-tool-name / bad-arguments throws into
+            // error tool-results so chat memory never ends up with a dangling tool_use.
+            ToolErrorRecovery.configure(builder);
             if (toolProvider instanceof AgentLoopTracker tracker) {
                 // Issue #1188: Langchain4j defaults maxToolCallingRoundTrips to 100,
                 // which silently overrides user-configured tool-call limits above 100.

--- a/src/test/java/com/devoxx/genie/service/agent/ToolErrorRecoveryTest.java
+++ b/src/test/java/com/devoxx/genie/service/agent/ToolErrorRecoveryTest.java
@@ -1,0 +1,165 @@
+package com.devoxx.genie.service.agent;
+
+import dev.langchain4j.agent.tool.ToolExecutionRequest;
+import dev.langchain4j.agent.tool.ToolSpecification;
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.data.message.ChatMessage;
+import dev.langchain4j.data.message.ToolExecutionResultMessage;
+import dev.langchain4j.memory.chat.MessageWindowChatMemory;
+import dev.langchain4j.model.chat.ChatModel;
+import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.model.chat.request.json.JsonObjectSchema;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import dev.langchain4j.service.AiServices;
+import dev.langchain4j.service.tool.ToolExecutor;
+import dev.langchain4j.service.tool.ToolProvider;
+import dev.langchain4j.service.tool.ToolProviderResult;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Reproduces the root cause of issue #1193: when the model requests a tool that is not
+ * registered (disabled in settings, or a hallucinated name — common with models like
+ * DeepSeek whose system prompt instructs tool usage), Langchain4j's default
+ * {@code HallucinatedToolNameStrategy.THROW_EXCEPTION} kills the tool loop <em>after</em>
+ * the AiMessage(tool_calls) was already written to chat memory but <em>before</em> any
+ * tool result is written. The dangling tool_calls tail then breaks every subsequent
+ * request with "An assistant message with 'tool_calls' must be followed by tool messages
+ * responding to each 'tool_call_id'".
+ *
+ * <p>The fix: {@link ToolErrorRecovery#configure(AiServices)} replaces the throwing
+ * default with a strategy that returns an error tool-result, keeping memory consistent
+ * and giving the model a chance to self-correct.
+ */
+class ToolErrorRecoveryTest {
+
+    interface Assistant {
+        String chat(String userMessage);
+    }
+
+    /**
+     * Fake model that first requests a tool that does not exist, then — if it receives
+     * an error tool-result back — recovers by calling the real tool, then answers.
+     */
+    private static final class HallucinatingChatModel implements ChatModel {
+        private int requests = 0;
+
+        @Override
+        public ChatResponse doChat(ChatRequest request) {
+            requests++;
+            List<ChatMessage> messages = request.messages();
+            ChatMessage last = messages.get(messages.size() - 1);
+
+            if (requests == 1) {
+                // Hallucinated tool name on the first round trip
+                return ChatResponse.builder()
+                        .aiMessage(AiMessage.from(ToolExecutionRequest.builder()
+                                .id("call_1")
+                                .name("no_such_tool")
+                                .arguments("{}")
+                                .build()))
+                        .build();
+            }
+
+            if (last instanceof ToolExecutionResultMessage toolResult
+                    && toolResult.text().contains("no_such_tool")) {
+                // Model self-corrects after being told the tool doesn't exist
+                return ChatResponse.builder()
+                        .aiMessage(AiMessage.from(ToolExecutionRequest.builder()
+                                .id("call_2")
+                                .name("read_file")
+                                .arguments("{}")
+                                .build()))
+                        .build();
+            }
+
+            return ChatResponse.builder()
+                    .aiMessage(AiMessage.from("recovered and done"))
+                    .build();
+        }
+    }
+
+    private static ToolProvider realToolProvider() {
+        ToolExecutor executor = (req, id) -> "file content";
+        ToolSpecification spec = ToolSpecification.builder()
+                .name("read_file")
+                .description("Reads a file")
+                .parameters(JsonObjectSchema.builder().build())
+                .build();
+        return req -> ToolProviderResult.builder().add(spec, executor).build();
+    }
+
+    /**
+     * Characterization of the issue #1193 root cause: without the recovery strategy,
+     * a hallucinated tool name throws AND leaves a dangling AiMessage(tool_calls) as
+     * the tail of chat memory — corrupting the conversation for all later requests.
+     * This documents why {@link ToolErrorRecovery} must not be removed.
+     */
+    @Test
+    void withoutRecovery_hallucinatedToolThrowsAndLeavesDanglingToolCallsInMemory() {
+        MessageWindowChatMemory memory = MessageWindowChatMemory.withMaxMessages(100);
+
+        Assistant assistant = AiServices.builder(Assistant.class)
+                .chatModel(new HallucinatingChatModel())
+                .chatMemoryProvider(memoryId -> memory)
+                .toolProvider(realToolProvider())
+                .build();
+
+        assertThatThrownBy(() -> assistant.chat("do something"))
+                .hasMessageContaining("no_such_tool");
+
+        // The corrupted state that produces the issue #1193 API error on the next request:
+        List<ChatMessage> messages = memory.messages();
+        ChatMessage tail = messages.get(messages.size() - 1);
+        assertThat(tail).isInstanceOf(AiMessage.class);
+        assertThat(((AiMessage) tail).hasToolExecutionRequests()).isTrue();
+    }
+
+    @Test
+    void withRecovery_hallucinatedToolGetsErrorResultAndModelSelfCorrects() {
+        MessageWindowChatMemory memory = MessageWindowChatMemory.withMaxMessages(100);
+
+        Assistant assistant = ToolErrorRecovery.configure(AiServices.builder(Assistant.class)
+                        .chatModel(new HallucinatingChatModel())
+                        .chatMemoryProvider(memoryId -> memory)
+                        .toolProvider(realToolProvider()))
+                .build();
+
+        String answer = assistant.chat("do something");
+
+        assertThat(answer).isEqualTo("recovered and done");
+    }
+
+    @Test
+    void withRecovery_everyToolCallInMemoryHasItsResult() {
+        MessageWindowChatMemory memory = MessageWindowChatMemory.withMaxMessages(100);
+
+        Assistant assistant = ToolErrorRecovery.configure(AiServices.builder(Assistant.class)
+                        .chatModel(new HallucinatingChatModel())
+                        .chatMemoryProvider(memoryId -> memory)
+                        .toolProvider(realToolProvider()))
+                .build();
+
+        assistant.chat("do something");
+
+        // Memory must stay consistent: every tool_call id is answered by a result
+        List<ChatMessage> messages = memory.messages();
+        for (int i = 0; i < messages.size(); i++) {
+            if (messages.get(i) instanceof AiMessage aiMessage && aiMessage.hasToolExecutionRequests()) {
+                for (ToolExecutionRequest request : aiMessage.toolExecutionRequests()) {
+                    boolean answered = messages.stream()
+                            .filter(m -> m instanceof ToolExecutionResultMessage)
+                            .map(m -> (ToolExecutionResultMessage) m)
+                            .anyMatch(r -> r.id().equals(request.id()));
+                    assertThat(answered)
+                            .as("tool_call %s must have a matching tool result", request.id())
+                            .isTrue();
+                }
+            }
+        }
+    }
+}

--- a/src/test/java/com/devoxx/genie/service/prompt/memory/ChatMemoryPrepareMemorySanitizeTest.java
+++ b/src/test/java/com/devoxx/genie/service/prompt/memory/ChatMemoryPrepareMemorySanitizeTest.java
@@ -1,0 +1,152 @@
+package com.devoxx.genie.service.prompt.memory;
+
+import com.devoxx.genie.model.request.ChatMessageContext;
+import com.intellij.openapi.project.Project;
+import dev.langchain4j.agent.tool.ToolExecutionRequest;
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.data.message.ChatMessage;
+import dev.langchain4j.data.message.SystemMessage;
+import dev.langchain4j.data.message.ToolExecutionResultMessage;
+import dev.langchain4j.data.message.UserMessage;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Reproduces issue #1193: an agent tool loop that dies between writing the
+ * AiMessage(tool_calls) and its ToolExecutionResultMessage(s) — e.g. a hallucinated
+ * tool name (Langchain4j default strategy: throw), a round-trip-limit throw, or a
+ * streaming error — leaves a dangling tool_use tail in chat memory. Every subsequent
+ * request in the conversation is then rejected by OpenAI-compatible providers with
+ * "An assistant message with 'tool_calls' must be followed by tool messages responding
+ * to each 'tool_call_id'".
+ *
+ * <p>The fix: {@link ChatMemoryManager#prepareMemory(ChatMessageContext)} sanitizes
+ * the orphaned tool tail before every new prompt, so a corrupted conversation heals
+ * itself on the next message instead of being broken until restart.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class ChatMemoryPrepareMemorySanitizeTest {
+
+    private static final String PROJECT_HASH = "project-hash";
+
+    @Mock
+    private ChatMemoryService mockChatMemoryService;
+
+    @Mock
+    private Project mockProject;
+
+    private ChatMemoryManager chatMemoryManager;
+
+    @BeforeEach
+    void setUp() {
+        try (MockedStatic<ChatMemoryService> staticMock = Mockito.mockStatic(ChatMemoryService.class)) {
+            staticMock.when(ChatMemoryService::getInstance).thenReturn(mockChatMemoryService);
+            chatMemoryManager = new ChatMemoryManager();
+        }
+        when(mockProject.getLocationHash()).thenReturn(PROJECT_HASH);
+        when(mockChatMemoryService.hasMemory(PROJECT_HASH)).thenReturn(true);
+        when(mockChatMemoryService.isEmptyByKey(PROJECT_HASH)).thenReturn(false);
+    }
+
+    private ChatMessageContext context() {
+        return ChatMessageContext.builder()
+                .id("ctx-1")
+                .project(mockProject)
+                .userPrompt("next prompt")
+                .build();
+    }
+
+    private static AiMessage toolUse(String... ids) {
+        ToolExecutionRequest[] requests = new ToolExecutionRequest[ids.length];
+        for (int i = 0; i < ids.length; i++) {
+            requests[i] = ToolExecutionRequest.builder()
+                    .id(ids[i])
+                    .name("some_tool")
+                    .arguments("{}")
+                    .build();
+        }
+        return AiMessage.from(requests);
+    }
+
+    @SuppressWarnings("unchecked")
+    private List<ChatMessage> capturedRemoval() {
+        ArgumentCaptor<List<ChatMessage>> captor = ArgumentCaptor.forClass(List.class);
+        verify(mockChatMemoryService).removeMessagesByKey(eq(PROJECT_HASH), captor.capture());
+        return captor.getValue();
+    }
+
+    @Test
+    void prepareMemoryRemovesDanglingToolUseLeftByFailedToolLoop() {
+        // A previous turn died after the AiMessage(tool_calls) was added to memory
+        // but before any tool result was written (issue #1193).
+        AiMessage danglingToolUse = toolUse("call_1");
+        when(mockChatMemoryService.getMessagesByKey(PROJECT_HASH))
+                .thenReturn(List.of(
+                        SystemMessage.from("sys"),
+                        UserMessage.from("previous prompt"),
+                        danglingToolUse));
+
+        chatMemoryManager.prepareMemory(context());
+
+        List<ChatMessage> removed = capturedRemoval();
+        Assertions.assertEquals(1, removed.size());
+        Assertions.assertTrue(removed.contains(danglingToolUse));
+    }
+
+    @Test
+    void prepareMemoryRemovesToolUseWithPartialResults() {
+        // The turn died after only one of two tool results was written.
+        AiMessage toolUse = toolUse("call_1", "call_2");
+        ToolExecutionResultMessage partial = ToolExecutionResultMessage.from(
+                ToolExecutionRequest.builder().id("call_1").name("some_tool").arguments("{}").build(),
+                "result");
+        when(mockChatMemoryService.getMessagesByKey(PROJECT_HASH))
+                .thenReturn(List.of(
+                        UserMessage.from("previous prompt"),
+                        toolUse,
+                        partial));
+
+        chatMemoryManager.prepareMemory(context());
+
+        List<ChatMessage> removed = capturedRemoval();
+        Assertions.assertEquals(2, removed.size());
+        Assertions.assertTrue(removed.contains(toolUse));
+        Assertions.assertTrue(removed.contains(partial));
+    }
+
+    @Test
+    void prepareMemoryKeepsHealthyConversationIntact() {
+        AiMessage toolUse = toolUse("call_1");
+        ToolExecutionResultMessage result = ToolExecutionResultMessage.from(
+                ToolExecutionRequest.builder().id("call_1").name("some_tool").arguments("{}").build(),
+                "result");
+        when(mockChatMemoryService.getMessagesByKey(PROJECT_HASH))
+                .thenReturn(List.of(
+                        UserMessage.from("previous prompt"),
+                        toolUse,
+                        result,
+                        AiMessage.from("final answer")));
+
+        chatMemoryManager.prepareMemory(context());
+
+        verify(mockChatMemoryService, never()).removeMessagesByKey(eq(PROJECT_HASH), anyList());
+    }
+}


### PR DESCRIPTION
Fixes #1193

## Problem

In Agent mode, langchain4j's tool loop writes the `AiMessage(tool_calls)` to chat memory **before** executing tools and writing their results (`AiServiceStreamingResponseHandler.onCompleteResponse`). Any throw in between leaves a dangling `tool_calls` tail in `MessageWindowChatMemory`, and every subsequent request in the conversation is rejected by OpenAI-compatible providers (DeepSeek, OpenAI, …) with:

> An assistant message with 'tool_calls' must be followed by tool messages responding to each 'tool_call_id'. (insufficient tool messages following tool_calls message)

Verified producers in langchain4j 1.17.x (all use defaults DevoxxGenie never overrode):

- **Hallucinated / unavailable tool name** — default `HallucinatedToolNameStrategy.THROW_EXCEPTION`. Triggered by prompts that instruct tool usage (the reporter's system prompt mandates `run_command`) when the tool is disabled or the model misspells the name.
- **Malformed tool arguments** — default `ToolArgumentsErrorHandler` rethrows.
- **Tool round-trip limit** — langchain4j throws immediately after adding the `AiMessage(tool_calls)` to memory.

The existing `sanitizeOrphanedToolMessages()` repair only ran on explicit cancellation, so a corrupted conversation stayed broken until restart.

## Fix (two layers)

1. **`ToolErrorRecovery`** — configures every tool-using `AiServices` builder (streaming, non-streaming, sub-agent) to return hallucinated-tool-name and bad-arguments errors as *tool results* instead of throwing. Memory stays consistent and the model gets feedback to self-correct.
2. **Self-healing memory** — `ChatMemoryManager.prepareMemory()` now sanitizes an orphaned tool tail before each new prompt (reusing the tested cancellation-path sanitizer), so conversations corrupted by any remaining abnormal-termination path heal on the next message.

## Tests

- `ToolErrorRecoveryTest` — characterization test empirically reproduces the root cause against real langchain4j (hallucinated tool name throws **and** leaves the dangling `tool_calls` tail in memory), plus tests proving the recovery strategy lets the model self-correct and keeps every `tool_call` paired with a result.
- `ChatMemoryPrepareMemorySanitizeTest` — `prepareMemory` removes a dangling tool tail (with and without partial results) and leaves healthy conversations untouched.
- Full test suite: `BUILD SUCCESSFUL` (written test-first; the 4 fix tests failed before the implementation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)