### PR TITLE
fix(test): exempt AWS SDK idle-connection-reaper thread from leak detector

### DIFF
--- a/src/test/java/com/devoxx/genie/chatmodel/cloud/bedrock/BedrockModelFactoryTest.java
+++ b/src/test/java/com/devoxx/genie/chatmodel/cloud/bedrock/BedrockModelFactoryTest.java
@@ -10,6 +10,7 @@ import com.devoxx.genie.service.models.LLMModelRegistryService;
 import com.devoxx.genie.ui.settings.DevoxxGenieStateService;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.testFramework.ServiceContainerUtil;
+import com.intellij.testFramework.common.ThreadLeakTracker;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
@@ -33,6 +34,14 @@ class BedrockModelFactoryTest extends AbstractLightPlatformTestCase {
     @BeforeEach
     public void setUp() throws Exception {
         super.setUp();
+
+        // Building a BedrockRuntimeClient starts the AWS SDK's JVM-wide singleton
+        // "idle-connection-reaper" daemon thread, which deliberately outlives the individual
+        // clients created by the factory. Exempt it from the platform's thread-leak assertion.
+        // Registered on the application disposable (not the test root one) because the leak
+        // check runs after the test root disposable has already been disposed.
+        ThreadLeakTracker.longRunningThreadCreated(ApplicationManager.getApplication(), "idle-connection-reaper");
+
         // Mock SettingsState
         settingsStateMock = mock(DevoxxGenieStateService.class);
         when(settingsStateMock.getAwsAccessKeyId()).thenReturn(DUMMY_AWS_ACCESS_KEY);


### PR DESCRIPTION
# Pull Request

## Description

Fixes the single failing test on the CI Tests workflow (`3394 tests completed, 1 failed, 25 skipped`).

`BedrockModelFactoryTest.createChatModelAttachesRawTrafficListenerWhenEnabled` builds real `BedrockRuntimeClient` instances through the factory. The first client built starts the AWS SDK's JVM-wide singleton `idle-connection-reaper` daemon thread (Apache5 HTTP client), which by design outlives the individual clients. The IntelliJ platform test framework's thread-leak detector then fails the test:

```
java.lang.AssertionError: Thread leaked: Thread[#72,idle-connection-reaper,5,main] (alive) TIMED_WAITING
```

This was not introduced by the recent dependency bump — the July 11 CI run failed identically.

The fix registers the thread name with `ThreadLeakTracker.longRunningThreadCreated(...)` in the test's `setUp()`, the standard IntelliJ-platform mechanism for exempting known long-lived library threads. It is registered on the **application** disposable rather than `getTestRootDisposable()` because the leak check runs after the test-root disposable has already been disposed — a test-root registration would be removed right before the check runs.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test addition/improvement

## Related Issue

CI failure on `master` Tests workflow (runs 29233901835 and 29145068428).

## Changes Made

- Register `idle-connection-reaper` with `ThreadLeakTracker.longRunningThreadCreated(...)` in `BedrockModelFactoryTest.setUp()`, scoped to the application disposable.

## Testing

**How has this been tested?**

- [x] Unit tests

Reproduced the exact CI failure locally without the fix (red), then confirmed the test class passes with it (green), on the same platform build CI uses (IntelliJ 2025.3.3 / 253.29346.138, JDK 21). Full suite run locally: `BedrockModelFactoryTest` all green; the only local failures are environment-dependent tests requiring a `.env` with real API keys, which pass on CI via secrets.

**Test Configuration:**
- IntelliJ IDEA version: 2025.3.3 (platform 253.29346.138, headless test framework)
- JDK version: 21
- OS: Linux

## Documentation

- [ ] I have updated the documentation at [genie.devoxx.com](https://genie.devoxx.com) if needed
- [ ] I have updated CLAUDE.md if architecture/patterns changed
- [x] I have added/updated code comments for complex logic
- [ ] I have updated the README.md if needed

## Checklist

- [x] My code follows the existing code style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Screenshots/Videos (if applicable)

N/A

## Additional Notes

While running the full suite locally, `AcpClientTest.testIsRunning_reflectsProcessState` showed a similar (but distinct) `acp-reader` thread leak in this sandboxed environment only — it passes on CI, so it was left out of scope here.

## Breaking Changes

None.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the project's license.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011vWWomBoym6fxmq9yeaEP6

---
_Generated by [Claude Code](https://claude.ai/code/session_011vWWomBoym6fxmq9yeaEP6)_