### PR TITLE
feat(welcome): expand Explore Features by default, persist toggle

### DIFF
--- a/src/main/java/com/devoxx/genie/ui/settings/DevoxxGenieStateService.java
+++ b/src/main/java/com/devoxx/genie/ui/settings/DevoxxGenieStateService.java
@@ -341,7 +341,10 @@ public final class DevoxxGenieStateService implements PersistentStateComponent<D
 
     // Show/hide Add File button in footer
     private Boolean showAddFileButton = true;
-    
+
+    // Expanded/collapsed state of the "Explore Features" section on the welcome screen
+    private Boolean welcomeFeaturesExpanded = true;
+
     // MCP settings
     private MCPSettings mcpSettings = new MCPSettings();
     private Boolean mcpEnabled = false;

--- a/src/main/kotlin/com/devoxx/genie/ui/compose/screen/WelcomeScreen.kt
+++ b/src/main/kotlin/com/devoxx/genie/ui/compose/screen/WelcomeScreen.kt
@@ -40,6 +40,7 @@ import com.devoxx.genie.ui.compose.model.FeatureDoc
 import com.devoxx.genie.ui.compose.model.SkillUi
 import com.devoxx.genie.ui.compose.theme.*
 import com.devoxx.genie.ui.compose.util.fireTrackingPixel
+import com.devoxx.genie.ui.settings.DevoxxGenieStateService
 import com.intellij.ide.BrowserUtil
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -199,16 +200,21 @@ fun WelcomeScreen(
             Spacer(Modifier.height(20.dp))
         }
 
-        // Features section — collapsed by default. The feature chip grid is the
-        // single biggest vertical consumer and is reference material users learn
-        // once, so it's tucked behind a collapsible header to keep the welcome
-        // page short and the fresh/changing sections reachable.
-        var featuresExpanded by remember { mutableStateOf(false) }
+        // Features section — expanded by default so the chip grid is immediately
+        // discoverable, but kept collapsible so users who already know the
+        // features can shrink it and reach the fresh/changing sections faster.
+        // The choice is persisted, so a collapse survives restarts.
+        var featuresExpanded by remember {
+            mutableStateOf(DevoxxGenieStateService.getInstance().welcomeFeaturesExpanded != false)
+        }
         CollapsibleSectionHeader(
             title = "Explore Features",
             count = FEATURES.size,
             expanded = featuresExpanded,
-            onToggle = { featuresExpanded = !featuresExpanded },
+            onToggle = {
+                featuresExpanded = !featuresExpanded
+                DevoxxGenieStateService.getInstance().welcomeFeaturesExpanded = featuresExpanded
+            },
         )
         if (featuresExpanded) {
             Spacer(Modifier.height(8.dp))


### PR DESCRIPTION
## Summary
- The "Explore Features" section on the welcome screen now renders **expanded** by default, so the feature chip grid is immediately discoverable instead of hidden behind a click.
- The section remains collapsible, and the choice is now persisted via a new `welcomeFeaturesExpanded` field on `DevoxxGenieStateService` — a collapse survives an IDE restart rather than resetting on every recomposition.
- Absent field (existing settings files) deserializes to `null` and is treated as expanded; only an explicit user collapse stores `false`.

## Notes
- The setting is application-level, not per-project — consistent with the neighbouring UI toggles (`showAddFileButton`, `showCalcTokensButton`).

## Test plan
- [ ] Fresh install / no existing setting: welcome screen shows "Explore Features" expanded
- [ ] Collapse the section, restart the IDE — it stays collapsed
- [ ] Re-expand, restart — it stays expanded
- [ ] Existing settings file from a previous version still opens expanded (no `welcomeFeaturesExpanded` key)

🤖 Generated with [Claude Code](https://claude.com/claude-code)