### PR TITLE
feat(analytics): track thinking, debug logging, and advanced-feature enablement

### DIFF
--- a/src/main/java/com/devoxx/genie/service/analytics/AnalyticsEventBuilder.java
+++ b/src/main/java/com/devoxx/genie/service/analytics/AnalyticsEventBuilder.java
@@ -47,7 +47,11 @@ public final class AnalyticsEventBuilder {
             "feature_id", Set.of(
                     "rag", "semantic_search", "web_search_google", "web_search_tavily",
                     "agent", "mcp", "streaming", "project_context_full",
-                    "project_context_selected", "devoxxgenie_md", "custom_prompt"),
+                    "project_context_selected", "devoxxgenie_md", "custom_prompt",
+                    "thinking", "mcp_debug_logs", "agent_debug_logs",
+                    "raw_request_response_logging", "web_search_agent_tool",
+                    "rag_query_expansion", "parallel_explore", "psi_tools",
+                    "security_scan", "spec_browser", "event_automation", "inline_completion"),
             "provider_type", Set.of("local", "cloud", "none"),
             "tool_call_count", Set.of("0", "1", "2-5", "6-10", "11+"),
             "mcp_server_count", Set.of("0", "1", "2-5", "6-10", "11+"),

--- a/src/main/java/com/devoxx/genie/service/analytics/AnalyticsSessionSnapshotService.java
+++ b/src/main/java/com/devoxx/genie/service/analytics/AnalyticsSessionSnapshotService.java
@@ -135,6 +135,21 @@ public final class AnalyticsSessionSnapshotService implements DevoxxGenieSetting
         emitIfEnabled(state.isTavilySearchEnabled(), FeatureId.WEB_SEARCH_TAVILY);
         emitIfEnabled(hasAnyCustomPrompt(state), FeatureId.CUSTOM_PROMPT);
 
+        // Additional enablement signals (task-241): reasoning output, debug logging, and
+        // adoption of newer/advanced capabilities. All read plain boolean toggles — no content.
+        emitIfEnabled(state.getShowThinkingEnabled(), FeatureId.THINKING);
+        emitIfEnabled(state.getMcpDebugLogsEnabled(), FeatureId.MCP_DEBUG_LOGS);
+        emitIfEnabled(state.getAgentDebugLogsEnabled(), FeatureId.AGENT_DEBUG_LOGS);
+        emitIfEnabled(state.getRawRequestResponseLoggingEnabled(), FeatureId.RAW_REQUEST_RESPONSE_LOGGING);
+        emitIfEnabled(state.getWebSearchAgentToolEnabled(), FeatureId.WEB_SEARCH_AGENT_TOOL);
+        emitIfEnabled(state.getRagQueryExpansionEnabled(), FeatureId.RAG_QUERY_EXPANSION);
+        emitIfEnabled(state.getParallelExploreEnabled(), FeatureId.PARALLEL_EXPLORE);
+        emitIfEnabled(state.getPsiToolsEnabled(), FeatureId.PSI_TOOLS);
+        emitIfEnabled(state.getSecurityScanEnabled(), FeatureId.SECURITY_SCAN);
+        emitIfEnabled(state.getSpecBrowserEnabled(), FeatureId.SPEC_BROWSER);
+        emitIfEnabled(state.getEventAutomationEnabled(), FeatureId.EVENT_AUTOMATION);
+        emitIfEnabled(hasInlineCompletion(state), FeatureId.INLINE_COMPLETION);
+
         sink.trackFeatureCounts(
                 Buckets.standard(mcpServerCount(state)),
                 Buckets.standard(customPromptCount(state)),
@@ -154,6 +169,12 @@ public final class AnalyticsSessionSnapshotService implements DevoxxGenieSetting
 
     private boolean hasAnyCustomPrompt(@NotNull DevoxxGenieStateService state) {
         return customPromptCount(state) > 0;
+    }
+
+    /** Inline completion is "enabled" once the user has picked a provider for it. */
+    private boolean hasInlineCompletion(@NotNull DevoxxGenieStateService state) {
+        String provider = state.getInlineCompletionProvider();
+        return provider != null && !provider.isBlank();
     }
 
     private int customPromptCount(@NotNull DevoxxGenieStateService state) {

--- a/src/main/java/com/devoxx/genie/service/analytics/FeatureId.java
+++ b/src/main/java/com/devoxx/genie/service/analytics/FeatureId.java
@@ -29,7 +29,22 @@ public enum FeatureId {
     PROJECT_CONTEXT_FULL("project_context_full", true),
     PROJECT_CONTEXT_SELECTED("project_context_selected", true),
     DEVOXXGENIE_MD("devoxxgenie_md", true),
-    CUSTOM_PROMPT("custom_prompt", false);
+    CUSTOM_PROMPT("custom_prompt", false),
+
+    // Additional session-enablement signals (task-241). All enablement-only: they describe
+    // which optional capabilities a user has switched on, never any user content.
+    THINKING("thinking", false),
+    MCP_DEBUG_LOGS("mcp_debug_logs", false),
+    AGENT_DEBUG_LOGS("agent_debug_logs", false),
+    RAW_REQUEST_RESPONSE_LOGGING("raw_request_response_logging", false),
+    WEB_SEARCH_AGENT_TOOL("web_search_agent_tool", false),
+    RAG_QUERY_EXPANSION("rag_query_expansion", false),
+    PARALLEL_EXPLORE("parallel_explore", false),
+    PSI_TOOLS("psi_tools", false),
+    SECURITY_SCAN("security_scan", false),
+    SPEC_BROWSER("spec_browser", false),
+    EVENT_AUTOMATION("event_automation", false),
+    INLINE_COMPLETION("inline_completion", false);
 
     private final String wireValue;
     private final boolean usageOnly;

--- a/src/test/java/com/devoxx/genie/service/analytics/AnalyticsSessionSnapshotServiceTest.java
+++ b/src/test/java/com/devoxx/genie/service/analytics/AnalyticsSessionSnapshotServiceTest.java
@@ -48,6 +48,22 @@ class AnalyticsSessionSnapshotServiceTest {
         state.setMcpSettings(new MCPSettings());
         state.setChatMemorySize(0);
 
+        // Neutralize the additional enablement toggles (task-241) so each test opts in
+        // explicitly. PSI tools and parallel explore default to true, so they must be
+        // cleared or they would fire in every snapshot.
+        state.setShowThinkingEnabled(false);
+        state.setMcpDebugLogsEnabled(false);
+        state.setAgentDebugLogsEnabled(false);
+        state.setRawRequestResponseLoggingEnabled(false);
+        state.setWebSearchAgentToolEnabled(false);
+        state.setRagQueryExpansionEnabled(false);
+        state.setParallelExploreEnabled(false);
+        state.setPsiToolsEnabled(false);
+        state.setSecurityScanEnabled(false);
+        state.setSpecBrowserEnabled(false);
+        state.setEventAutomationEnabled(false);
+        state.setInlineCompletionProvider("");
+
         analytics = new RecordingSink();
         snapshot = new AnalyticsSessionSnapshotService(analytics);
     }
@@ -159,6 +175,40 @@ class AnalyticsSessionSnapshotServiceTest {
         withState(snapshot::snapshotIfNeeded);
 
         assertThat(analytics.lastCountsEvent.chatMemoryBucket).isEqualTo("11-20");
+    }
+
+    @Test
+    void snapshotEmitsAdditionalEnablementSignals() {
+        // task-241: reasoning output, debug logging, and advanced-feature adoption.
+        state.setShowThinkingEnabled(true);
+        state.setMcpDebugLogsEnabled(true);
+        state.setAgentDebugLogsEnabled(true);
+        state.setRawRequestResponseLoggingEnabled(true);
+        state.setWebSearchAgentToolEnabled(true);
+        state.setRagQueryExpansionEnabled(true);
+        state.setParallelExploreEnabled(true);
+        state.setPsiToolsEnabled(true);
+        state.setSecurityScanEnabled(true);
+        state.setSpecBrowserEnabled(true);
+        state.setEventAutomationEnabled(true);
+        state.setInlineCompletionProvider("Ollama");
+
+        withState(snapshot::snapshotIfNeeded);
+
+        assertThat(analytics.enabledEvents).containsExactlyInAnyOrder(
+                FeatureId.THINKING, FeatureId.MCP_DEBUG_LOGS, FeatureId.AGENT_DEBUG_LOGS,
+                FeatureId.RAW_REQUEST_RESPONSE_LOGGING, FeatureId.WEB_SEARCH_AGENT_TOOL,
+                FeatureId.RAG_QUERY_EXPANSION, FeatureId.PARALLEL_EXPLORE, FeatureId.PSI_TOOLS,
+                FeatureId.SECURITY_SCAN, FeatureId.SPEC_BROWSER, FeatureId.EVENT_AUTOMATION,
+                FeatureId.INLINE_COMPLETION);
+    }
+
+    @Test
+    void inlineCompletionSignalRequiresProvider() {
+        // Blank provider → not enabled.
+        state.setInlineCompletionProvider("   ");
+        withState(snapshot::snapshotIfNeeded);
+        assertThat(analytics.enabledEvents).doesNotContain(FeatureId.INLINE_COMPLETION);
     }
 
     @Test


### PR DESCRIPTION
Extend the per-session feature-enablement snapshot with twelve additional
opt-in signals so the roadmap reflects which optional capabilities users
actually switch on:

- thinking (reasoning-model output)
- mcp_debug_logs, agent_debug_logs, raw_request_response_logging
- web_search_agent_tool, rag_query_expansion, parallel_explore, psi_tools
- security_scan, spec_browser, event_automation, inline_completion

All are enablement-only booleans read from DevoxxGenieStateService — no user
content is ever read. Each new FeatureId is added to the closed feature_id
enum allowlist in AnalyticsEventBuilder, keeping the privacy contract intact:
values outside the allowlist are still dropped. AnalyticsEventBuilder.java
remains the canonical "exactly what we send" disclosure referenced by the
consent notice, so it stays accurate automatically.

Tests reset the new toggles in setUp (psi_tools and parallel_explore default
to true) and add coverage for the new signals and the inline-completion
provider gate.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01QxnwhRxP3FNmkPGNmjTUjs