### PR TITLE
fix: send max_completion_tokens for reasoning models on Custom OpenAI (#1225)

### DIFF
--- a/src/main/java/com/devoxx/genie/chatmodel/local/customopenai/CustomOpenAIChatModelFactory.java
+++ b/src/main/java/com/devoxx/genie/chatmodel/local/customopenai/CustomOpenAIChatModelFactory.java
@@ -58,19 +58,40 @@ public class CustomOpenAIChatModelFactory implements ChatModelFactory {
     @Override
     public ChatModel createChatModel(@NotNull CustomChatModel customChatModel) {
         DevoxxGenieStateService stateInstance = DevoxxGenieStateService.getInstance();
-        return OpenAiChatModel.builder()
+        OpenAiChatModel.OpenAiChatModelBuilder builder = OpenAiChatModel.builder()
                 .baseUrl(stateInstance.getCustomOpenAIUrl())
                 .apiKey(stateInstance.isCustomOpenAIApiKeyEnabled() ? stateInstance.getCustomOpenAIApiKey() : "na")
                 .modelName(resolveModelName(customChatModel))
                 .maxRetries(customChatModel.getMaxRetries())
                 .temperature(customChatModel.getTemperature())
-                .maxTokens(customChatModel.getMaxTokens())
                 .timeout(Duration.ofSeconds(customChatModel.getTimeout()))
                 .topP(customChatModel.getTopP())
                 .returnThinking(ThinkingSupport.isEnabled())
                 .listeners(getListener())
-                .httpClientBuilder(getHttpClientBuilder())
-                .build();
+                .httpClientBuilder(getHttpClientBuilder());
+
+        applyOutputTokenLimit(builder, customChatModel);
+
+        return builder.build();
+    }
+
+    /**
+     * Send the output-token cap under the field name the endpoint accepts.
+     *
+     * <p>Issue #1225: reasoning-family models (o1/o3/GPT-5) reject the legacy {@code max_tokens}
+     * with {@code 400 unsupported_parameter} and require {@code max_completion_tokens}. The two are
+     * mutually exclusive on the wire — sending both makes such a model fail on the legacy one — so
+     * exactly one is set, chosen by the "Custom OpenAI max_completion_tokens" setting. The model
+     * name is deliberately not sniffed: gateways such as LiteLLM expose arbitrary aliases
+     * ({@code gpt-chat-latest} in the report) that no naming pattern can reliably classify.</p>
+     */
+    private static void applyOutputTokenLimit(OpenAiChatModel.@NotNull OpenAiChatModelBuilder builder,
+                                              @NotNull CustomChatModel customChatModel) {
+        if (DevoxxGenieStateService.getInstance().isCustomOpenAIUseMaxCompletionTokens()) {
+            builder.maxCompletionTokens(customChatModel.getMaxTokens());
+        } else {
+            builder.maxTokens(customChatModel.getMaxTokens());
+        }
     }
 
     @Override

--- a/src/main/java/com/devoxx/genie/ui/settings/DevoxxGenieStateService.java
+++ b/src/main/java/com/devoxx/genie/ui/settings/DevoxxGenieStateService.java
@@ -156,6 +156,13 @@ public final class DevoxxGenieStateService implements PersistentStateComponent<D
     private boolean isCustomOpenAIForceHttp11 = false;
     private boolean isCustomOpenAIModelNameEnabled = false;
     private boolean isCustomOpenAIApiKeyEnabled = false;
+    /**
+     * Issue #1225: reasoning-family models (o1/o3/GPT-5, and gateways fronting them such as
+     * LiteLLM) reject the legacy {@code max_tokens} field with a 400 and demand
+     * {@code max_completion_tokens} instead. When enabled, the output-token cap is sent under
+     * the new name. Off by default so existing endpoints keep their current wire format.
+     */
+    private boolean isCustomOpenAIUseMaxCompletionTokens = false;
 
     // Remote LLM Providers
     private boolean isOpenAIEnabled = false;

--- a/src/main/java/com/devoxx/genie/ui/settings/llm/LLMProvidersComponent.java
+++ b/src/main/java/com/devoxx/genie/ui/settings/llm/LLMProvidersComponent.java
@@ -160,6 +160,8 @@ public class LLMProvidersComponent extends AbstractSettingsComponent {
     @Getter
     private final JCheckBox enableCustomOpenAIApiKeyCheckBox = new JCheckBox("", stateService.isCustomOpenAIApiKeyEnabled());
     @Getter
+    private final JCheckBox customOpenAIUseMaxCompletionTokensCheckBox = new JCheckBox("", stateService.isCustomOpenAIUseMaxCompletionTokens());
+    @Getter
     private final JCheckBox openAIEnabledCheckBox = new JCheckBox("", stateService.isOpenAIEnabled());
     @Getter
     private final JCheckBox mistralEnabledCheckBox = new JCheckBox("", stateService.isMistralEnabled());
@@ -259,6 +261,10 @@ public class LLMProvidersComponent extends AbstractSettingsComponent {
         addProviderSettingRow(panel, gbc, "Custom OpenAI API Key", enableCustomOpenAIApiKeyCheckBox, customOpenAIApiKeyField);
         addProviderSettingRow(panel, gbc, "Custom OpenAI HTTP 1.1", customOpenAIForceHttp11CheckBox);
         addHintText(panel, gbc, "Use HTTP/2 when unchecked");
+        addProviderSettingRow(panel, gbc, "Custom OpenAI max_completion_tokens", customOpenAIUseMaxCompletionTokensCheckBox);
+        addHintText(panel, gbc, "Send the output token limit as <code>max_completion_tokens</code> instead of <code>max_tokens</code>. " +
+                "Enable this for reasoning models (o1, o3, GPT-5) and gateways such as LiteLLM fronting them, which reject <code>max_tokens</code> with " +
+                "<i>\"Unsupported parameter: 'max_tokens' is not supported with this model\"</i>.");
         addProviderSettingRow(panel, gbc, "Custom OpenAI Context Window", customOpenAIContextWindowEnabledCheckBox, customOpenAIContextWindowField);
         addHintText(panel, gbc, "Token window used for the usage bar and token calculation. When unchecked, DevoxxGenie assumes " + CustomOpenAIContextWindow.DEFAULT_CONTEXT_WINDOW + " tokens. Set this to your internal model's real context size to avoid a false red 'context exceeded' warning (the request is sent either way).");
         addSettingRow(panel, gbc, "Custom OpenAI Input Cost", customOpenAIInputCostField);

--- a/src/main/java/com/devoxx/genie/ui/settings/llm/LLMProvidersConfigurable.java
+++ b/src/main/java/com/devoxx/genie/ui/settings/llm/LLMProvidersConfigurable.java
@@ -130,6 +130,7 @@ public class LLMProvidersConfigurable implements Configurable {
         isModified |= stateService.isCustomOpenAIUrlEnabled() != llmSettingsComponent.getCustomOpenAIUrlEnabledCheckBox().isSelected();
         isModified |= stateService.isCustomOpenAIModelNameEnabled() != llmSettingsComponent.getCustomOpenAIModelNameEnabledCheckBox().isSelected();
         isModified |= stateService.isCustomOpenAIForceHttp11() != llmSettingsComponent.getCustomOpenAIForceHttp11CheckBox().isSelected();
+        isModified |= stateService.isCustomOpenAIUseMaxCompletionTokens() != llmSettingsComponent.getCustomOpenAIUseMaxCompletionTokensCheckBox().isSelected();
 
         isModified |= stateService.isOpenAIEnabled() != llmSettingsComponent.getOpenAIEnabledCheckBox().isSelected();
         isModified |= stateService.isMistralEnabled() != llmSettingsComponent.getMistralEnabledCheckBox().isSelected();
@@ -181,6 +182,7 @@ public class LLMProvidersConfigurable implements Configurable {
         settings.setCustomOpenAIApiKey(new String(llmSettingsComponent.getCustomOpenAIApiKeyField().getPassword()));
         settings.setCustomOpenAIApiKeyEnabled(llmSettingsComponent.getEnableCustomOpenAIApiKeyCheckBox().isSelected());
         settings.setCustomOpenAIForceHttp11(llmSettingsComponent.getCustomOpenAIForceHttp11CheckBox().isSelected());
+        settings.setCustomOpenAIUseMaxCompletionTokens(llmSettingsComponent.getCustomOpenAIUseMaxCompletionTokensCheckBox().isSelected());
         settings.setCustomOpenAIContextWindow(
                 llmSettingsComponent.getCustomOpenAIContextWindowEnabledCheckBox().isSelected()
                         ? llmSettingsComponent.getCustomOpenAIContextWindowField().getNumber()
@@ -480,6 +482,7 @@ public class LLMProvidersConfigurable implements Configurable {
         llmSettingsComponent.getCustomOpenAIUrlEnabledCheckBox().setSelected(settings.isCustomOpenAIUrlEnabled());
         llmSettingsComponent.getCustomOpenAIModelNameEnabledCheckBox().setSelected(settings.isCustomOpenAIModelNameEnabled());
         llmSettingsComponent.getCustomOpenAIForceHttp11CheckBox().setSelected(settings.isCustomOpenAIForceHttp11());
+        llmSettingsComponent.getCustomOpenAIUseMaxCompletionTokensCheckBox().setSelected(settings.isCustomOpenAIUseMaxCompletionTokens());
 
 
         llmSettingsComponent.getOpenAIEnabledCheckBox().setSelected(settings.isOpenAIEnabled());

--- a/src/test/java/com/devoxx/genie/chatmodel/local/customopenai/CustomOpenAIMaxCompletionTokensTest.java
+++ b/src/test/java/com/devoxx/genie/chatmodel/local/customopenai/CustomOpenAIMaxCompletionTokensTest.java
@@ -1,0 +1,134 @@
+package com.devoxx.genie.chatmodel.local.customopenai;
+
+import com.devoxx.genie.model.CustomChatModel;
+import com.devoxx.genie.service.mcp.MCPService;
+import com.devoxx.genie.ui.settings.DevoxxGenieStateService;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import dev.langchain4j.model.chat.ChatModel;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import java.io.IOException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Issue #1225: models of the reasoning family (o1/o3/GPT-5) reject the legacy {@code max_tokens}
+ * field with {@code 400 Unsupported parameter: 'max_tokens' is not supported with this model.
+ * Use 'max_completion_tokens' instead}. A LiteLLM gateway fronting such a model (reported case:
+ * {@code gpt-chat-latest}) surfaces the same 400 while its {@code gpt-4o} / {@code gpt-4.1} models
+ * keep working.
+ *
+ * <p>These tests assert the actual JSON on the wire, since the whole bug is which field name gets
+ * serialised.</p>
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class CustomOpenAIMaxCompletionTokensTest {
+
+    private static final String CHAT_COMPLETION_RESPONSE = """
+            {
+              "id": "chatcmpl-1",
+              "object": "chat.completion",
+              "model": "gpt-chat-latest",
+              "choices": [
+                {"index": 0, "message": {"role": "assistant", "content": "ok"}, "finish_reason": "stop"}
+              ],
+              "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2}
+            }
+            """;
+
+    private MockWebServer server;
+    private MockedStatic<DevoxxGenieStateService> mockedStateService;
+    private MockedStatic<MCPService> mockedMCPService;
+    private DevoxxGenieStateService mockState;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        server = new MockWebServer();
+        server.start();
+
+        mockState = mock(DevoxxGenieStateService.class);
+        when(mockState.getCustomOpenAIUrl()).thenReturn(server.url("/v1/").toString());
+        when(mockState.isCustomOpenAIApiKeyEnabled()).thenReturn(false);
+        when(mockState.getCustomOpenAIApiKey()).thenReturn("");
+        when(mockState.isCustomOpenAIModelNameEnabled()).thenReturn(false);
+        when(mockState.getCustomOpenAIModelName()).thenReturn("");
+        when(mockState.isCustomOpenAIForceHttp11()).thenReturn(false);
+        when(mockState.isCustomOpenAIUseMaxCompletionTokens()).thenReturn(false);
+        when(mockState.getAgentModeEnabled()).thenReturn(false);
+
+        mockedStateService = Mockito.mockStatic(DevoxxGenieStateService.class);
+        mockedStateService.when(DevoxxGenieStateService::getInstance).thenReturn(mockState);
+
+        mockedMCPService = Mockito.mockStatic(MCPService.class);
+        mockedMCPService.when(MCPService::isMCPEnabled).thenReturn(false);
+    }
+
+    @AfterEach
+    void tearDown() throws IOException {
+        if (mockedStateService != null) mockedStateService.close();
+        if (mockedMCPService != null) mockedMCPService.close();
+        try {
+            server.shutdown();
+        } catch (IOException e) {
+            // Ignore shutdown errors from pending responses
+        }
+    }
+
+    @Test
+    void sendsMaxCompletionTokensWhenSettingEnabled() throws InterruptedException {
+        when(mockState.isCustomOpenAIUseMaxCompletionTokens()).thenReturn(true);
+
+        JsonObject body = chat("gpt-chat-latest", 256);
+
+        // The whole point of the setting: the cap travels under the new name...
+        assertThat(body.has("max_completion_tokens")).isTrue();
+        assertThat(body.get("max_completion_tokens").getAsInt()).isEqualTo(256);
+        // ...and the legacy name is absent, since its mere presence is what the model rejects.
+        assertThat(body.has("max_tokens")).isFalse();
+    }
+
+    @Test
+    void sendsLegacyMaxTokensWhenSettingDisabled() throws InterruptedException {
+        JsonObject body = chat("gpt-4o", 256);
+
+        // Default stays on the legacy field so endpoints that only understand it keep working.
+        assertThat(body.has("max_tokens")).isTrue();
+        assertThat(body.get("max_tokens").getAsInt()).isEqualTo(256);
+        assertThat(body.has("max_completion_tokens")).isFalse();
+    }
+
+    private JsonObject chat(String modelName, int maxTokens) throws InterruptedException {
+        server.enqueue(new MockResponse()
+                .setBody(CHAT_COMPLETION_RESPONSE)
+                .setHeader("Content-Type", "application/json"));
+
+        CustomChatModel customChatModel = new CustomChatModel();
+        customChatModel.setModelName(modelName);
+        customChatModel.setTemperature(0.7);
+        customChatModel.setTopP(0.9);
+        customChatModel.setMaxTokens(maxTokens);
+        customChatModel.setMaxRetries(1);
+        customChatModel.setTimeout(10);
+
+        ChatModel model = new CustomOpenAIChatModelFactory().createChatModel(customChatModel);
+        model.chat("hello");
+
+        RecordedRequest recordedRequest = server.takeRequest();
+        return JsonParser.parseString(recordedRequest.getBody().readUtf8()).getAsJsonObject();
+    }
+}

--- a/src/test/java/com/devoxx/genie/ui/settings/llm/LLMProvidersConfigurableTest.java
+++ b/src/test/java/com/devoxx/genie/ui/settings/llm/LLMProvidersConfigurableTest.java
@@ -112,6 +112,31 @@ class LLMProvidersConfigurableTest {
 
 
     @Test
+    void shouldApplyCustomOpenAIUseMaxCompletionTokensSetting() throws ConfigurationException {
+        // Issue #1225: the checkbox that switches the output cap to 'max_completion_tokens'
+        // must survive the isModified/apply round-trip, or reasoning models stay broken
+        // after the user ticks it.
+        LLMProvidersComponent component = getSettingsComponent();
+
+        component.getCustomOpenAIUseMaxCompletionTokensCheckBox().setSelected(true);
+
+        assertThat(configurable.isModified()).isTrue();
+
+        configurable.apply();
+
+        assertThat(stateService.isCustomOpenAIUseMaxCompletionTokens()).isTrue();
+    }
+
+    @Test
+    void shouldResetCustomOpenAIUseMaxCompletionTokensSetting() {
+        stateService.setCustomOpenAIUseMaxCompletionTokens(true);
+
+        configurable.reset();
+
+        assertThat(getSettingsComponent().getCustomOpenAIUseMaxCompletionTokensCheckBox().isSelected()).isTrue();
+    }
+
+    @Test
     void shouldApplyCustomOpenAIContextWindowSetting() throws ConfigurationException {
         LLMProvidersComponent component = getSettingsComponent();
 


### PR DESCRIPTION
Fixes #1225

## Problem

Reasoning-family models (o1/o3/GPT-5) and gateways fronting them reject the legacy `max_tokens` field:

```
litellm.BadRequestError: Azure_aiException - Unsupported parameter: 'max_tokens' is not
supported with this model. Use 'max_completion_tokens' instead.
```

Reported against a LiteLLM endpoint serving `gpt-chat-latest`, where `gpt-4o` and `gpt-4.1` on the same endpoint kept working.

## Cause

`CustomOpenAIChatModelFactory.createChatModel()` unconditionally called `.maxTokens(...)`, which langchain4j serialises as `max_tokens`.

Note that `createStreamingChatModel()` sets no token cap at all, so streaming mode was never affected — the reporter must have streaming off.

## Fix

A new **Custom OpenAI max_completion_tokens** setting (LLM Providers, off by default) switches the builder to `.maxCompletionTokens(...)`. Exactly one of the two is ever set: the mere presence of the legacy field is what the model rejects, so sending both would not help.

The model name is deliberately **not** sniffed — gateways such as LiteLLM expose arbitrary aliases (`gpt-chat-latest`) that no naming pattern can reliably classify, which is why this is an explicit setting rather than a heuristic.

## Tests

`CustomOpenAIMaxCompletionTokensTest` asserts the JSON actually on the wire via MockWebServer, since the bug is purely one of which field name gets serialised:

- setting on → `max_completion_tokens: 256` present, `max_tokens` absent
- setting off → `max_tokens: 256` present, `max_completion_tokens` absent

The test was written first and confirmed red on the enabled case. Two round-trip tests in `LLMProvidersConfigurableTest` cover isModified/apply/reset for the new checkbox.

`./gradlew build` and `./gradlew test` green.

## Not addressed here

The same unconditional `.maxTokens(...)` exists in `LocalChatModelFactory:71`, `DeepInfraChatModelFactory:29`, `CloudflareChatModelFactory:58` and `NvidiaChatModelFactory:165`, which would fail identically against a GPT-5-class model. Left alone to keep this focused on the reported provider.

🤖 Generated with [Claude Code](https://claude.com/claude-code)