### PR TITLE
chore(skills): update Co-Authored-By trailer to Opus 4.8

### DIFF
--- a/.claude/skills/close-task-commit-push-pr/SKILL.md
+++ b/.claude/skills/close-task-commit-push-pr/SKILL.md
@@ -49,7 +49,7 @@ Print a short commit plan (list of planned commits with the files in each) so th
 - Create one commit per logical group identified above. Stage only the files for that group using explicit file names (never `git add -A`; never stage `.env` or credential files).
 - Write a clean, descriptive commit message for each commit using conventional commits style.
 - End every commit message with:
-  `Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>`
+  `Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>`
 - Use a HEREDOC to pass the commit message for correct formatting.
 - **Include the closed task file** in the final commit.
 

--- a/.claude/skills/git-commit-push-pr/SKILL.md
+++ b/.claude/skills/git-commit-push-pr/SKILL.md
@@ -33,7 +33,7 @@ Print a short commit plan (list of planned commits with the files in each) so th
 - Create one commit per logical group identified above. Stage only the files for that group using explicit file names (never `git add -A`; never stage `.env` or credential files).
 - Write a clean, descriptive commit message for each commit using conventional commits style.
 - End every commit message with:
-  `Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>`
+  `Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>`
 - Use a HEREDOC to pass the commit message for correct formatting.
 
 ### Step 3 — Push


### PR DESCRIPTION
## Summary
- Both commit-and-PR skills (`git-commit-push-pr`, `close-task-commit-push-pr`) pinned a stale `Claude Opus 4.6 (1M context)` trailer, so generated commits credited the wrong model version.
- Bumped both to `Claude Opus 4.8 (1M context)`.

## Note
This string will drift again on the next model bump. A more durable alternative would be to have the skills say *"end every commit message with a `Co-Authored-By:` trailer naming the model you're running as"* rather than hardcoding a version — happy to follow up with that if preferred.

## Test plan
- [ ] Run `/git-commit-push-pr` and confirm the generated commit carries the 4.8 trailer
- [ ] Run `/close-task-commit-push-pr` and confirm the same

🤖 Generated with [Claude Code](https://claude.com/claude-code)