### PR TITLE
Add Raw Request/Response debug viewer for LLM traffic (#1197)

### DIFF
--- a/src/main/java/com/devoxx/genie/chatmodel/ChatModelFactory.java
+++ b/src/main/java/com/devoxx/genie/chatmodel/ChatModelFactory.java
@@ -5,6 +5,7 @@ import com.devoxx.genie.model.LanguageModel;
 import com.devoxx.genie.model.enumarations.ModelProvider;
 import com.devoxx.genie.service.models.LLMModelRegistryService;
 import com.devoxx.genie.service.LLMProviderService;
+import com.devoxx.genie.service.debug.RawTrafficListenerService;
 import com.devoxx.genie.service.mcp.MCPListenerService;
 import com.devoxx.genie.service.mcp.MCPService;
 import com.devoxx.genie.ui.settings.DevoxxGenieStateService;
@@ -12,6 +13,7 @@ import dev.langchain4j.model.chat.ChatModel;
 import dev.langchain4j.model.chat.StreamingChatModel;
 import dev.langchain4j.model.chat.listener.ChatModelListener;
 
+import java.util.ArrayList;
 import java.util.List;
 
 public interface ChatModelFactory {
@@ -65,12 +67,16 @@ public interface ChatModelFactory {
     default void resetModels() {}
 
     default List<ChatModelListener> getListener() {
+        List<ChatModelListener> listeners = new ArrayList<>();
         // Attach MCPListenerService when MCP is enabled (for MCP tool logging)
         // or when agent mode is enabled (for intermediate response logging to Agent Logs)
         if (MCPService.isMCPEnabled() ||
                 Boolean.TRUE.equals(DevoxxGenieStateService.getInstance().getAgentModeEnabled())) {
-            return List.of(new MCPListenerService());
+            listeners.add(new MCPListenerService());
         }
-        return List.of();
+        if (Boolean.TRUE.equals(DevoxxGenieStateService.getInstance().getRawRequestResponseLoggingEnabled())) {
+            listeners.add(new RawTrafficListenerService());
+        }
+        return listeners;
     }
 }

--- a/src/main/java/com/devoxx/genie/model/activity/ActivityMessage.java
+++ b/src/main/java/com/devoxx/genie/model/activity/ActivityMessage.java
@@ -2,6 +2,7 @@ package com.devoxx.genie.model.activity;
 
 import com.devoxx.genie.model.agent.AgentMessage;
 import com.devoxx.genie.model.agent.AgentType;
+import com.devoxx.genie.model.debug.RawTrafficType;
 import com.devoxx.genie.model.mcp.MCPMessage;
 import com.devoxx.genie.model.mcp.MCPType;
 import lombok.AllArgsConstructor;
@@ -22,6 +23,11 @@ public class ActivityMessage {
 
     // Agent-specific
     private AgentType agentType;
+
+    // Raw request/response-specific
+    private RawTrafficType rawTrafficType;
+    /** One-line summary shown in the log list; {@link #content} holds the full redacted JSON payload. */
+    private String summary;
 
     // Shared fields
     private String content;

--- a/src/main/java/com/devoxx/genie/model/activity/ActivitySource.java
+++ b/src/main/java/com/devoxx/genie/model/activity/ActivitySource.java
@@ -2,5 +2,6 @@ package com.devoxx.genie.model.activity;
 
 public enum ActivitySource {
     MCP,
-    AGENT
+    AGENT,
+    RAW
 }

--- a/src/main/java/com/devoxx/genie/model/debug/RawTrafficType.java
+++ b/src/main/java/com/devoxx/genie/model/debug/RawTrafficType.java
@@ -1,0 +1,7 @@
+package com.devoxx.genie.model.debug;
+
+public enum RawTrafficType {
+    REQUEST,
+    RESPONSE,
+    ERROR
+}

--- a/src/main/java/com/devoxx/genie/service/debug/RawTrafficListenerService.java
+++ b/src/main/java/com/devoxx/genie/service/debug/RawTrafficListenerService.java
@@ -1,0 +1,207 @@
+package com.devoxx.genie.service.debug;
+
+import com.devoxx.genie.model.activity.ActivityMessage;
+import com.devoxx.genie.model.activity.ActivitySource;
+import com.devoxx.genie.model.debug.RawTrafficType;
+import com.devoxx.genie.ui.settings.DevoxxGenieStateService;
+import com.devoxx.genie.ui.topic.AppTopics;
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.PropertyAccessor;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.intellij.openapi.application.ApplicationManager;
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.data.message.ChatMessage;
+import dev.langchain4j.data.message.SystemMessage;
+import dev.langchain4j.data.message.ToolExecutionResultMessage;
+import dev.langchain4j.data.message.UserMessage;
+import dev.langchain4j.model.chat.listener.ChatModelErrorContext;
+import dev.langchain4j.model.chat.listener.ChatModelListener;
+import dev.langchain4j.model.chat.listener.ChatModelRequestContext;
+import dev.langchain4j.model.chat.listener.ChatModelResponseContext;
+import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import dev.langchain4j.model.output.TokenUsage;
+import lombok.extern.slf4j.Slf4j;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+/**
+ * Captures the full request/response exchanged with the LLM provider and publishes it (redacted)
+ * to the Activity Log panel, for debugging provider-specific issues. Only active when
+ * "Raw Request/Response Logging" is enabled in Settings — unlike {@link com.devoxx.genie.service.mcp.MCPListenerService},
+ * this can carry the complete prompt and response text, so it is opt-in.
+ * <p>
+ * langchain4j's request/response classes expose data through fluent accessors (e.g. {@code text()})
+ * rather than bean-style getters, so a conventional {@link ObjectMapper} would serialize them to
+ * "{}". The mapper here is configured to walk private fields directly instead.
+ */
+@Slf4j
+public class RawTrafficListenerService implements ChatModelListener {
+
+    private static final ObjectMapper RAW_MAPPER = createRawMapper();
+    private static final int SUMMARY_MAX_LEN = 80;
+    private static final int STACK_TRACE_FRAME_LIMIT = 10;
+
+    private static @NotNull ObjectMapper createRawMapper() {
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.setVisibility(PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY);
+        mapper.setVisibility(PropertyAccessor.GETTER, JsonAutoDetect.Visibility.NONE);
+        mapper.setVisibility(PropertyAccessor.IS_GETTER, JsonAutoDetect.Visibility.NONE);
+        mapper.setVisibility(PropertyAccessor.SETTER, JsonAutoDetect.Visibility.NONE);
+        mapper.setVisibility(PropertyAccessor.CREATOR, JsonAutoDetect.Visibility.NONE);
+        mapper.configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false);
+        mapper.configure(SerializationFeature.INDENT_OUTPUT, true);
+        return mapper;
+    }
+
+    private final Supplier<Boolean> enabledSupplier;
+    private final Consumer<ActivityMessage> publisher;
+
+    public RawTrafficListenerService() {
+        this(
+                () -> Boolean.TRUE.equals(DevoxxGenieStateService.getInstance().getRawRequestResponseLoggingEnabled()),
+                RawTrafficListenerService::publish
+        );
+    }
+
+    RawTrafficListenerService(Supplier<Boolean> enabledSupplier, Consumer<ActivityMessage> publisher) {
+        this.enabledSupplier = enabledSupplier;
+        this.publisher = publisher;
+    }
+
+    @Override
+    public void onRequest(@NotNull ChatModelRequestContext requestContext) {
+        if (!enabledSupplier.get()) {
+            return;
+        }
+        try {
+            ChatRequest chatRequest = requestContext.chatRequest();
+            String json = SecretRedactor.redact(RAW_MAPPER.writeValueAsString(chatRequest));
+            publisher.accept(ActivityMessage.builder()
+                    .source(ActivitySource.RAW)
+                    .rawTrafficType(RawTrafficType.REQUEST)
+                    .summary(summarizeRequest(chatRequest))
+                    .content(json)
+                    .build());
+        } catch (Throwable t) {
+            log.debug("Failed to capture raw LLM request", t);
+        }
+    }
+
+    @Override
+    public void onResponse(@NotNull ChatModelResponseContext responseContext) {
+        if (!enabledSupplier.get()) {
+            return;
+        }
+        try {
+            ChatResponse chatResponse = responseContext.chatResponse();
+            String json = SecretRedactor.redact(RAW_MAPPER.writeValueAsString(chatResponse));
+            publisher.accept(ActivityMessage.builder()
+                    .source(ActivitySource.RAW)
+                    .rawTrafficType(RawTrafficType.RESPONSE)
+                    .summary(summarizeResponse(chatResponse))
+                    .content(json)
+                    .build());
+        } catch (Throwable t) {
+            log.debug("Failed to capture raw LLM response", t);
+        }
+    }
+
+    @Override
+    public void onError(@NotNull ChatModelErrorContext errorContext) {
+        if (!enabledSupplier.get()) {
+            return;
+        }
+        try {
+            Throwable error = errorContext.error();
+            Map<String, Object> errorMap = new LinkedHashMap<>();
+            errorMap.put("errorType", error == null ? "unknown" : error.getClass().getName());
+            errorMap.put("message", error == null ? null : error.getMessage());
+            if (error != null) {
+                List<String> topFrames = new ArrayList<>();
+                StackTraceElement[] stackTrace = error.getStackTrace();
+                for (int i = 0; i < Math.min(STACK_TRACE_FRAME_LIMIT, stackTrace.length); i++) {
+                    topFrames.add(stackTrace[i].toString());
+                }
+                errorMap.put("stackTraceTop", topFrames);
+            }
+            String json = SecretRedactor.redact(RAW_MAPPER.writeValueAsString(errorMap));
+            publisher.accept(ActivityMessage.builder()
+                    .source(ActivitySource.RAW)
+                    .rawTrafficType(RawTrafficType.ERROR)
+                    .summary("ERROR → " + (error == null ? "unknown"
+                            : error.getClass().getSimpleName() + ": " + summarize(error.getMessage())))
+                    .content(json)
+                    .build());
+        } catch (Throwable t) {
+            log.debug("Failed to capture raw LLM error", t);
+        }
+    }
+
+    private static @NotNull String summarizeRequest(@NotNull ChatRequest request) {
+        List<ChatMessage> messages = request.messages();
+        int count = messages == null ? 0 : messages.size();
+        String preview = messages == null || messages.isEmpty() ? "" : previewOf(messages.get(messages.size() - 1));
+        StringBuilder sb = new StringBuilder("REQUEST → ").append(count).append(" message").append(count == 1 ? "" : "s");
+        if (!preview.isEmpty()) {
+            sb.append(": ").append(preview);
+        }
+        return sb.toString();
+    }
+
+    private static @NotNull String summarizeResponse(@NotNull ChatResponse response) {
+        StringBuilder sb = new StringBuilder("RESPONSE");
+        TokenUsage tokenUsage = response.tokenUsage();
+        if (tokenUsage != null) {
+            sb.append(" → tokens in/out: ")
+              .append(tokenUsage.inputTokenCount() == null ? "?" : tokenUsage.inputTokenCount())
+              .append("/")
+              .append(tokenUsage.outputTokenCount() == null ? "?" : tokenUsage.outputTokenCount());
+        }
+        AiMessage aiMessage = response.aiMessage();
+        if (aiMessage != null) {
+            String preview = previewOf(aiMessage);
+            if (!preview.isEmpty()) {
+                sb.append(" — ").append(preview);
+            } else if (aiMessage.hasToolExecutionRequests()) {
+                sb.append(" — ").append(aiMessage.toolExecutionRequests().size()).append(" tool call(s)");
+            }
+        }
+        return sb.toString();
+    }
+
+    private static @NotNull String previewOf(@NotNull ChatMessage message) {
+        String text = null;
+        if (message instanceof SystemMessage systemMessage) {
+            text = systemMessage.text();
+        } else if (message instanceof UserMessage userMessage && userMessage.hasSingleText()) {
+            text = userMessage.singleText();
+        } else if (message instanceof AiMessage aiMessage) {
+            text = aiMessage.text();
+        } else if (message instanceof ToolExecutionResultMessage toolExecutionResultMessage) {
+            text = toolExecutionResultMessage.text();
+        }
+        return text == null ? "" : summarize(text);
+    }
+
+    private static @NotNull String summarize(String text) {
+        if (text == null) {
+            return "";
+        }
+        String oneLine = text.replace('\n', ' ').replace('\r', ' ').trim();
+        return oneLine.length() > SUMMARY_MAX_LEN ? oneLine.substring(0, SUMMARY_MAX_LEN - 1) + "…" : oneLine;
+    }
+
+    private static void publish(@NotNull ActivityMessage message) {
+        ApplicationManager.getApplication().getMessageBus()
+                .syncPublisher(AppTopics.ACTIVITY_LOG_MSG)
+                .onActivityMessage(message);
+    }
+}

--- a/src/main/java/com/devoxx/genie/service/debug/SecretRedactor.java
+++ b/src/main/java/com/devoxx/genie/service/debug/SecretRedactor.java
@@ -4,6 +4,7 @@ import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 /**
@@ -31,9 +32,15 @@ public final class SecretRedactor {
         if (text == null || text.isEmpty()) {
             return text;
         }
-        String result = BEARER_TOKEN.matcher(text).replaceAll(m -> m.group(1) + mask(m.group(2)));
-        result = KNOWN_KEY_SHAPES.matcher(result).replaceAll(m -> mask(m.group(1)));
-        result = JSON_SECRET_FIELD.matcher(result).replaceAll(m -> m.group(1) + mask(m.group(2)) + m.group(3));
+        // quoteReplacement: replaceAll(Function) feeds the produced string through
+        // appendReplacement, so an unquoted '$' or '\' in a matched secret would throw
+        // "Illegal group reference" or corrupt the output.
+        String result = BEARER_TOKEN.matcher(text)
+                .replaceAll(m -> Matcher.quoteReplacement(m.group(1) + mask(m.group(2))));
+        result = KNOWN_KEY_SHAPES.matcher(result)
+                .replaceAll(m -> Matcher.quoteReplacement(mask(m.group(1))));
+        result = JSON_SECRET_FIELD.matcher(result)
+                .replaceAll(m -> Matcher.quoteReplacement(m.group(1) + mask(m.group(2)) + m.group(3)));
         return result;
     }
 

--- a/src/main/java/com/devoxx/genie/service/debug/SecretRedactor.java
+++ b/src/main/java/com/devoxx/genie/service/debug/SecretRedactor.java
@@ -1,0 +1,46 @@
+package com.devoxx.genie.service.debug;
+
+import org.jetbrains.annotations.Contract;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.regex.Pattern;
+
+/**
+ * Masks likely API keys/tokens/secrets in raw LLM request/response payloads before they are
+ * shown in the Activity Log or copied to the clipboard. Best-effort pattern matching, not a
+ * substitute for keeping real secrets out of prompts.
+ */
+public final class SecretRedactor {
+
+    private SecretRedactor() {}
+
+    private static final Pattern BEARER_TOKEN =
+            Pattern.compile("(?i)(bearer\\s+)([A-Za-z0-9\\-_.=]{8,})");
+
+    /** Well-known provider API key prefixes/shapes (OpenAI/Anthropic, AWS, Google, Groq, ...). */
+    private static final Pattern KNOWN_KEY_SHAPES = Pattern.compile(
+            "\\b(sk-ant-[A-Za-z0-9\\-_]{10,}|sk-[A-Za-z0-9\\-_]{16,}|AKIA[0-9A-Z]{16}|AIza[0-9A-Za-z\\-_]{20,}|gsk_[A-Za-z0-9]{16,})\\b");
+
+    /** Any JSON string field whose name looks secret-ish, regardless of value shape. */
+    private static final Pattern JSON_SECRET_FIELD = Pattern.compile(
+            "(?i)(\"(?:api[_-]?key|access[_-]?token|auth[_-]?token|authorization|secret|password|client[_-]?secret)\"\\s*:\\s*\")([^\"]{4,})(\")");
+
+    @Contract("null -> null; !null -> !null")
+    public static @Nullable String redact(@Nullable String text) {
+        if (text == null || text.isEmpty()) {
+            return text;
+        }
+        String result = BEARER_TOKEN.matcher(text).replaceAll(m -> m.group(1) + mask(m.group(2)));
+        result = KNOWN_KEY_SHAPES.matcher(result).replaceAll(m -> mask(m.group(1)));
+        result = JSON_SECRET_FIELD.matcher(result).replaceAll(m -> m.group(1) + mask(m.group(2)) + m.group(3));
+        return result;
+    }
+
+    private static @NotNull String mask(@NotNull String secret) {
+        if (secret.length() <= 8) {
+            return "****";
+        }
+        return secret.substring(0, 4) + "****" + secret.substring(secret.length() - 4);
+    }
+}

--- a/src/main/java/com/devoxx/genie/ui/panel/log/AgentMcpLogPanel.java
+++ b/src/main/java/com/devoxx/genie/ui/panel/log/AgentMcpLogPanel.java
@@ -3,6 +3,7 @@ package com.devoxx.genie.ui.panel.log;
 import com.devoxx.genie.model.activity.ActivityMessage;
 import com.devoxx.genie.model.activity.ActivitySource;
 import com.devoxx.genie.model.agent.AgentType;
+import com.devoxx.genie.model.debug.RawTrafficType;
 import com.devoxx.genie.model.mcp.MCPMessage;
 import com.devoxx.genie.model.rag.RAGLogMessage;
 import com.devoxx.genie.service.activity.ActivityLoggingMessage;
@@ -70,13 +71,14 @@ public class AgentMcpLogPanel extends SimpleToolWindowPanel implements ActivityL
     private static final DateTimeFormatter TIME_FORMATTER = DateTimeFormatter.ofPattern("HH:mm:ss.SSS");
     private static final ObjectMapper JSON_MAPPER = new ObjectMapper().enable(SerializationFeature.INDENT_OUTPUT);
 
-    enum LogSource { MCP, AGENT, RAG }
-    enum LogFilter { ALL, MCP_ONLY, AGENT_ONLY, RAG_ONLY }
+    enum LogSource { MCP, AGENT, RAG, RAW }
+    enum LogFilter { ALL, MCP_ONLY, AGENT_ONLY, RAG_ONLY, RAW_ONLY }
 
     record LogEntry(
         String timestamp,
         LogSource source,
-        AgentType agentType,  // null for MCP entries
+        AgentType agentType,  // null unless source == AGENT
+        RawTrafficType rawTrafficType,  // null unless source == RAW
         String message,
         String clipboardMessage,
         String fullContent
@@ -236,6 +238,7 @@ public class AgentMcpLogPanel extends SimpleToolWindowPanel implements ActivityL
                 case MCP_ONLY   -> "Show MCP Only";
                 case AGENT_ONLY -> "Show Agents Only";
                 case RAG_ONLY   -> "Show RAG Only";
+                case RAW_ONLY   -> "Show Raw Only";
             });
         }
 
@@ -246,6 +249,7 @@ public class AgentMcpLogPanel extends SimpleToolWindowPanel implements ActivityL
             group.add(filterAction("Show MCP Only",     LogFilter.MCP_ONLY));
             group.add(filterAction("Show Agents Only",  LogFilter.AGENT_ONLY));
             group.add(filterAction("Show RAG Only",     LogFilter.RAG_ONLY));
+            group.add(filterAction("Show Raw Only",     LogFilter.RAW_ONLY));
             return group;
         }
 
@@ -276,6 +280,7 @@ public class AgentMcpLogPanel extends SimpleToolWindowPanel implements ActivityL
             case MCP_ONLY -> e.source() == LogSource.MCP;
             case AGENT_ONLY -> e.source() == LogSource.AGENT;
             case RAG_ONLY -> e.source() == LogSource.RAG;
+            case RAW_ONLY -> e.source() == LogSource.RAW;
         };
     }
 
@@ -303,9 +308,23 @@ public class AgentMcpLogPanel extends SimpleToolWindowPanel implements ActivityL
                     LocalDateTime.now().format(TIME_FORMATTER),
                     LogSource.AGENT,
                     message.getAgentType(),
+                    null,
                     displayText,
                     clipboardText,
                     fullContent
+            );
+            addToPending(entry);
+        } else if (message.getSource() == ActivitySource.RAW) {
+            String summary = message.getSummary() != null ? message.getSummary() : "";
+            String content = message.getContent() != null ? message.getContent() : "";
+            LogEntry entry = new LogEntry(
+                    LocalDateTime.now().format(TIME_FORMATTER),
+                    LogSource.RAW,
+                    null,
+                    message.getRawTrafficType(),
+                    summary,
+                    summary,
+                    content
             );
             addToPending(entry);
         } else {
@@ -313,6 +332,7 @@ public class AgentMcpLogPanel extends SimpleToolWindowPanel implements ActivityL
             LogEntry entry = new LogEntry(
                     LocalDateTime.now().format(TIME_FORMATTER),
                     LogSource.MCP,
+                    null,
                     null,
                     content,
                     content,
@@ -341,6 +361,7 @@ public class AgentMcpLogPanel extends SimpleToolWindowPanel implements ActivityL
                 LocalDateTime.now().format(TIME_FORMATTER),
                 LogSource.MCP,
                 null,
+                null,
                 content,
                 content,
                 content
@@ -364,6 +385,7 @@ public class AgentMcpLogPanel extends SimpleToolWindowPanel implements ActivityL
         LogEntry entry = new LogEntry(
                 LocalDateTime.now().format(TIME_FORMATTER),
                 LogSource.RAG,
+                null,
                 null,
                 formatRagRow(message),
                 formatRagForClipboard(message),
@@ -667,6 +689,13 @@ public class AgentMcpLogPanel extends SimpleToolWindowPanel implements ActivityL
                     LightVirtualFile virtualFile = new LightVirtualFile(fileName, content);
                     FileEditorManager.getInstance(project).openFile(virtualFile, true);
                 });
+            } else if (logEntry.source() == LogSource.RAW) {
+                String fileName = "RawLog_" + logEntry.timestamp().replace(":", "").replace(".", "_") + ".json";
+                String finalContent = formatJsonContent(logEntry.fullContent());
+                ApplicationManager.getApplication().invokeLater(() -> {
+                    LightVirtualFile virtualFile = new LightVirtualFile(fileName, finalContent);
+                    FileEditorManager.getInstance(project).openFile(virtualFile, true);
+                });
             } else {
                 String content = logEntry.fullContent();
                 if (content.startsWith("<") || content.startsWith(">")) {
@@ -796,6 +825,7 @@ public class AgentMcpLogPanel extends SimpleToolWindowPanel implements ActivityL
                     case MCP   -> "[MCP] ";
                     case AGENT -> "[AGT] ";
                     case RAG   -> "[RAG] ";
+                    case RAW   -> "[RAW] ";
                 };
                 String badge = currentFilter == LogFilter.ALL ? sourceTag : "";
                 String plain = entry.timestamp() + " " + badge + entry.message();
@@ -840,6 +870,13 @@ public class AgentMcpLogPanel extends SimpleToolWindowPanel implements ActivityL
             if (entry.source() == LogSource.MCP) {
                 if (entry.message().startsWith("<")) return MCP_IN_COLOR;
                 if (entry.message().startsWith(">")) return MCP_OUT_COLOR;
+            }
+            if (entry.source() == LogSource.RAW && entry.rawTrafficType() != null) {
+                return switch (entry.rawTrafficType()) {
+                    case REQUEST  -> MCP_OUT_COLOR;
+                    case RESPONSE -> MCP_IN_COLOR;
+                    case ERROR    -> ERROR_COLOR;
+                };
             }
             return null;
         }

--- a/src/main/java/com/devoxx/genie/ui/settings/DevoxxGenieStateService.java
+++ b/src/main/java/com/devoxx/genie/ui/settings/DevoxxGenieStateService.java
@@ -367,6 +367,12 @@ public final class DevoxxGenieStateService implements PersistentStateComponent<D
     private Boolean agentAutoApproveReadOnly = false;
     private Boolean agentWriteApprovalRequired = true;
     private Boolean agentDebugLogsEnabled = false;
+    /**
+     * When enabled, the full request/response exchanged with the LLM provider (messages, tool
+     * calls, token usage) is captured and shown in the Activity Log panel, with likely secrets
+     * redacted. Opt-in because it can surface complete prompt/response text.
+     */
+    private Boolean rawRequestResponseLoggingEnabled = false;
     private Boolean showToolActivityInChat = false;
     private List<String> disabledAgentTools = new ArrayList<>();
 

--- a/src/main/java/com/devoxx/genie/ui/settings/debug/DebugSettingsComponent.java
+++ b/src/main/java/com/devoxx/genie/ui/settings/debug/DebugSettingsComponent.java
@@ -1,0 +1,72 @@
+package com.devoxx.genie.ui.settings.debug;
+
+import com.devoxx.genie.ui.settings.DevoxxGenieStateService;
+import com.intellij.ui.components.JBCheckBox;
+import com.intellij.ui.components.JBLabel;
+import com.intellij.util.ui.JBUI;
+import com.intellij.util.ui.UIUtil;
+
+import javax.swing.*;
+import java.awt.*;
+
+/**
+ * Settings UI for the "Raw Request/Response" debug viewer (see the Activity Log tool window).
+ */
+public class DebugSettingsComponent {
+
+    private final JPanel panel;
+    private final JBCheckBox rawRequestResponseLoggingCheckBox;
+
+    public DebugSettingsComponent() {
+        DevoxxGenieStateService state = DevoxxGenieStateService.getInstance();
+
+        rawRequestResponseLoggingCheckBox = new JBCheckBox("Enable Raw Request/Response Logging");
+        rawRequestResponseLoggingCheckBox.setSelected(Boolean.TRUE.equals(state.getRawRequestResponseLoggingEnabled()));
+
+        JBLabel description = new JBLabel(
+                "<html><body style='width:480px'>" +
+                        "When enabled, the exact request sent to the LLM provider (messages, tool calls, " +
+                        "model parameters) and the response received (message, tool calls, token usage) are " +
+                        "captured and shown in the <b>Activity Log</b> tool window, filterable to \"Show Raw " +
+                        "Only\". Double-click an entry to open the full JSON, or use \"Copy All\" for bug reports. " +
+                        "Likely API keys and tokens are masked automatically, but the raw prompt and response " +
+                        "text is not — avoid enabling this if your conversations may contain other secrets you " +
+                        "don't want written to the tool window / clipboard." +
+                        "</body></html>");
+        description.setForeground(UIUtil.getContextHelpForeground());
+
+        panel = new JPanel();
+        panel.setLayout(new BoxLayout(panel, BoxLayout.Y_AXIS));
+        panel.setBorder(JBUI.Borders.empty(12));
+
+        rawRequestResponseLoggingCheckBox.setAlignmentX(Component.LEFT_ALIGNMENT);
+        description.setAlignmentX(Component.LEFT_ALIGNMENT);
+
+        panel.add(rawRequestResponseLoggingCheckBox);
+        panel.add(Box.createVerticalStrut(6));
+        panel.add(description);
+        panel.add(Box.createVerticalGlue());
+    }
+
+    public JPanel getPanel() {
+        return panel;
+    }
+
+    public boolean isModified() {
+        return rawRequestResponseLoggingCheckBox.isSelected()
+                != Boolean.TRUE.equals(DevoxxGenieStateService.getInstance().getRawRequestResponseLoggingEnabled());
+    }
+
+    public void apply() {
+        DevoxxGenieStateService.getInstance().setRawRequestResponseLoggingEnabled(rawRequestResponseLoggingCheckBox.isSelected());
+    }
+
+    public void reset() {
+        rawRequestResponseLoggingCheckBox.setSelected(
+                Boolean.TRUE.equals(DevoxxGenieStateService.getInstance().getRawRequestResponseLoggingEnabled()));
+    }
+
+    public boolean isRawRequestResponseLoggingSelected() {
+        return rawRequestResponseLoggingCheckBox.isSelected();
+    }
+}

--- a/src/main/java/com/devoxx/genie/ui/settings/debug/DebugSettingsConfigurable.java
+++ b/src/main/java/com/devoxx/genie/ui/settings/debug/DebugSettingsConfigurable.java
@@ -1,0 +1,67 @@
+package com.devoxx.genie.ui.settings.debug;
+
+import com.intellij.openapi.options.Configurable;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.wm.ToolWindow;
+import com.intellij.openapi.wm.ToolWindowManager;
+import org.jetbrains.annotations.Nls;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import javax.swing.*;
+
+public class DebugSettingsConfigurable implements Configurable {
+
+    private final Project project;
+    private DebugSettingsComponent component;
+
+    public DebugSettingsConfigurable(@NotNull Project project) {
+        this.project = project;
+    }
+
+    @Nls(capitalization = Nls.Capitalization.Title)
+    @Override
+    public String getDisplayName() {
+        return "Debug";
+    }
+
+    @Override
+    public @Nullable JComponent createComponent() {
+        component = new DebugSettingsComponent();
+        return component.getPanel();
+    }
+
+    @Override
+    public boolean isModified() {
+        return component != null && component.isModified();
+    }
+
+    @Override
+    public void apply() {
+        if (component == null) {
+            return;
+        }
+        boolean wasEnabled = component.isRawRequestResponseLoggingSelected();
+        component.apply();
+
+        // Auto-open the Activity Log panel when raw logging is turned on, so users see it start filling.
+        if (wasEnabled) {
+            ToolWindow toolWindow = ToolWindowManager.getInstance(project).getToolWindow("DevoxxGenieActivityLogs");
+            if (toolWindow != null) {
+                toolWindow.show();
+            }
+        }
+    }
+
+    @Override
+    public void reset() {
+        if (component != null) {
+            component.reset();
+        }
+    }
+
+    @Override
+    public void disposeUIResources() {
+        component = null;
+    }
+}

--- a/src/main/java/com/devoxx/genie/ui/settings/debug/DebugSettingsConfigurable.java
+++ b/src/main/java/com/devoxx/genie/ui/settings/debug/DebugSettingsConfigurable.java
@@ -41,11 +41,11 @@ public class DebugSettingsConfigurable implements Configurable {
         if (component == null) {
             return;
         }
-        boolean wasEnabled = component.isRawRequestResponseLoggingSelected();
+        boolean nowEnabled = component.isRawRequestResponseLoggingSelected();
         component.apply();
 
         // Auto-open the Activity Log panel when raw logging is turned on, so users see it start filling.
-        if (wasEnabled) {
+        if (nowEnabled) {
             ToolWindow toolWindow = ToolWindowManager.getInstance(project).getToolWindow("DevoxxGenieActivityLogs");
             if (toolWindow != null) {
                 toolWindow.show();

--- a/src/main/kotlin/com/devoxx/genie/ui/compose/viewmodel/ConversationViewModel.kt
+++ b/src/main/kotlin/com/devoxx/genie/ui/compose/viewmodel/ConversationViewModel.kt
@@ -259,6 +259,10 @@ class ConversationViewModel(
     fun onActivityMessage(message: ActivityMessage) {
         if (activityDeactivated.get()) return
 
+        // Raw request/response captures carry the full LLM payload JSON as content — they
+        // belong to the Activity Log tool window only, never to the in-chat timeline.
+        if (message.source == ActivitySource.RAW) return
+
         val msgId = activeMessageId ?: return
 
         // Agent loop limit reached — surface a durable terminal notice in the chat

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -717,6 +717,11 @@
                              instance="com.devoxx.genie.ui.settings.agent.AgentSettingsConfigurable"
                              displayName="Agent Mode (BETA)"/>
 
+        <projectConfigurable id="com.devoxx.genie.debugsettings"
+                             parentId="com.devoxx.genie.DevoxxGenie"
+                             instance="com.devoxx.genie.ui.settings.debug.DebugSettingsConfigurable"
+                             displayName="Debug"/>
+
         <projectConfigurable id="com.devoxx.genie.WebSearch"
                              parentId="com.devoxx.genie.DevoxxGenie"
                              instance="com.devoxx.genie.ui.settings.websearch.WebSearchProvidersConfigurable"

--- a/src/test/java/com/devoxx/genie/service/debug/SecretRedactorTest.java
+++ b/src/test/java/com/devoxx/genie/service/debug/SecretRedactorTest.java
@@ -57,4 +57,23 @@ class SecretRedactorTest {
         assertThat(redacted).contains("****");
         assertThat(redacted).doesNotContain("ab12");
     }
+
+    @Test
+    void redact_secretContainingDollarSign_doesNotThrowIllegalGroupReference() {
+        // Matcher.replaceAll(Function) feeds the produced string through appendReplacement,
+        // which interprets '$' as a group reference unless quoted. A secret like "pa$$word..."
+        // used to throw IllegalArgumentException, silently dropping the log entry.
+        String text = "{\"password\":\"pa$$word12345\"}";
+        String redacted = SecretRedactor.redact(text);
+        assertThat(redacted).isEqualTo("{\"password\":\"pa$$****2345\"}");
+    }
+
+    @Test
+    void redact_secretContainingBackslash_isMaskedWithoutCorruption() {
+        // Unquoted '\' in the replacement is treated as an escape by appendReplacement and
+        // used to be silently swallowed from the masked output.
+        String text = "{\"apiKey\":\"a\\bcdefghijklmn\"}";
+        String redacted = SecretRedactor.redact(text);
+        assertThat(redacted).isEqualTo("{\"apiKey\":\"a\\bc****klmn\"}");
+    }
 }

--- a/src/test/java/com/devoxx/genie/service/debug/SecretRedactorTest.java
+++ b/src/test/java/com/devoxx/genie/service/debug/SecretRedactorTest.java
@@ -1,0 +1,60 @@
+package com.devoxx.genie.service.debug;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SecretRedactorTest {
+
+    @Test
+    void redact_nullOrEmpty_returnsAsIs() {
+        assertThat(SecretRedactor.redact(null)).isNull();
+        assertThat(SecretRedactor.redact("")).isEmpty();
+    }
+
+    @Test
+    void redact_plainTextWithoutSecrets_isUnchanged() {
+        String text = "{\"role\":\"user\",\"content\":\"Explain this Java method\"}";
+        assertThat(SecretRedactor.redact(text)).isEqualTo(text);
+    }
+
+    @Test
+    void redact_bearerToken_masksTokenKeepsPrefix() {
+        String text = "Authorization header: Bearer sk-abcdef1234567890ABCDEF";
+        String redacted = SecretRedactor.redact(text);
+        assertThat(redacted).contains("Bearer ");
+        assertThat(redacted).doesNotContain("sk-abcdef1234567890ABCDEF");
+        assertThat(redacted).contains("****");
+    }
+
+    @Test
+    void redact_openAiStyleKey_isMasked() {
+        String text = "key=sk-proj-abcdefghijklmnopqrstuvwxyz1234567890";
+        String redacted = SecretRedactor.redact(text);
+        assertThat(redacted).doesNotContain("sk-proj-abcdefghijklmnopqrstuvwxyz1234567890");
+        assertThat(redacted).contains("sk-p").contains("7890");
+    }
+
+    @Test
+    void redact_awsAccessKey_isMasked() {
+        String text = "aws_access_key_id = AKIAABCDEFGHIJKLMNOP";
+        String redacted = SecretRedactor.redact(text);
+        assertThat(redacted).doesNotContain("AKIAABCDEFGHIJKLMNOP");
+    }
+
+    @Test
+    void redact_jsonSecretField_masksValueOnly() {
+        String text = "{\"apiKey\":\"abcdefghijklmnop\",\"model\":\"gpt-4o\"}";
+        String redacted = SecretRedactor.redact(text);
+        assertThat(redacted).contains("\"apiKey\":\"abcd****mnop\"");
+        assertThat(redacted).contains("\"model\":\"gpt-4o\"");
+    }
+
+    @Test
+    void redact_shortSecret_masksCompletely() {
+        String text = "\"password\":\"ab12\"";
+        String redacted = SecretRedactor.redact(text);
+        assertThat(redacted).contains("****");
+        assertThat(redacted).doesNotContain("ab12");
+    }
+}


### PR DESCRIPTION
Adds an opt-in "Enable Raw Request/Response Logging" setting (Settings ->
DevoxxGenie -> Debug, off by default) that captures the full request and
response exchanged with the LLM provider - messages, tool calls, token
usage - and shows it in the Activity Log tool window, filterable to
"Show Raw Only" with double-click-to-JSON and copy-all for bug reports.

The capture listener hooks into ChatModelFactory.getListener(), the
existing choke point every provider factory already attaches listeners
through. Provider API keys are never in scope: every factory sets
.apiKey(...) on the model builder at construction time, so it lives in
the HTTP client, not in the ChatRequest/ChatResponse objects being
serialized. SecretRedactor additionally masks Bearer tokens, known key
shapes (sk-, sk-ant-, AKIA, AIza, gsk_) and secret-looking JSON fields
as defense-in-depth.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01WucmgwC2KW4975qz73YvRS