### PR TITLE
docs: promote 104k active users and 80k downloads on landing page

### DIFF
--- a/docusaurus/src/pages/index.js
+++ b/docusaurus/src/pages/index.js
@@ -83,6 +83,24 @@ export default function Home() {
           DevoxxGenie Workshop
         </a>
       </div>
+      <section className={styles.statsBand}>
+        <div className="container">
+          <div className={styles.statsGrid}>
+            <div className={styles.statCard}>
+              <div className={styles.statNumber}>104,000+</div>
+              <div className={styles.statLabel}>Active Users</div>
+            </div>
+            <div className={styles.statCard}>
+              <div className={styles.statNumber}>80,000</div>
+              <div className={styles.statLabel}>Plugin Downloads</div>
+            </div>
+            <div className={styles.statCard}>
+              <div className={styles.statNumber}>100%</div>
+              <div className={styles.statLabel}>Open Source &amp; Free</div>
+            </div>
+          </div>
+        </div>
+      </section>
       <main>
         <div className="container home-section">
           <div className="row">
@@ -390,7 +408,7 @@ milestone: v2.0
           <div className="row">
             <div className="col col--12 text--center">
               <h2>Start Using DevoxxGenie Today</h2>
-              <p>Join over 45,000 developers who are already using DevoxxGenie to improve their productivity.</p>
+              <p>Join over 104,000 developers who are already using DevoxxGenie to improve their productivity.</p>
               <p><em>100% free and open source with no hidden costs - just bring your own API keys (BYOK)!</em></p>
               <div className={styles.buttons} style={{marginTop: '20px'}}>
                 <Link

--- a/docusaurus/src/pages/index.js
+++ b/docusaurus/src/pages/index.js
@@ -99,6 +99,7 @@ export default function Home() {
               <div className={styles.statLabel}>Open Source &amp; Free</div>
             </div>
           </div>
+          <p className={styles.statsAsOf}>As of July 2026</p>
         </div>
       </section>
       <main>

--- a/docusaurus/src/pages/index.module.css
+++ b/docusaurus/src/pages/index.module.css
@@ -78,6 +78,15 @@
   color: #fff;
 }
 
+.statsAsOf {
+  margin: 1.5rem 0 0;
+  text-align: center;
+  font-size: 0.85rem;
+  font-weight: 500;
+  opacity: 0.8;
+  color: #fff;
+}
+
 /* Video styles */
 .videoContainer {
   width: 100%;

--- a/docusaurus/src/pages/index.module.css
+++ b/docusaurus/src/pages/index.module.css
@@ -41,6 +41,43 @@
   justify-content: center;
 }
 
+/* Stats band */
+.statsBand {
+  background: var(--ifm-color-primary);
+  color: #fff;
+  padding: 2.5rem 1rem;
+}
+
+.statsGrid {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: stretch;
+  justify-content: center;
+  gap: 1.5rem;
+}
+
+.statCard {
+  flex: 1 1 200px;
+  max-width: 280px;
+  text-align: center;
+  padding: 1rem 1.5rem;
+}
+
+.statNumber {
+  font-size: 2.75rem;
+  font-weight: 800;
+  line-height: 1.1;
+  color: #fff;
+}
+
+.statLabel {
+  margin-top: 0.4rem;
+  font-size: 1rem;
+  font-weight: 500;
+  opacity: 0.92;
+  color: #fff;
+}
+
 /* Video styles */
 .videoContainer {
   width: 100%;


### PR DESCRIPTION
## Description

Promotes DevoxxGenie's latest growth milestones on the Docusaurus landing page (`genie.devoxx.com`). Adds a prominent stats band near the top of the homepage and refreshes a stale figure in the closing call-to-action.

## Type of Change

- [x] Documentation update

## Related Issue

<!-- None -->

## Changes Made

- Added a full-width, brand-colored **stats band** just below the hero/workshop banner highlighting **104,000+ Active Users**, **80,000 Plugin Downloads**, and **100% Open Source & Free**.
- Added an **"As of July 2026"** caption beneath the stats so viewers know when the figures were current.
- Updated the outdated **"Join over 45,000 developers"** line in the closing CTA to **104,000**.
- Added matching responsive CSS (`.statsBand`, `.statsGrid`, `.statCard`, `.statNumber`, `.statLabel`, `.statsAsOf`) that flex-wraps to a single column on mobile.

## Testing

**How has this been tested?**

- [x] Manual testing (Docusaurus content-only change)

## Documentation

- [x] I have updated the documentation at [genie.devoxx.com](https://genie.devoxx.com) if needed

## Additional Notes

Downloads shown as **80,000** (no "+") to match the "close to 80,000" figure rather than overclaiming. Confirmed there were no other stale `45,000`-style references across the docusaurus site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UgZMmiY7pyczpznMc4Jbfu)_