### PR TITLE
fix(debug): attach raw request/response listener to Ollama streaming, Mistral and Bedrock models

### DIFF
--- a/src/main/java/com/devoxx/genie/chatmodel/cloud/bedrock/BedrockModelFactory.java
+++ b/src/main/java/com/devoxx/genie/chatmodel/cloud/bedrock/BedrockModelFactory.java
@@ -95,6 +95,7 @@ public class BedrockModelFactory implements ChatModelFactory {
                         .temperature(customChatModel.getTemperature())
                         .maxOutputTokens(customChatModel.getMaxTokens())
                         .build())
+                .listeners(getListener())
                 .build();
     }
 
@@ -113,6 +114,7 @@ public class BedrockModelFactory implements ChatModelFactory {
                         .temperature(customChatModel.getTemperature())
                         .maxOutputTokens(customChatModel.getMaxTokens())
                         .build())
+                .listeners(getListener())
                 .build();
     }
 
@@ -124,6 +126,7 @@ public class BedrockModelFactory implements ChatModelFactory {
                         .temperature(customChatModel.getTemperature())
                         .maxOutputTokens(customChatModel.getMaxTokens())
                         .build())
+                .listeners(getListener())
                 .build();
     }
 
@@ -135,6 +138,7 @@ public class BedrockModelFactory implements ChatModelFactory {
                         .temperature(customChatModel.getTemperature())
                         .maxOutputTokens(customChatModel.getMaxTokens())
                         .build())
+                .listeners(getListener())
                 .build();
     }
 
@@ -146,6 +150,7 @@ public class BedrockModelFactory implements ChatModelFactory {
                         .temperature(customChatModel.getTemperature())
                         .maxOutputTokens(customChatModel.getMaxTokens())
                         .build())
+                .listeners(getListener())
                 .build();
     }
 
@@ -157,6 +162,7 @@ public class BedrockModelFactory implements ChatModelFactory {
                         .temperature(customChatModel.getTemperature())
                         .maxOutputTokens(customChatModel.getMaxTokens())
                         .build())
+                .listeners(getListener())
                 .build();
     }
 
@@ -168,6 +174,7 @@ public class BedrockModelFactory implements ChatModelFactory {
                         .temperature(customChatModel.getTemperature())
                         .maxOutputTokens(customChatModel.getMaxTokens())
                         .build())
+                .listeners(getListener())
                 .build();
     }
 

--- a/src/main/java/com/devoxx/genie/chatmodel/cloud/mistral/MistralChatModelFactory.java
+++ b/src/main/java/com/devoxx/genie/chatmodel/cloud/mistral/MistralChatModelFactory.java
@@ -29,6 +29,7 @@ public class MistralChatModelFactory implements ChatModelFactory {
             .timeout(Duration.ofSeconds(customChatModel.getTimeout()))
             .topP(customChatModel.getTopP())
             .returnThinking(ThinkingSupport.isEnabled())
+            .listeners(getListener())
             .build();
     }
 
@@ -41,6 +42,7 @@ public class MistralChatModelFactory implements ChatModelFactory {
             .topP(customChatModel.getTopP())
             .timeout(Duration.ofSeconds(customChatModel.getTimeout()))
             .returnThinking(ThinkingSupport.isEnabled())
+            .listeners(getListener())
             .build();
     }
 

--- a/src/main/java/com/devoxx/genie/chatmodel/local/ollama/OllamaChatModelFactory.java
+++ b/src/main/java/com/devoxx/genie/chatmodel/local/ollama/OllamaChatModelFactory.java
@@ -51,7 +51,8 @@ public class OllamaChatModelFactory extends LocalChatModelFactory {
                 .modelName(customChatModel.getModelName())
                 .temperature(customChatModel.getTemperature())
                 .topP(customChatModel.getTopP())
-                .timeout(Duration.ofSeconds(customChatModel.getTimeout()));
+                .timeout(Duration.ofSeconds(customChatModel.getTimeout()))
+                .listeners(getListener());
 
         applyThinkingSetting(builder);
 

--- a/src/main/java/com/devoxx/genie/ui/settings/agent/AgentSettingsConfigurable.java
+++ b/src/main/java/com/devoxx/genie/ui/settings/agent/AgentSettingsConfigurable.java
@@ -48,10 +48,10 @@ public class AgentSettingsConfigurable implements Configurable {
             agentSettingsComponent.apply();
             messageBus.syncPublisher(AppTopics.SETTINGS_CHANGED_TOPIC).settingsChanged(true);
 
-            // Auto-open the Agent Logs panel when debug logging is enabled
+            // Auto-open the Activity Log panel when debug logging is enabled
             if (Boolean.TRUE.equals(DevoxxGenieStateService.getInstance().getAgentDebugLogsEnabled())) {
                 ToolWindow toolWindow = ToolWindowManager.getInstance(project)
-                        .getToolWindow("DevoxxGenieAgentLogs");
+                        .getToolWindow("DevoxxGenieActivityLogs");
                 if (toolWindow != null) {
                     toolWindow.show();
                 }

--- a/src/main/java/com/devoxx/genie/ui/settings/debug/DebugSettingsComponent.java
+++ b/src/main/java/com/devoxx/genie/ui/settings/debug/DebugSettingsComponent.java
@@ -10,12 +10,17 @@ import javax.swing.*;
 import java.awt.*;
 
 /**
- * Settings UI for the "Raw Request/Response" debug viewer (see the Activity Log tool window).
+ * Central settings UI for all debug logging options. Raw Request/Response logging lives here;
+ * the MCP and agent debug log checkboxes are mirrored from their original settings pages
+ * (MCP Settings and Agent Mode) — both places edit the same underlying setting, so changing
+ * one is reflected in the other.
  */
 public class DebugSettingsComponent {
 
     private final JPanel panel;
     private final JBCheckBox rawRequestResponseLoggingCheckBox;
+    private final JBCheckBox mcpLoggingCheckBox;
+    private final JBCheckBox agentDebugLogsCheckBox;
 
     public DebugSettingsComponent() {
         DevoxxGenieStateService state = DevoxxGenieStateService.getInstance();
@@ -23,29 +28,54 @@ public class DebugSettingsComponent {
         rawRequestResponseLoggingCheckBox = new JBCheckBox("Enable Raw Request/Response Logging");
         rawRequestResponseLoggingCheckBox.setSelected(Boolean.TRUE.equals(state.getRawRequestResponseLoggingEnabled()));
 
-        JBLabel description = new JBLabel(
-                "<html><body style='width:480px'>" +
-                        "When enabled, the exact request sent to the LLM provider (messages, tool calls, " +
-                        "model parameters) and the response received (message, tool calls, token usage) are " +
-                        "captured and shown in the <b>Activity Log</b> tool window, filterable to \"Show Raw " +
-                        "Only\". Double-click an entry to open the full JSON, or use \"Copy All\" for bug reports. " +
-                        "Likely API keys and tokens are masked automatically, but the raw prompt and response " +
-                        "text is not — avoid enabling this if your conversations may contain other secrets you " +
-                        "don't want written to the tool window / clipboard." +
-                        "</body></html>");
-        description.setForeground(UIUtil.getContextHelpForeground());
+        mcpLoggingCheckBox = new JBCheckBox("Enable MCP Logging");
+        mcpLoggingCheckBox.setSelected(Boolean.TRUE.equals(state.getMcpDebugLogsEnabled()));
+
+        agentDebugLogsCheckBox = new JBCheckBox("Enable agent debug logs");
+        agentDebugLogsCheckBox.setSelected(Boolean.TRUE.equals(state.getAgentDebugLogsEnabled()));
 
         panel = new JPanel();
         panel.setLayout(new BoxLayout(panel, BoxLayout.Y_AXIS));
         panel.setBorder(JBUI.Borders.empty(12));
 
-        rawRequestResponseLoggingCheckBox.setAlignmentX(Component.LEFT_ALIGNMENT);
+        addOption(rawRequestResponseLoggingCheckBox,
+                "When enabled, the exact request sent to the LLM provider (messages, tool calls, " +
+                        "model parameters) and the response received (message, tool calls, token usage) are " +
+                        "captured and shown in the <b>Activity Log</b> tool window, filterable to \"Show Raw " +
+                        "Only\". Double-click an entry to open the full JSON, or use \"Copy All\" for bug reports. " +
+                        "Likely API keys and tokens are masked automatically, but the raw prompt and response " +
+                        "text is not — avoid enabling this if your conversations may contain other secrets you " +
+                        "don't want written to the tool window / clipboard.");
+
+        panel.add(Box.createVerticalStrut(16));
+
+        addOption(mcpLoggingCheckBox,
+                "Logs MCP (Model Context Protocol) traffic to the <b>Activity Log</b> tool window, " +
+                        "filterable to \"Show MCP Only\". Only takes effect when MCP support is enabled. " +
+                        "Also available in Settings → DevoxxGenie → MCP Settings (both edit the same setting).");
+
+        panel.add(Box.createVerticalStrut(16));
+
+        addOption(agentDebugLogsCheckBox,
+                "Logs agent activity — tool calls with their arguments and results, intermediate LLM " +
+                        "responses, approvals and sub-agent lifecycle — to the <b>Activity Log</b> tool window, " +
+                        "filterable to \"Show Agents Only\". " +
+                        "Also available in Settings → DevoxxGenie → Agent Mode (both edit the same setting).");
+
+        panel.add(Box.createVerticalGlue());
+    }
+
+    private void addOption(JBCheckBox checkBox, String descriptionHtml) {
+        JBLabel description = new JBLabel(
+                "<html><body style='width:480px'>" + descriptionHtml + "</body></html>");
+        description.setForeground(UIUtil.getContextHelpForeground());
+
+        checkBox.setAlignmentX(Component.LEFT_ALIGNMENT);
         description.setAlignmentX(Component.LEFT_ALIGNMENT);
 
-        panel.add(rawRequestResponseLoggingCheckBox);
+        panel.add(checkBox);
         panel.add(Box.createVerticalStrut(6));
         panel.add(description);
-        panel.add(Box.createVerticalGlue());
     }
 
     public JPanel getPanel() {
@@ -53,20 +83,29 @@ public class DebugSettingsComponent {
     }
 
     public boolean isModified() {
-        return rawRequestResponseLoggingCheckBox.isSelected()
-                != Boolean.TRUE.equals(DevoxxGenieStateService.getInstance().getRawRequestResponseLoggingEnabled());
+        DevoxxGenieStateService state = DevoxxGenieStateService.getInstance();
+        return rawRequestResponseLoggingCheckBox.isSelected() != Boolean.TRUE.equals(state.getRawRequestResponseLoggingEnabled())
+                || mcpLoggingCheckBox.isSelected() != Boolean.TRUE.equals(state.getMcpDebugLogsEnabled())
+                || agentDebugLogsCheckBox.isSelected() != Boolean.TRUE.equals(state.getAgentDebugLogsEnabled());
     }
 
     public void apply() {
-        DevoxxGenieStateService.getInstance().setRawRequestResponseLoggingEnabled(rawRequestResponseLoggingCheckBox.isSelected());
+        DevoxxGenieStateService state = DevoxxGenieStateService.getInstance();
+        state.setRawRequestResponseLoggingEnabled(rawRequestResponseLoggingCheckBox.isSelected());
+        state.setMcpDebugLogsEnabled(mcpLoggingCheckBox.isSelected());
+        state.setAgentDebugLogsEnabled(agentDebugLogsCheckBox.isSelected());
     }
 
     public void reset() {
-        rawRequestResponseLoggingCheckBox.setSelected(
-                Boolean.TRUE.equals(DevoxxGenieStateService.getInstance().getRawRequestResponseLoggingEnabled()));
+        DevoxxGenieStateService state = DevoxxGenieStateService.getInstance();
+        rawRequestResponseLoggingCheckBox.setSelected(Boolean.TRUE.equals(state.getRawRequestResponseLoggingEnabled()));
+        mcpLoggingCheckBox.setSelected(Boolean.TRUE.equals(state.getMcpDebugLogsEnabled()));
+        agentDebugLogsCheckBox.setSelected(Boolean.TRUE.equals(state.getAgentDebugLogsEnabled()));
     }
 
-    public boolean isRawRequestResponseLoggingSelected() {
-        return rawRequestResponseLoggingCheckBox.isSelected();
+    public boolean isAnyLoggingSelected() {
+        return rawRequestResponseLoggingCheckBox.isSelected()
+                || mcpLoggingCheckBox.isSelected()
+                || agentDebugLogsCheckBox.isSelected();
     }
 }

--- a/src/main/java/com/devoxx/genie/ui/settings/debug/DebugSettingsConfigurable.java
+++ b/src/main/java/com/devoxx/genie/ui/settings/debug/DebugSettingsConfigurable.java
@@ -41,10 +41,10 @@ public class DebugSettingsConfigurable implements Configurable {
         if (component == null) {
             return;
         }
-        boolean nowEnabled = component.isRawRequestResponseLoggingSelected();
+        boolean nowEnabled = component.isAnyLoggingSelected();
         component.apply();
 
-        // Auto-open the Activity Log panel when raw logging is turned on, so users see it start filling.
+        // Auto-open the Activity Log panel when any debug logging is turned on, so users see it start filling.
         if (nowEnabled) {
             ToolWindow toolWindow = ToolWindowManager.getInstance(project).getToolWindow("DevoxxGenieActivityLogs");
             if (toolWindow != null) {

--- a/src/main/java/com/devoxx/genie/ui/settings/mcp/MCPSettingsConfigurable.java
+++ b/src/main/java/com/devoxx/genie/ui/settings/mcp/MCPSettingsConfigurable.java
@@ -53,10 +53,10 @@ public class MCPSettingsConfigurable implements Configurable {
             // TODO Check if things have changed, if so Notify listeners that settings have changed
             messageBus.syncPublisher(AppTopics.SETTINGS_CHANGED_TOPIC).settingsChanged(true);
 
-            // Auto-open the MCP Logs panel when debug logging is enabled
+            // Auto-open the Activity Log panel when debug logging is enabled
             if (MCPService.isDebugLogsEnabled()) {
                 ToolWindow toolWindow = ToolWindowManager.getInstance(project)
-                        .getToolWindow("DevoxxGenieMCPLogs");
+                        .getToolWindow("DevoxxGenieActivityLogs");
                 if (toolWindow != null) {
                     toolWindow.show();
                 }

--- a/src/test/java/com/devoxx/genie/chatmodel/cloud/bedrock/BedrockModelFactoryTest.java
+++ b/src/test/java/com/devoxx/genie/chatmodel/cloud/bedrock/BedrockModelFactoryTest.java
@@ -1,9 +1,11 @@
 package com.devoxx.genie.chatmodel.cloud.bedrock;
 
 import com.devoxx.genie.chatmodel.AbstractLightPlatformTestCase;
+import com.devoxx.genie.model.CustomChatModel;
 import com.devoxx.genie.model.LanguageModel;
 import com.devoxx.genie.model.enumarations.AwsBedrockAuthMode;
 import com.devoxx.genie.model.enumarations.ModelProvider;
+import com.devoxx.genie.service.debug.RawTrafficListenerService;
 import com.devoxx.genie.service.models.LLMModelRegistryService;
 import com.devoxx.genie.ui.settings.DevoxxGenieStateService;
 import com.intellij.openapi.application.ApplicationManager;
@@ -83,6 +85,28 @@ class BedrockModelFactoryTest extends AbstractLightPlatformTestCase {
         when(settingsStateMock.getAwsProfileName()).thenReturn("bedrock");
         AwsCredentialsProvider awsCredentialsProvider = factory.getCredentialsProvider();
         assertThat(awsCredentialsProvider).isInstanceOf(ProfileCredentialsProvider.class);
+    }
+
+    @Test
+    void createChatModelAttachesRawTrafficListenerWhenEnabled() {
+        when(settingsStateMock.getMcpEnabled()).thenReturn(false);
+        when(settingsStateMock.getAgentModeEnabled()).thenReturn(false);
+        when(settingsStateMock.getRawRequestResponseLoggingEnabled()).thenReturn(true);
+        when(settingsStateMock.getShouldEnableAWSRegionalInference()).thenReturn(false);
+
+        BedrockModelFactory factory = new BedrockModelFactory();
+
+        CustomChatModel anthropicModel = new CustomChatModel();
+        anthropicModel.setModelName("anthropic.claude-sonnet-4-20250514-v1:0");
+        assertThat(factory.createChatModel(anthropicModel).listeners())
+                .anyMatch(RawTrafficListenerService.class::isInstance);
+        assertThat(factory.createStreamingChatModel(anthropicModel).listeners())
+                .anyMatch(RawTrafficListenerService.class::isInstance);
+
+        CustomChatModel mistralModel = new CustomChatModel();
+        mistralModel.setModelName("mistral.mistral-large-2402-v1:0");
+        assertThat(factory.createChatModel(mistralModel).listeners())
+                .anyMatch(RawTrafficListenerService.class::isInstance);
     }
 
     private static LanguageModel model(String modelName) {

--- a/src/test/java/com/devoxx/genie/chatmodel/cloud/mistral/MistralChatModelFactoryTest.java
+++ b/src/test/java/com/devoxx/genie/chatmodel/cloud/mistral/MistralChatModelFactoryTest.java
@@ -4,6 +4,7 @@ import com.devoxx.genie.chatmodel.AbstractLightPlatformTestCase;
 import com.devoxx.genie.model.CustomChatModel;
 import com.devoxx.genie.model.LanguageModel;
 import com.devoxx.genie.model.enumarations.ModelProvider;
+import com.devoxx.genie.service.debug.RawTrafficListenerService;
 import com.devoxx.genie.service.models.LLMModelRegistryService;
 import com.devoxx.genie.ui.settings.DevoxxGenieStateService;
 import com.intellij.openapi.application.ApplicationManager;
@@ -97,6 +98,25 @@ public class MistralChatModelFactoryTest extends AbstractLightPlatformTestCase {
         } catch (ReflectiveOperationException e) {
             throw new AssertionError("Unable to read LangChain4j Mistral returnThinking flag", e);
         }
+    }
+
+    @Test
+    void createChatModelAttachesRawTrafficListenerWhenEnabled() {
+        DevoxxGenieStateService state = DevoxxGenieStateService.getInstance();
+        when(state.getMcpEnabled()).thenReturn(false);
+        when(state.getAgentModeEnabled()).thenReturn(false);
+        when(state.getRawRequestResponseLoggingEnabled()).thenReturn(true);
+
+        MistralChatModelFactory factory = new MistralChatModelFactory();
+        CustomChatModel customChatModel = new CustomChatModel();
+        customChatModel.setModelName("mistral-small-latest");
+        customChatModel.setMaxRetries(3);
+        customChatModel.setTimeout(60);
+
+        Assertions.assertThat(factory.createChatModel(customChatModel).listeners())
+            .anyMatch(RawTrafficListenerService.class::isInstance);
+        Assertions.assertThat(factory.createStreamingChatModel(customChatModel).listeners())
+            .anyMatch(RawTrafficListenerService.class::isInstance);
     }
 
     @Test

--- a/src/test/java/com/devoxx/genie/chatmodel/local/ollama/OllamaChatModelFactoryTest.java
+++ b/src/test/java/com/devoxx/genie/chatmodel/local/ollama/OllamaChatModelFactoryTest.java
@@ -1,6 +1,7 @@
 package com.devoxx.genie.chatmodel.local.ollama;
 
 import com.devoxx.genie.model.CustomChatModel;
+import com.devoxx.genie.service.debug.RawTrafficListenerService;
 import com.devoxx.genie.ui.settings.DevoxxGenieStateService;
 import dev.langchain4j.model.chat.ChatModel;
 import dev.langchain4j.model.chat.StreamingChatModel;
@@ -165,5 +166,49 @@ class OllamaChatModelFactoryTest {
             assertThat(result).isNotNull();
             assertThat(((OllamaStreamingChatModel) result).defaultRequestParameters().numCtx()).isEqualTo(8192);
         }
+    }
+
+    @Test
+    void testCreateChatModelAttachesRawTrafficListenerWhenEnabled() {
+        try (MockedStatic<DevoxxGenieStateService> mockedSettings = Mockito.mockStatic(DevoxxGenieStateService.class)) {
+            DevoxxGenieStateService mockSettingsState = mockStateWithRawLoggingEnabled();
+            when(DevoxxGenieStateService.getInstance()).thenReturn(mockSettingsState);
+
+            OllamaChatModelFactory factory = new OllamaChatModelFactory();
+            CustomChatModel customChatModel = new CustomChatModel();
+            customChatModel.setModelName("ollama");
+
+            ChatModel result = factory.createChatModel(customChatModel);
+
+            org.assertj.core.api.Assertions.assertThat(result.listeners())
+                    .anyMatch(RawTrafficListenerService.class::isInstance);
+        }
+    }
+
+    @Test
+    void testCreateStreamingChatModelAttachesRawTrafficListenerWhenEnabled() {
+        try (MockedStatic<DevoxxGenieStateService> mockedSettings = Mockito.mockStatic(DevoxxGenieStateService.class)) {
+            DevoxxGenieStateService mockSettingsState = mockStateWithRawLoggingEnabled();
+            when(DevoxxGenieStateService.getInstance()).thenReturn(mockSettingsState);
+
+            OllamaChatModelFactory factory = new OllamaChatModelFactory();
+            CustomChatModel customChatModel = new CustomChatModel();
+            customChatModel.setModelName("ollama");
+
+            StreamingChatModel result = factory.createStreamingChatModel(customChatModel);
+
+            org.assertj.core.api.Assertions.assertThat(result.listeners())
+                    .anyMatch(RawTrafficListenerService.class::isInstance);
+        }
+    }
+
+    private static DevoxxGenieStateService mockStateWithRawLoggingEnabled() {
+        DevoxxGenieStateService mockSettingsState = mock(DevoxxGenieStateService.class);
+        when(mockSettingsState.getOllamaModelUrl()).thenReturn("http://localhost:8080");
+        when(mockSettingsState.getShowThinkingEnabled()).thenReturn(false);
+        when(mockSettingsState.getMcpEnabled()).thenReturn(false);
+        when(mockSettingsState.getAgentModeEnabled()).thenReturn(false);
+        when(mockSettingsState.getRawRequestResponseLoggingEnabled()).thenReturn(true);
+        return mockSettingsState;
     }
 }


### PR DESCRIPTION
The opt-in "Raw Request/Response Logging" debug viewer (#1197) captures LLM
traffic via a RawTrafficListenerService registered in ChatModelFactory.getListener().
Three factories never wired that listener into the models they build, so enabling
the setting produced no [RAW] entries in the Activity Log for:

- Ollama in streaming mode (createStreamingChatModel missed .listeners(...),
  while the non-streaming variant had it)
- Mistral (both chat and streaming models)
- Amazon Bedrock (all model variants, chat and streaming)

Add .listeners(getListener()) to those builders, matching every other provider
factory, and cover the wiring with regression tests that assert a
RawTrafficListenerService is present on the built models when the setting is on.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01FKGPC5A6wmW51piqKdNXuU