### PR TITLE
docs: broaden landing page text to all JetBrains IDEs

### DIFF
--- a/docusaurus/docusaurus.config.js
+++ b/docusaurus/docusaurus.config.js
@@ -9,10 +9,10 @@ import {themes as prismThemes} from 'prism-react-renderer';
 /** @type {import('@docusaurus/types').Config} */
 const config = {
   title: 'DevoxxGenie',
-  tagline: 'A fully Java-based LLM Code Assistant plugin for IntelliJ IDEA',
+  tagline: 'A fully Java-based LLM Code Assistant plugin for JetBrains IDEs',
   favicon: 'img/favicon.ico',
   customFields: {
-    description: 'Enhance your Java development with AI assistance. DevoxxGenie is a free, open-source plugin that brings local and cloud LLM capabilities directly to your IntelliJ IDEA environment using your own API keys (BYOK).',
+    description: 'Enhance your development with AI assistance. DevoxxGenie is a free, open-source plugin that brings local and cloud LLM capabilities directly to your JetBrains IDE (IntelliJ IDEA, PyCharm, WebStorm, and more) using your own API keys (BYOK).',
     noIndex: false  // Allows search engines to index your site
   },
 
@@ -165,8 +165,8 @@ const config = {
       // SEO and Social cards
       image: 'img/devoxxgenie-social-card.jpg',
       metadata: [
-        {name: 'keywords', content: 'java, intellij plugin, llm, code assistant, spec-driven development, sdd, backlog.md, rag, ai coding, local llm, cloud llm, mcp, openai, anthropic, ollama'},
-        {name: 'description', content: 'DevoxxGenie is a free, open-source LLM Code Assistant plugin for IntelliJ IDEA. Supports local models (Ollama, LMStudio) and cloud providers (OpenAI, Anthropic, Google). Features include MCP, RAG, web search, custom commands, and LLM-activated skills.'},
+        {name: 'keywords', content: 'java, jetbrains plugin, intellij plugin, pycharm, webstorm, llm, code assistant, spec-driven development, sdd, backlog.md, rag, ai coding, local llm, cloud llm, mcp, openai, anthropic, ollama'},
+        {name: 'description', content: 'DevoxxGenie is a free, open-source LLM Code Assistant plugin for JetBrains IDEs (IntelliJ IDEA, PyCharm, WebStorm, and more). Supports local models (Ollama, LMStudio) and cloud providers (OpenAI, Anthropic, Google). Features include MCP, RAG, web search, custom commands, and LLM-activated skills.'},
         {property: 'og:type', content: 'website'},
         {property: 'og:site_name', content: 'DevoxxGenie'},
         {name: 'twitter:card', content: 'summary_large_image'},

--- a/docusaurus/docusaurus.config.js
+++ b/docusaurus/docusaurus.config.js
@@ -165,7 +165,7 @@ const config = {
       // SEO and Social cards
       image: 'img/devoxxgenie-social-card.jpg',
       metadata: [
-        {name: 'keywords', content: 'java, jetbrains plugin, intellij plugin, pycharm, webstorm, llm, code assistant, spec-driven development, sdd, backlog.md, rag, ai coding, local llm, cloud llm, mcp, openai, anthropic, ollama'},
+        {name: 'keywords', content: 'java, jetbrains plugin, intellij idea, pycharm, webstorm, phpstorm, rubymine, clion, goland, rider, datagrip, dataspell, rustrover, aqua, llm, code assistant, spec-driven development, sdd, backlog.md, rag, ai coding, local llm, cloud llm, mcp, openai, anthropic, ollama'},
         {name: 'description', content: 'DevoxxGenie is a free, open-source LLM Code Assistant plugin for JetBrains IDEs (IntelliJ IDEA, PyCharm, WebStorm, and more). Supports local models (Ollama, LMStudio) and cloud providers (OpenAI, Anthropic, Google). Features include MCP, RAG, web search, custom commands, and LLM-activated skills.'},
         {property: 'og:type', content: 'website'},
         {property: 'og:site_name', content: 'DevoxxGenie'},

--- a/docusaurus/src/pages/index.js
+++ b/docusaurus/src/pages/index.js
@@ -19,7 +19,7 @@ const softwareSchema = {
     'price': '0',
     'priceCurrency': 'USD'
   },
-  'description': 'A fully Java-based LLM Code Assistant plugin for IntelliJ IDEA, designed to integrate with both local and cloud-based LLM providers.',
+  'description': 'A fully Java-based LLM Code Assistant plugin for JetBrains IDEs (IntelliJ IDEA, PyCharm, WebStorm, and more), designed to integrate with both local and cloud-based LLM providers.',
   'screenshot': 'https://genie.devoxx.com/img/devoxxgenie-social-card.jpg',
   'softwareVersion': '0.9.13',
   'author': {
@@ -48,7 +48,7 @@ function HomepageHeader() {
         <source src={useBaseUrl('/img/DevoxxGenie.mp4')} type="video/mp4;codecs=avc1.42E01E" />
       </video>
       <div className={styles.heroOverlay}>
-        <h1 className="hero__title">DevoxxGenie — Free AI Code Assistant for IntelliJ IDEA</h1>
+        <h1 className="hero__title">DevoxxGenie — Free AI Code Assistant for JetBrains IDEs</h1>
         <p className="hero__subtitle">{siteConfig.tagline}</p>
         <div className={styles.buttons}>
           <Link
@@ -67,7 +67,7 @@ export default function Home() {
 
   return (
     <Layout
-      title="Free AI Code Assistant Plugin for IntelliJ IDEA"
+      title="Free AI Code Assistant Plugin for JetBrains IDEs"
       description={siteConfig.customFields.description}>
       <Head>
         <script type="application/ld+json">{JSON.stringify(softwareSchema)}</script>
@@ -108,7 +108,7 @@ export default function Home() {
             <div className="col col--6">
               <h2>The Power of AI in Your IDE</h2>
               <p>
-                DevoxxGenie is a fully Java-based LLM Code Assistant plugin for IntelliJ IDEA, designed to integrate with both local and cloud-based LLM providers.
+                DevoxxGenie is a fully Java-based LLM Code Assistant plugin for JetBrains IDEs (IntelliJ IDEA, PyCharm, WebStorm, and more), designed to integrate with both local and cloud-based LLM providers.
               </p>
               <p>
                 With DevoxxGenie, developers can leverage the power of artificial intelligence to improve code quality, solve problems faster, and learn new concepts, all within their familiar IDE environment.
@@ -134,7 +134,7 @@ export default function Home() {
                 >
                   <img
                     src="https://img.youtube.com/vi/t1MOHCfsdvk/maxresdefault.jpg"
-                    alt="DevoxxGenie AI Code Assistant demo video for IntelliJ IDEA"
+                    alt="DevoxxGenie AI Code Assistant demo video for JetBrains IDEs"
                     style={{width: '100%', display: 'block', borderRadius: '8px'}}
                   />
                   <div style={{


### PR DESCRIPTION
The docusaurus landing page described DevoxxGenie as a plugin for
IntelliJ IDEA only, but it supports any JetBrains IDE (IntelliJ IDEA,
PyCharm, WebStorm, etc.). Update the hero title, taglines, descriptions,
SEO metadata, and JSON-LD accordingly.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01DEQKGWQjM6NdAz57nhQS1K