### PR TITLE
fix: honour Custom OpenAI context window instead of the 4096 default

### DIFF
--- a/src/main/java/com/devoxx/genie/chatmodel/local/customopenai/CustomOpenAIChatModelFactory.java
+++ b/src/main/java/com/devoxx/genie/chatmodel/local/customopenai/CustomOpenAIChatModelFactory.java
@@ -6,6 +6,7 @@ import com.devoxx.genie.chatmodel.local.LocalLLMProviderUtil;
 import com.devoxx.genie.model.CustomChatModel;
 import com.devoxx.genie.model.LanguageModel;
 import com.devoxx.genie.model.enumarations.ModelProvider;
+import com.devoxx.genie.model.gpt4all.Model;
 import com.devoxx.genie.model.gpt4all.ResponseDTO;
 import com.devoxx.genie.ui.settings.DevoxxGenieStateService;
 import com.intellij.openapi.diagnostic.Logger;
@@ -45,11 +46,14 @@ public class CustomOpenAIChatModelFactory implements ChatModelFactory {
             .build();
 
     /**
-     * Cached result of the last {@link #getModels()} probe. {@code null} means "not yet fetched".
+     * Model ids returned by the last {@link #getModels()} probe. {@code null} means "not yet fetched".
      * Cleared by {@link #resetModels()} (the Refresh button). Caching prevents a network round-trip
      * on every provider selection, which otherwise re-probed the endpoint each time.
+     * <p>
+     * Only the ids are cached, never the assembled {@link LanguageModel}s: context window and costs
+     * come from settings, so caching built models froze whatever those settings were at first probe.
      */
-    private volatile List<LanguageModel> cachedModels = null;
+    private volatile List<String> cachedModelIds = null;
 
     @Override
     public ChatModel createChatModel(@NotNull CustomChatModel customChatModel) {
@@ -132,27 +136,45 @@ public class CustomOpenAIChatModelFactory implements ChatModelFactory {
      */
     @Override
     public List<LanguageModel> getModels() {
-        List<LanguageModel> cached = cachedModels;
-        if (cached != null) {
-            return cached;
+        List<String> cached = cachedModelIds;
+        if (cached == null) {
+            cached = fetchModelIdsFromServer();
+            // Only cache a successful, non-empty probe. An empty result usually means the endpoint
+            // was momentarily unreachable/slow (e.g. right after IDE startup); caching it would make
+            // the model list stick empty until a manual Refresh. Leaving it uncached lets the next
+            // (background, bounded) probe recover once the endpoint is available.
+            if (!cached.isEmpty()) {
+                cachedModelIds = cached;
+            }
         }
-        List<LanguageModel> models = fetchModelsFromServer();
-        // Only cache a successful, non-empty probe. An empty result usually means the endpoint
-        // was momentarily unreachable/slow (e.g. right after IDE startup); caching it would make
-        // the model list stick empty until a manual Refresh. Leaving it uncached lets the next
-        // (background, bounded) probe recover once the endpoint is available.
-        if (!models.isEmpty()) {
-            cachedModels = models;
-        }
-        return models;
+        return cached.stream()
+                .map(CustomOpenAIChatModelFactory::toLanguageModel)
+                .collect(Collectors.toList());
     }
 
     @Override
     public void resetModels() {
-        cachedModels = null;
+        cachedModelIds = null;
     }
 
-    private List<LanguageModel> fetchModelsFromServer() {
+    /**
+     * Build a {@link LanguageModel} for a model id using the <em>current</em> settings, so a context
+     * window or cost edited in Settings takes effect without re-probing the endpoint.
+     */
+    private static @NotNull LanguageModel toLanguageModel(@NotNull String modelId) {
+        DevoxxGenieStateService state = DevoxxGenieStateService.getInstance();
+        return LanguageModel.builder()
+                .provider(ModelProvider.CustomOpenAI)
+                .modelName(modelId)
+                .displayName(modelId)
+                .inputCost(CustomOpenAICost.resolve(state.getCustomOpenAIInputCost()))
+                .outputCost(CustomOpenAICost.resolve(state.getCustomOpenAIOutputCost()))
+                .inputMaxTokens(CustomOpenAIContextWindow.resolve(state.getCustomOpenAIContextWindow()))
+                .apiKeyUsed(state.isCustomOpenAIApiKeyEnabled())
+                .build();
+    }
+
+    private List<String> fetchModelIdsFromServer() {
         DevoxxGenieStateService state = DevoxxGenieStateService.getInstance();
         String baseUrl = state.getCustomOpenAIUrl();
         if (baseUrl == null || baseUrl.isBlank()) {
@@ -166,15 +188,7 @@ public class CustomOpenAIChatModelFactory implements ChatModelFactory {
             }
             return response.getData().stream()
                     .filter(model -> model != null && model.getId() != null && !model.getId().isBlank())
-                    .map(model -> LanguageModel.builder()
-                            .provider(ModelProvider.CustomOpenAI)
-                            .modelName(model.getId())
-                            .displayName(model.getId())
-                            .inputCost(CustomOpenAICost.resolve(state.getCustomOpenAIInputCost()))
-                            .outputCost(CustomOpenAICost.resolve(state.getCustomOpenAIOutputCost()))
-                            .inputMaxTokens(CustomOpenAIContextWindow.resolve(state.getCustomOpenAIContextWindow()))
-                            .apiKeyUsed(state.isCustomOpenAIApiKeyEnabled())
-                            .build())
+                    .map(Model::getId)
                     .collect(Collectors.toList());
         } catch (Exception e) {
             // Degrade gracefully: a missing/empty/failing models endpoint must

--- a/src/main/java/com/devoxx/genie/ui/panel/LlmProviderPanel.java
+++ b/src/main/java/com/devoxx/genie/ui/panel/LlmProviderPanel.java
@@ -2,7 +2,10 @@ package com.devoxx.genie.ui.panel;
 
 import com.devoxx.genie.chatmodel.ChatModelFactory;
 import com.devoxx.genie.chatmodel.ChatModelFactoryProvider;
+import com.devoxx.genie.chatmodel.local.customopenai.CustomOpenAIContextWindow;
+import com.devoxx.genie.chatmodel.local.customopenai.CustomOpenAICost;
 import com.devoxx.genie.chatmodel.local.exo.ExoChatModelFactory;
+import com.devoxx.genie.util.LanguageModelSelectionUtil;
 import com.devoxx.genie.model.Constant;
 import com.devoxx.genie.model.LanguageModel;
 import com.devoxx.genie.model.enumarations.ModelProvider;
@@ -449,14 +452,55 @@ public class LlmProviderPanel extends JBPanel<LlmProviderPanel> implements LLMSe
         if (provider == null) {
             return;
         }
-        LanguageModel restored = LanguageModel.builder()
-                .provider(provider)
-                .modelName(lastSelectedLanguageModel)
-                .displayName(lastSelectedLanguageModel)
-                .build();
+        LanguageModel restored = synthesizePersistedModel(provider, lastSelectedLanguageModel);
         modelNameComboBox.addItem(restored);
         modelNameComboBox.setSelectedItem(restored);
         modelNameComboBox.setVisible(true);
+    }
+
+    /**
+     * Build the stand-in {@link LanguageModel} for a persisted model the provider did not return.
+     *
+     * <p>For Custom OpenAI the context window and costs are settings, not properties of the
+     * {@code /models} response, so they are resolved here as well. Leaving the context window at 0
+     * hid the conversation context indicator entirely for users whose endpoint does not enumerate
+     * their configured model.</p>
+     */
+    static @NotNull LanguageModel synthesizePersistedModel(@NotNull ModelProvider provider,
+                                                           String modelName) {
+        LanguageModel.LanguageModelBuilder builder = LanguageModel.builder()
+                .provider(provider)
+                .modelName(modelName)
+                .displayName(modelName);
+        if (provider == ModelProvider.CustomOpenAI) {
+            DevoxxGenieStateService state = DevoxxGenieStateService.getInstance();
+            builder.inputCost(CustomOpenAICost.resolve(state.getCustomOpenAIInputCost()))
+                    .outputCost(CustomOpenAICost.resolve(state.getCustomOpenAIOutputCost()))
+                    .inputMaxTokens(CustomOpenAIContextWindow.resolve(state.getCustomOpenAIContextWindow()))
+                    .apiKeyUsed(state.isCustomOpenAIApiKeyEnabled());
+        }
+        return builder.build();
+    }
+
+    /**
+     * Re-select {@code previous} after the model combo has been repopulated (e.g. once settings
+     * were applied). Matching is by model name, because the refreshed models carry the settings
+     * just applied and therefore no longer {@code equals()} the instance that was selected before.
+     *
+     * <p>When the provider no longer offers the model it is re-added for Custom OpenAI, whose
+     * {@code /models} endpoint need not enumerate the configured model; for other providers the
+     * model genuinely disappeared, so the refreshed list's first entry stays selected.</p>
+     */
+    public void reselectModel(@Nullable LanguageModel previous) {
+        if (previous == null || LanguageModelSelectionUtil.reselectByModelName(modelNameComboBox, previous)) {
+            return;
+        }
+        ModelProvider provider = (ModelProvider) modelProviderComboBox.getSelectedItem();
+        if (provider == ModelProvider.CustomOpenAI && previous.getModelName() != null) {
+            LanguageModel restored = synthesizePersistedModel(provider, previous.getModelName());
+            modelNameComboBox.addItem(restored);
+            modelNameComboBox.setSelectedItem(restored);
+        }
     }
 
     /**

--- a/src/main/java/com/devoxx/genie/ui/window/DevoxxGenieToolWindowContent.java
+++ b/src/main/java/com/devoxx/genie/ui/window/DevoxxGenieToolWindowContent.java
@@ -250,11 +250,11 @@ public class DevoxxGenieToolWindowContent implements SettingsChangeListener, Glo
 
         if (currentProvider != null) {
             // Model loading is asynchronous, so re-select the current model and lift the
-            // tracking suppression only once the combo has actually been repopulated.
+            // tracking suppression only once the combo has actually been repopulated. The
+            // repopulated models carry the settings just applied (e.g. a new Custom OpenAI context
+            // window), so re-selection matches on the model name rather than on value equality.
             llmProviderPanel.updateModelNamesComboBox(currentProvider.getName(), () -> {
-                if (currentModel != null) {
-                    llmProviderPanel.getModelNameComboBox().setSelectedItem(currentModel);
-                }
+                llmProviderPanel.reselectModel(currentModel);
                 suppressModelSelectionTracking = false;
             });
         } else {

--- a/src/main/java/com/devoxx/genie/util/LanguageModelSelectionUtil.java
+++ b/src/main/java/com/devoxx/genie/util/LanguageModelSelectionUtil.java
@@ -1,0 +1,44 @@
+package com.devoxx.genie.util;
+
+import com.devoxx.genie.model.LanguageModel;
+import org.jetbrains.annotations.Nullable;
+
+import javax.swing.JComboBox;
+
+/**
+ * Helpers for restoring a model selection in a combo box that has just been repopulated.
+ */
+public final class LanguageModelSelectionUtil {
+
+    private LanguageModelSelectionUtil() {
+    }
+
+    /**
+     * Re-select {@code previous} in {@code comboBox} by matching on the model name.
+     *
+     * <p>{@link LanguageModel} is a value type whose {@code equals()} covers the settings-derived
+     * fields (context window, costs). Once those settings change, the previously selected instance
+     * no longer equals its refreshed counterpart in the repopulated list, and
+     * {@code JComboBox.setSelectedItem()} rejects an item absent from its model — leaving the
+     * selection on whichever model happened to be added first. Matching on the name instead keeps
+     * the user's model selected while adopting the refreshed values.</p>
+     *
+     * @return {@code true} when a model with the same name was found and selected; {@code false}
+     * when the name is absent, in which case the current selection is left untouched and the
+     * caller decides how to preserve the previous model.
+     */
+    public static boolean reselectByModelName(@Nullable JComboBox<LanguageModel> comboBox,
+                                              @Nullable LanguageModel previous) {
+        if (comboBox == null || previous == null || previous.getModelName() == null) {
+            return false;
+        }
+        for (int i = 0; i < comboBox.getItemCount(); i++) {
+            LanguageModel item = comboBox.getItemAt(i);
+            if (item != null && previous.getModelName().equals(item.getModelName())) {
+                comboBox.setSelectedIndex(i);
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/src/test/java/com/devoxx/genie/chatmodel/local/customopenai/CustomOpenAIChatModelFactoryTest.java
+++ b/src/test/java/com/devoxx/genie/chatmodel/local/customopenai/CustomOpenAIChatModelFactoryTest.java
@@ -236,6 +236,65 @@ class CustomOpenAIChatModelFactoryTest {
         }
     }
 
+    @Test
+    void getModelsReflectsContextWindowChangedAfterFirstProbe() {
+        // Regression: the factory used to cache fully-built LanguageModel objects, so the
+        // context window configured in Settings after the first probe never reached the model.
+        // The conversation footer then kept showing the 4096 default as the denominator.
+        when(mockState.getCustomOpenAIUrl()).thenReturn("http://localhost:8080/v1/");
+        when(mockState.getCustomOpenAIContextWindow()).thenReturn(null);
+
+        try (MockedStatic<LocalLLMProviderUtil> util = Mockito.mockStatic(LocalLLMProviderUtil.class)) {
+            util.when(() -> LocalLLMProviderUtil.getModelsFromUrl(
+                            eq("http://localhost:8080/v1/models"), eq(ResponseDTO.class), any(OkHttpClient.class)))
+                    .thenReturn(buildResponse("model-a"));
+
+            CustomOpenAIChatModelFactory factory = new CustomOpenAIChatModelFactory();
+
+            assertThat(factory.getModels())
+                    .extracting(LanguageModel::getInputMaxTokens)
+                    .containsExactly(CustomOpenAIContextWindow.DEFAULT_CONTEXT_WINDOW);
+
+            // User sets the real context window in Settings -> Tools -> DevoxxGenie -> LLM Providers.
+            when(mockState.getCustomOpenAIContextWindow()).thenReturn(262_000);
+
+            assertThat(factory.getModels())
+                    .extracting(LanguageModel::getInputMaxTokens)
+                    .containsExactly(262_000);
+
+            // Still a single network probe: the settings-derived fields are rebuilt, not re-fetched.
+            util.verify(() -> LocalLLMProviderUtil.getModelsFromUrl(
+                    eq("http://localhost:8080/v1/models"), eq(ResponseDTO.class), any(OkHttpClient.class)), times(1));
+        }
+    }
+
+    @Test
+    void getModelsReflectsCostsChangedAfterFirstProbe() {
+        // Same staleness applied to the cost fields, which feed the cost estimate in the footer.
+        when(mockState.getCustomOpenAIUrl()).thenReturn("http://localhost:8080/v1/");
+        when(mockState.getCustomOpenAIInputCost()).thenReturn(null);
+        when(mockState.getCustomOpenAIOutputCost()).thenReturn(null);
+
+        try (MockedStatic<LocalLLMProviderUtil> util = Mockito.mockStatic(LocalLLMProviderUtil.class)) {
+            util.when(() -> LocalLLMProviderUtil.getModelsFromUrl(
+                            eq("http://localhost:8080/v1/models"), eq(ResponseDTO.class), any(OkHttpClient.class)))
+                    .thenReturn(buildResponse("model-a"));
+
+            CustomOpenAIChatModelFactory factory = new CustomOpenAIChatModelFactory();
+            factory.getModels();
+
+            when(mockState.getCustomOpenAIInputCost()).thenReturn(1.5);
+            when(mockState.getCustomOpenAIOutputCost()).thenReturn(2.5);
+
+            assertThat(factory.getModels())
+                    .singleElement()
+                    .satisfies(model -> {
+                        assertThat(model.getInputCost()).isEqualTo(1.5);
+                        assertThat(model.getOutputCost()).isEqualTo(2.5);
+                    });
+        }
+    }
+
     private static ResponseDTO buildResponse(String... modelIds) {
         ResponseDTO dto = new ResponseDTO();
         dto.setData(java.util.Arrays.stream(modelIds).map(id -> {

--- a/src/test/java/com/devoxx/genie/ui/panel/LlmProviderPanelTest.java
+++ b/src/test/java/com/devoxx/genie/ui/panel/LlmProviderPanelTest.java
@@ -2,6 +2,7 @@ package com.devoxx.genie.ui.panel;
 
 import com.devoxx.genie.chatmodel.ChatModelFactory;
 import com.devoxx.genie.chatmodel.ChatModelFactoryProvider;
+import com.devoxx.genie.chatmodel.local.customopenai.CustomOpenAIContextWindow;
 import com.devoxx.genie.model.LanguageModel;
 import com.devoxx.genie.model.enumarations.ModelProvider;
 import com.devoxx.genie.service.LLMProviderService;
@@ -639,5 +640,104 @@ class LlmProviderPanelTest {
 
         ComboBox<LanguageModel> modelComboBox = panel.getModelNameComboBox();
         assertThat(modelComboBox.getItemCount()).isEqualTo(1);
+    }
+
+    @Test
+    void reselectModelKeepsTheUserSelectionAfterAContextWindowChange() {
+        // End-to-end shape of the reported bug: the user selected the second model, then raised the
+        // Custom OpenAI context window. Applying settings repopulates the combo with refreshed
+        // models; the previously selected instance still carries the old 4096 window, so it no
+        // longer equals its counterpart. Selection must stay on the user's model, with 262000.
+        when(stateService.isCustomOpenAIUrlEnabled()).thenReturn(true);
+        when(stateService.getSelectedProvider("test-hash")).thenReturn("CustomOpenAI");
+        when(llmProviderService.getAvailableModelProviders()).thenReturn(List.of(ModelProvider.CustomOpenAI));
+
+        ChatModelFactory factory = mock(ChatModelFactory.class);
+        when(factory.getModels()).thenReturn(List.of(
+                LanguageModel.builder().provider(ModelProvider.CustomOpenAI)
+                        .modelName("model-a").displayName("model-a").inputMaxTokens(262_000).build(),
+                LanguageModel.builder().provider(ModelProvider.CustomOpenAI)
+                        .modelName("model-b").displayName("model-b").inputMaxTokens(262_000).build()));
+        factoryProviderMockedStatic.when(() -> ChatModelFactoryProvider.getFactoryByProvider("CustomOpenAI"))
+                .thenReturn(Optional.of(factory));
+
+        LlmProviderPanel panel = new LlmProviderPanel(project);
+
+        LanguageModel staleSelection = LanguageModel.builder().provider(ModelProvider.CustomOpenAI)
+                .modelName("model-b").displayName("model-b").inputMaxTokens(4096).build();
+
+        panel.reselectModel(staleSelection);
+
+        LanguageModel selected = (LanguageModel) panel.getModelNameComboBox().getSelectedItem();
+        assertThat(selected).isNotNull();
+        assertThat(selected.getModelName()).isEqualTo("model-b");
+        assertThat(selected.getInputMaxTokens()).isEqualTo(262_000);
+    }
+
+    @Test
+    void reselectModelReAddsACustomOpenAIModelTheEndpointDoesNotEnumerate() {
+        when(stateService.isCustomOpenAIUrlEnabled()).thenReturn(true);
+        when(stateService.getSelectedProvider("test-hash")).thenReturn("CustomOpenAI");
+        when(stateService.getCustomOpenAIContextWindow()).thenReturn(262_000);
+        when(llmProviderService.getAvailableModelProviders()).thenReturn(List.of(ModelProvider.CustomOpenAI));
+
+        ChatModelFactory factory = mock(ChatModelFactory.class);
+        when(factory.getModels()).thenReturn(List.of(
+                LanguageModel.builder().provider(ModelProvider.CustomOpenAI)
+                        .modelName("model-a").displayName("model-a").inputMaxTokens(262_000).build()));
+        factoryProviderMockedStatic.when(() -> ChatModelFactoryProvider.getFactoryByProvider("CustomOpenAI"))
+                .thenReturn(Optional.of(factory));
+
+        LlmProviderPanel panel = new LlmProviderPanel(project);
+
+        LanguageModel privateModel = LanguageModel.builder().provider(ModelProvider.CustomOpenAI)
+                .modelName("private-model").displayName("private-model").inputMaxTokens(4096).build();
+
+        panel.reselectModel(privateModel);
+
+        LanguageModel selected = (LanguageModel) panel.getModelNameComboBox().getSelectedItem();
+        assertThat(selected).isNotNull();
+        assertThat(selected.getModelName()).isEqualTo("private-model");
+        assertThat(selected.getInputMaxTokens()).isEqualTo(262_000);
+    }
+
+    @Test
+    void synthesizedCustomOpenAIModelCarriesTheConfiguredContextWindow() {
+        // A Custom OpenAI endpoint need not enumerate the configured model, in which case the
+        // persisted selection is synthesised. It previously defaulted inputMaxTokens to 0, which
+        // hid the conversation context indicator instead of using the configured window.
+        when(stateService.getCustomOpenAIContextWindow()).thenReturn(262_000);
+        when(stateService.getCustomOpenAIInputCost()).thenReturn(1.5);
+        when(stateService.getCustomOpenAIOutputCost()).thenReturn(2.5);
+
+        LanguageModel restored =
+                LlmProviderPanel.synthesizePersistedModel(ModelProvider.CustomOpenAI, "private-model");
+
+        assertThat(restored.getModelName()).isEqualTo("private-model");
+        assertThat(restored.getInputMaxTokens()).isEqualTo(262_000);
+        assertThat(restored.getInputCost()).isEqualTo(1.5);
+        assertThat(restored.getOutputCost()).isEqualTo(2.5);
+    }
+
+    @Test
+    void synthesizedCustomOpenAIModelFallsBackToTheDefaultContextWindow() {
+        when(stateService.getCustomOpenAIContextWindow()).thenReturn(null);
+
+        LanguageModel restored =
+                LlmProviderPanel.synthesizePersistedModel(ModelProvider.CustomOpenAI, "private-model");
+
+        assertThat(restored.getInputMaxTokens()).isEqualTo(CustomOpenAIContextWindow.DEFAULT_CONTEXT_WINDOW);
+    }
+
+    @Test
+    void synthesizedModelForOtherProvidersIsUnchanged() {
+        // Only Custom OpenAI derives its window from settings; other providers keep the minimal
+        // stand-in so no bogus window is invented for them.
+        LanguageModel restored =
+                LlmProviderPanel.synthesizePersistedModel(ModelProvider.Ollama, "llama3");
+
+        assertThat(restored.getProvider()).isEqualTo(ModelProvider.Ollama);
+        assertThat(restored.getModelName()).isEqualTo("llama3");
+        assertThat(restored.getInputMaxTokens()).isZero();
     }
 }

--- a/src/test/java/com/devoxx/genie/util/LanguageModelSelectionUtilTest.java
+++ b/src/test/java/com/devoxx/genie/util/LanguageModelSelectionUtilTest.java
@@ -1,0 +1,86 @@
+package com.devoxx.genie.util;
+
+import com.devoxx.genie.model.LanguageModel;
+import com.devoxx.genie.model.enumarations.ModelProvider;
+import org.junit.jupiter.api.Test;
+
+import javax.swing.JComboBox;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class LanguageModelSelectionUtilTest {
+
+    private static LanguageModel model(String name, int inputMaxTokens) {
+        return LanguageModel.builder()
+                .provider(ModelProvider.CustomOpenAI)
+                .modelName(name)
+                .displayName(name)
+                .inputMaxTokens(inputMaxTokens)
+                .build();
+    }
+
+    @Test
+    void reselectKeepsTheUserModelAndPicksUpTheRefreshedContextWindow() {
+        // Regression: after the Custom OpenAI context window changed, the settings-changed handler
+        // re-selected the *previously selected* LanguageModel instance. LanguageModel is a Lombok
+        // @Data value type whose equals() covers inputMaxTokens, so the stale instance no longer
+        // equals its refreshed counterpart and the selection silently jumped to the first model.
+        LanguageModel stale = model("model-b", 4096);
+
+        JComboBox<LanguageModel> comboBox = new JComboBox<>();
+        comboBox.addItem(model("model-a", 262_000));
+        comboBox.addItem(model("model-b", 262_000));
+
+        assertThat(LanguageModelSelectionUtil.reselectByModelName(comboBox, stale)).isTrue();
+
+        LanguageModel selected = (LanguageModel) comboBox.getSelectedItem();
+        assertThat(selected).isNotNull();
+        assertThat(selected.getModelName()).isEqualTo("model-b");
+        assertThat(selected.getInputMaxTokens()).isEqualTo(262_000);
+    }
+
+    @Test
+    void plainSetSelectedItemSilentlyDropsTheStaleSelection() {
+        // Documents the Swing behaviour the fix works around: a non-editable JComboBox rejects a
+        // setSelectedItem() argument that is absent from its model, so the stale instance is
+        // discarded and the auto-selected first model stays selected.
+        LanguageModel stale = model("model-b", 4096);
+
+        JComboBox<LanguageModel> comboBox = new JComboBox<>();
+        comboBox.addItem(model("model-a", 262_000));
+        comboBox.addItem(model("model-b", 262_000));
+        comboBox.setSelectedItem(stale);
+
+        LanguageModel selected = (LanguageModel) comboBox.getSelectedItem();
+        assertThat(selected).isNotNull();
+        assertThat(selected.getModelName()).isEqualTo("model-a");
+    }
+
+    @Test
+    void reselectReportsNoMatchAndLeavesSelectionWhenTheNameIsAbsent() {
+        // Custom OpenAI endpoints do not always enumerate the configured model. The util reports
+        // the miss so the caller can re-add the model rather than silently swapping it.
+        LanguageModel previous = model("private-model", 262_000);
+
+        JComboBox<LanguageModel> comboBox = new JComboBox<>();
+        comboBox.addItem(model("model-a", 262_000));
+
+        assertThat(LanguageModelSelectionUtil.reselectByModelName(comboBox, previous)).isFalse();
+
+        LanguageModel selected = (LanguageModel) comboBox.getSelectedItem();
+        assertThat(selected).isNotNull();
+        assertThat(selected.getModelName()).isEqualTo("model-a");
+    }
+
+    @Test
+    void reselectReportsNoMatchWhenPreviousIsNull() {
+        JComboBox<LanguageModel> comboBox = new JComboBox<>();
+        comboBox.addItem(model("model-a", 262_000));
+
+        assertThat(LanguageModelSelectionUtil.reselectByModelName(comboBox, null)).isFalse();
+
+        LanguageModel selected = (LanguageModel) comboBox.getSelectedItem();
+        assertThat(selected).isNotNull();
+        assertThat(selected.getModelName()).isEqualTo("model-a");
+    }
+}


### PR DESCRIPTION
## Problem

Setting **Custom OpenAI Context Window** to e.g. `262000` had no effect: the conversation footer kept reporting a 4K window and drove the usage bar red (`Context window: 5K / 4K (133%)`).

## Root cause

Three distinct defects, all on the Custom OpenAI path:

1. **`CustomOpenAIChatModelFactory` cached fully-built `LanguageModel` objects.** Their `inputMaxTokens` / `inputCost` / `outputCost` are *settings*, not properties of the `/models` response, so the first probe froze whatever the settings were at that moment — the 4096 default on a fresh install. Nothing invalidated the cache when the settings later changed. The footer denominator reads straight from this object (`ActionButtonsPanel.onNewConversation()` → `chatMessageContext.getLanguageModel().getInputMaxTokens()`).

2. **Re-selection after Apply silently changed the user's model.** Applying settings repopulates the model combo, then `DevoxxGenieToolWindowContent` re-selected the *previously selected instance*. `LanguageModel` is a Lombok `@Data` value type whose `equals()` covers `inputMaxTokens`, so the stale instance no longer matched its refreshed counterpart — and a non-editable `JComboBox` **rejects** a `setSelectedItem()` argument absent from its model, leaving the user on whichever model sorted first.

3. **The persisted-model restore path synthesised a model with `inputMaxTokens = 0`.** For Custom OpenAI, whose `/models` endpoint need not enumerate the configured model, this hid the context indicator entirely.

## Fix

1. Cache only the model **ids**; rebuild the settings-derived fields on every `getModels()` call. The network probe still runs exactly once (the existing freeze-regression test pins this).
2. Re-select by **model name** (`LanguageModelSelectionUtil.reselectByModelName`) rather than value equality; re-add the model for Custom OpenAI when the endpoint does not enumerate it.
3. Resolve the window and costs in the synthesised restore model too.

## Tests

TDD — tests written first, and the two behavioural fixes were confirmed to fail against the old code before being restored (so they are not tautological).

- `CustomOpenAIChatModelFactoryTest` — context window and costs changed after the first probe are reflected, with still a single probe.
- `LanguageModelSelectionUtilTest` — includes a test documenting the counter-intuitive `JComboBox.setSelectedItem()` rejection behaviour.
- `LlmProviderPanelTest` — end-to-end shape of the report: selection survives a context-window change and carries the new window; Custom OpenAI model absent from `/models` is re-added.

Full suite green (`./gradlew test`).

## Verification note

Verified through the test suite, not by driving the IDE. `NvidiaChatModelFactory` caches its model list the same way; its cached fields are not settings-derived today so it is not currently buggy, but it is the same shape — left untouched to keep this change scoped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)