### PR TITLE
fix: show agent tool activity during streaming

### DIFF
--- a/backlog/tasks/task-254 - Show-agent-tool-activity-during-streaming-responses.md
+++ b/backlog/tasks/task-254 - Show-agent-tool-activity-during-streaming-responses.md
@@ -1,11 +1,11 @@
 ---
 id: TASK-254
 title: Show agent tool activity during streaming responses
-status: In Progress
+status: Done
 assignee:
   - Codex
 created_date: '2026-07-24 12:23'
-updated_date: '2026-07-24 12:39'
+updated_date: '2026-07-24 12:43'
 labels:
   - bug
   - agent
@@ -39,7 +39,7 @@ Agent tool calls are recorded in DevoxxGenie Logs but their matching rows disapp
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Agent tool requests and results appear in the matching streaming conversation when chat tool activity is enabled
+- [x] #1 Agent tool requests and results appear in the matching streaming conversation when chat tool activity is enabled
 - [x] #2 Agent tool activity continues to appear for non-streaming conversations
 - [x] #3 Raw request and response payloads remain excluded from the conversation output
 - [x] #4 Automated regression coverage verifies the streaming activity lifecycle
@@ -82,3 +82,18 @@ created: 2026-07-24 12:29
 Investigation reproduced the issue: matching AGT tool request/result events appear in DevoxxGenie Logs but not the conversation when streaming is enabled; disabling streaming renders them in chat.
 ---
 <!-- COMMENTS:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+## Summary
+- Serialized in-chat activity delivery onto the IntelliJ EDT so streaming Compose updates cannot race background agent events.
+- Captured and validated the active prompt generation to discard stale queued activity rather than attach it to a later prompt.
+- Preserved RAW payload filtering and added dispatcher, streaming lifecycle, and prompt-switch regression coverage.
+
+## Validation
+- Manual in-IDE streaming verification confirmed agent activity now appears in the conversation (user confirmation).
+- `./gradlew test --rerun-tasks --tests com.devoxx.genie.ui.panel.conversation.ActivityMessageDispatcherTest --tests com.devoxx.genie.ui.compose.viewmodel.ConversationViewModelTest` (40 passing tests).
+- `./gradlew buildPlugin`.
+- Independent code review completed with no remaining findings.
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/backlog/tasks/task-254 - Show-agent-tool-activity-during-streaming-responses.md
+++ b/backlog/tasks/task-254 - Show-agent-tool-activity-during-streaming-responses.md
@@ -5,7 +5,7 @@ status: Done
 assignee:
   - Codex
 created_date: '2026-07-24 12:23'
-updated_date: '2026-07-24 12:43'
+updated_date: '2026-07-24 12:44'
 labels:
   - bug
   - agent
@@ -96,4 +96,7 @@ Investigation reproduced the issue: matching AGT tool request/result events appe
 - `./gradlew test --rerun-tasks --tests com.devoxx.genie.ui.panel.conversation.ActivityMessageDispatcherTest --tests com.devoxx.genie.ui.compose.viewmodel.ConversationViewModelTest` (40 passing tests).
 - `./gradlew buildPlugin`.
 - Independent code review completed with no remaining findings.
+
+## Pull Request
+- https://github.com/devoxx/DevoxxGenieIDEAPlugin/pull/1235
 <!-- SECTION:FINAL_SUMMARY:END -->

--- a/backlog/tasks/task-254 - Show-agent-tool-activity-during-streaming-responses.md
+++ b/backlog/tasks/task-254 - Show-agent-tool-activity-during-streaming-responses.md
@@ -5,7 +5,7 @@ status: In Progress
 assignee:
   - Codex
 created_date: '2026-07-24 12:23'
-updated_date: '2026-07-24 12:31'
+updated_date: '2026-07-24 12:39'
 labels:
   - bug
   - agent
@@ -14,6 +14,19 @@ labels:
 dependencies: []
 documentation:
   - docs/superpowers/specs/2026-07-24-streaming-agent-activity-design.md
+modified_files:
+  - >-
+    src/main/java/com/devoxx/genie/ui/panel/conversation/ActivityMessageDispatcher.java
+  - src/main/java/com/devoxx/genie/ui/panel/conversation/ConversationPanel.java
+  - src/main/kotlin/com/devoxx/genie/ui/compose/ConversationViewController.kt
+  - >-
+    src/main/kotlin/com/devoxx/genie/ui/compose/ComposeConversationViewController.kt
+  - >-
+    src/main/kotlin/com/devoxx/genie/ui/compose/viewmodel/ConversationViewModel.kt
+  - >-
+    src/test/java/com/devoxx/genie/ui/panel/conversation/ActivityMessageDispatcherTest.java
+  - >-
+    src/test/kotlin/com/devoxx/genie/ui/compose/viewmodel/ConversationViewModelTest.kt
 priority: high
 ordinal: 3000
 ---
@@ -27,9 +40,9 @@ Agent tool calls are recorded in DevoxxGenie Logs but their matching rows disapp
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
 - [ ] #1 Agent tool requests and results appear in the matching streaming conversation when chat tool activity is enabled
-- [ ] #2 Agent tool activity continues to appear for non-streaming conversations
-- [ ] #3 Raw request and response payloads remain excluded from the conversation output
-- [ ] #4 Automated regression coverage verifies the streaming activity lifecycle
+- [x] #2 Agent tool activity continues to appear for non-streaming conversations
+- [x] #3 Raw request and response payloads remain excluded from the conversation output
+- [x] #4 Automated regression coverage verifies the streaming activity lifecycle
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -53,6 +66,12 @@ A single focused change that serializes in-chat activity delivery with streaming
 - Modify: src/test/kotlin/com/devoxx/genie/ui/compose/viewmodel/ConversationViewModelTest.kt
 - Create: docs/superpowers/plans/2026-07-24-streaming-agent-activity.md
 <!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented on `fix/task-254-show-agent-tool-activity-during-streaming` in commits `bf2af431` and `9fb4a83a`. Activity bus events now transition to the IntelliJ EDT before mutating Compose state and retain the active prompt generation; stale queued events are dropped after a prompt switch. Focused regression tests and `./gradlew buildPlugin` pass. Independent review identified the prompt-switch race; it was fixed with a queued interleaving test. In-IDE streaming verification remains pending.
+<!-- SECTION:NOTES:END -->
 
 ## Comments
 

--- a/backlog/tasks/task-254 - Show-agent-tool-activity-during-streaming-responses.md
+++ b/backlog/tasks/task-254 - Show-agent-tool-activity-during-streaming-responses.md
@@ -2,15 +2,18 @@
 id: TASK-254
 title: Show agent tool activity during streaming responses
 status: In Progress
-assignee: []
+assignee:
+  - Codex
 created_date: '2026-07-24 12:23'
-updated_date: '2026-07-24 12:29'
+updated_date: '2026-07-24 12:31'
 labels:
   - bug
   - agent
   - streaming
   - ui
 dependencies: []
+documentation:
+  - docs/superpowers/specs/2026-07-24-streaming-agent-activity-design.md
 priority: high
 ordinal: 3000
 ---
@@ -28,6 +31,28 @@ Agent tool calls are recorded in DevoxxGenie Logs but their matching rows disapp
 - [ ] #3 Raw request and response payloads remain excluded from the conversation output
 - [ ] #4 Automated regression coverage verifies the streaming activity lifecycle
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+# TASK-254 Implementation Plan
+
+## Scope
+A single focused change that serializes in-chat activity delivery with streaming UI updates. No provider, tool-execution, or raw-log changes.
+
+## Steps
+1. Add a focused test seam for dispatching activity messages to the IntelliJ UI queue; verify delivery is deferred and preserves the original activity event.
+2. Update the conversation-panel activity subscription to route accepted messages through that dispatcher before calling the Compose conversation controller.
+3. Add regression coverage for a streamed message lifecycle in the view model: tool request opens an entry, a streamed response update preserves it, and tool response resolves it.
+4. Run the focused Compose and dispatcher tests, then the relevant Gradle test suite.
+
+## Files
+- Create: src/main/java/com/devoxx/genie/ui/panel/conversation/ActivityMessageDispatcher.java
+- Create: src/test/java/com/devoxx/genie/ui/panel/conversation/ActivityMessageDispatcherTest.java
+- Modify: src/main/java/com/devoxx/genie/ui/panel/conversation/ConversationPanel.java
+- Modify: src/test/kotlin/com/devoxx/genie/ui/compose/viewmodel/ConversationViewModelTest.kt
+- Create: docs/superpowers/plans/2026-07-24-streaming-agent-activity.md
+<!-- SECTION:PLAN:END -->
 
 ## Comments
 

--- a/backlog/tasks/task-254 - Show-agent-tool-activity-during-streaming-responses.md
+++ b/backlog/tasks/task-254 - Show-agent-tool-activity-during-streaming-responses.md
@@ -1,0 +1,40 @@
+---
+id: TASK-254
+title: Show agent tool activity during streaming responses
+status: In Progress
+assignee: []
+created_date: '2026-07-24 12:23'
+updated_date: '2026-07-24 12:29'
+labels:
+  - bug
+  - agent
+  - streaming
+  - ui
+dependencies: []
+priority: high
+ordinal: 3000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Agent tool calls are recorded in DevoxxGenie Logs but their matching rows disappear from the conversation output when streaming is enabled. With streaming disabled, the same activity renders in chat. Restore consistent in-chat visibility without exposing raw request/response payloads.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Agent tool requests and results appear in the matching streaming conversation when chat tool activity is enabled
+- [ ] #2 Agent tool activity continues to appear for non-streaming conversations
+- [ ] #3 Raw request and response payloads remain excluded from the conversation output
+- [ ] #4 Automated regression coverage verifies the streaming activity lifecycle
+<!-- AC:END -->
+
+## Comments
+
+<!-- COMMENTS:BEGIN -->
+author: Codex
+created: 2026-07-24 12:29
+---
+Investigation reproduced the issue: matching AGT tool request/result events appear in DevoxxGenie Logs but not the conversation when streaming is enabled; disabling streaming renders them in chat.
+---
+<!-- COMMENTS:END -->

--- a/docs/superpowers/plans/2026-07-24-streaming-agent-activity.md
+++ b/docs/superpowers/plans/2026-07-24-streaming-agent-activity.md
@@ -1,0 +1,104 @@
+# Streaming Agent Activity Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make streaming conversations retain the agent tool-activity timeline already available in non-streaming conversations.
+
+**Architecture:** Activity events cross from background tool execution into the Compose conversation UI. Marshal them onto the IntelliJ EDT at the conversation-panel boundary so they serialize with streaming partial/final response updates. A small dispatcher isolates the queueing behavior for unit tests; the view model remains responsible for formatting, pairing, and RAW-event exclusion.
+
+**Tech Stack:** IntelliJ Platform message bus/EDT, Java 17, Kotlin, Compose Desktop, JUnit 5, AssertJ.
+
+---
+
+### Task 1: Serialize conversation activity delivery
+
+**Files:**
+- Create: `src/main/java/com/devoxx/genie/ui/panel/conversation/ActivityMessageDispatcher.java`
+- Create: `src/test/java/com/devoxx/genie/ui/panel/conversation/ActivityMessageDispatcherTest.java`
+- Modify: `src/main/java/com/devoxx/genie/ui/panel/conversation/ConversationPanel.java:165-173`
+
+- [ ] **Step 1: Write the failing dispatcher test**
+
+```java
+@Test
+void dispatch_defersActivityHandlingUntilTheUiQueueRuns() {
+    List<Runnable> queued = new ArrayList<>();
+    ActivityMessage message = ActivityMessage.builder().source(ActivitySource.AGENT).build();
+    AtomicReference<ActivityMessage> delivered = new AtomicReference<>();
+
+    ActivityMessageDispatcher dispatcher = new ActivityMessageDispatcher(queued::add);
+    dispatcher.dispatch(message, delivered::set);
+
+    assertThat(delivered).hasValue(null);
+    assertThat(queued).hasSize(1);
+    queued.getFirst().run();
+    assertThat(delivered).hasValueSameInstanceAs(message);
+}
+```
+
+- [ ] **Step 2: Run the test and confirm it fails because the dispatcher does not exist**
+
+Run: `./gradlew test --tests com.devoxx.genie.ui.panel.conversation.ActivityMessageDispatcherTest`
+
+- [ ] **Step 3: Add the minimal dispatcher and use it from `ConversationPanel`**
+
+```java
+final class ActivityMessageDispatcher {
+    void dispatch(ActivityMessage message, Consumer<ActivityMessage> consumer) {
+        ApplicationManager.getApplication().invokeLater(() -> consumer.accept(message));
+    }
+}
+```
+
+The panel keeps its project-hash filter, then delegates `viewController::onActivityMessage` through this dispatcher.
+
+- [ ] **Step 4: Run the dispatcher test and confirm it passes**
+
+Run: `./gradlew test --tests com.devoxx.genie.ui.panel.conversation.ActivityMessageDispatcherTest`
+
+### Task 2: Guard the streaming lifecycle against timeline loss
+
+**Files:**
+- Modify: `src/test/kotlin/com/devoxx/genie/ui/compose/viewmodel/ConversationViewModelTest.kt`
+
+- [ ] **Step 1: Write a failing lifecycle test**
+
+```kotlin
+@Test
+fun `streamed response update preserves an open agent tool entry`() {
+    val viewModel = ConversationViewModel(showToolActivityInChat = { true })
+    viewModel.addUserPromptMessage(ChatMessageContext.builder().id("msg-1").userPrompt("time").build())
+    viewModel.onActivityMessage(toolRequest("run_command", "{\\\"command\\\":\\\"date\\\"}"))
+    viewModel.updateAiMessageContent(ChatMessageContext.builder().id("msg-1").aiMessage(AiMessage.from("answer")).build())
+    viewModel.onActivityMessage(toolResponse("run_command", "Fri Jul 24", callNumber = 1))
+
+    assertThat(activeMessageEntries(viewModel).single().status).isEqualTo(ActivityStatus.SUCCESS)
+}
+```
+
+- [ ] **Step 2: Run the focused Kotlin test and confirm it passes after Task 1’s serialized delivery behavior is in place**
+
+Run: `./gradlew test --tests com.devoxx.genie.ui.compose.viewmodel.ConversationViewModelTest`
+
+- [ ] **Step 3: Run focused regression verification**
+
+Run: `./gradlew test --tests com.devoxx.genie.ui.panel.conversation.ActivityMessageDispatcherTest --tests com.devoxx.genie.ui.compose.viewmodel.ConversationViewModelTest`
+
+Expected: both test classes pass.
+
+### Task 3: Validate the task outcome
+
+**Files:**
+- Modify: `backlog/tasks/task-254 - Show-agent-tool-activity-during-streaming-responses.md` (through Backlog MCP only)
+
+- [ ] **Step 1: Run the project’s relevant test suite**
+
+Run: `./gradlew test --tests com.devoxx.genie.ui.panel.conversation.ActivityMessageDispatcherTest --tests com.devoxx.genie.ui.compose.viewmodel.ConversationViewModelTest`
+
+- [ ] **Step 2: Inspect the diff**
+
+Run: `git diff --check && git diff -- src/main/java/com/devoxx/genie/ui/panel/conversation/ConversationPanel.java src/main/java/com/devoxx/genie/ui/panel/conversation/ActivityMessageDispatcher.java src/test/java/com/devoxx/genie/ui/panel/conversation/ActivityMessageDispatcherTest.java src/test/kotlin/com/devoxx/genie/ui/compose/viewmodel/ConversationViewModelTest.kt`
+
+- [ ] **Step 3: Update Backlog acceptance criteria and notes once verification evidence is available**
+
+Use `backlog.task_edit` to check each satisfied acceptance criterion and record the exact test command/result.

--- a/docs/superpowers/specs/2026-07-24-streaming-agent-activity-design.md
+++ b/docs/superpowers/specs/2026-07-24-streaming-agent-activity-design.md
@@ -1,0 +1,20 @@
+# Streaming Agent Activity Design
+
+## Goal
+Show agent tool requests and results in the matching conversation while a response streams, just as they are shown when streaming is disabled.
+
+## Context
+The Activity Log receives matching `AGENT` events for streaming runs, but the Compose conversation timeline does not display them. Streaming response text is explicitly applied on the IntelliJ EDT, while `ConversationPanel` forwards activity messages synchronously from the publishing thread to the Compose view model. This mixes concurrent UI-state updates and allows streamed response rendering to replace an activity update.
+
+## Design
+`ConversationPanel` will marshal each accepted activity message onto the IntelliJ EDT before calling `ConversationViewController.onActivityMessage`. It will keep its existing project-location filter. The EDT then serializes activity changes with streaming partial/final response updates, loading-indicator changes, and the Compose runtime.
+
+The change intentionally applies to all activity sources delivered to the conversation panel. `ConversationViewModel` remains responsible for excluding `RAW` messages, so raw request and response payloads remain visible only in the Activity Log tool window.
+
+## Alternatives Considered
+1. Marshal activity delivery in `ConversationPanel` (chosen): a narrow, UI-bound ordering fix at the message-bus-to-Compose boundary.
+2. Marshal every `ComposeConversationViewController` method: broader than required and risks changing unrelated callers.
+3. Buffer activity inside streaming handlers: requires correlating events to requests and would weaken live progress updates.
+
+## Testing
+Add a regression test that verifies activity events are dispatched through the EDT boundary and retain the request/result lifecycle while a streaming response update is queued. Keep existing view-model tests for non-streaming behavior and RAW-message exclusion.

--- a/src/main/java/com/devoxx/genie/ui/panel/conversation/ActivityMessageDispatcher.java
+++ b/src/main/java/com/devoxx/genie/ui/panel/conversation/ActivityMessageDispatcher.java
@@ -1,0 +1,27 @@
+package com.devoxx.genie.ui.panel.conversation;
+
+import com.devoxx.genie.model.activity.ActivityMessage;
+import com.intellij.openapi.application.ApplicationManager;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.function.Consumer;
+
+/**
+ * Serializes activity-log delivery with Swing and Compose UI updates on the IntelliJ EDT.
+ */
+final class ActivityMessageDispatcher {
+
+    private final Consumer<Runnable> uiQueue;
+
+    ActivityMessageDispatcher() {
+        this(runnable -> ApplicationManager.getApplication().invokeLater(runnable));
+    }
+
+    ActivityMessageDispatcher(@NotNull Consumer<Runnable> uiQueue) {
+        this.uiQueue = uiQueue;
+    }
+
+    void dispatch(@NotNull ActivityMessage message, @NotNull Consumer<ActivityMessage> consumer) {
+        uiQueue.accept(() -> consumer.accept(message));
+    }
+}

--- a/src/main/java/com/devoxx/genie/ui/panel/conversation/ActivityMessageDispatcher.java
+++ b/src/main/java/com/devoxx/genie/ui/panel/conversation/ActivityMessageDispatcher.java
@@ -4,6 +4,7 @@ import com.devoxx.genie.model.activity.ActivityMessage;
 import com.intellij.openapi.application.ApplicationManager;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.function.IntSupplier;
 import java.util.function.Consumer;
 
 /**
@@ -23,5 +24,20 @@ final class ActivityMessageDispatcher {
 
     void dispatch(@NotNull ActivityMessage message, @NotNull Consumer<ActivityMessage> consumer) {
         uiQueue.accept(() -> consumer.accept(message));
+    }
+
+    /**
+     * Delivers an activity only while the prompt generation that produced it remains active.
+     * This prevents an event waiting on the EDT from being attached to a later prompt.
+     */
+    void dispatch(@NotNull ActivityMessage message,
+                  int expectedGeneration,
+                  @NotNull IntSupplier currentGeneration,
+                  @NotNull Consumer<ActivityMessage> consumer) {
+        uiQueue.accept(() -> {
+            if (expectedGeneration == currentGeneration.getAsInt()) {
+                consumer.accept(message);
+            }
+        });
     }
 }

--- a/src/main/java/com/devoxx/genie/ui/panel/conversation/ConversationPanel.java
+++ b/src/main/java/com/devoxx/genie/ui/panel/conversation/ConversationPanel.java
@@ -48,6 +48,7 @@ public class ConversationPanel
     private final MessageBusConnection messageBusConnection;
     private final ChatService chatService;
     private final JComponent displayComponent;
+    private final ActivityMessageDispatcher activityMessageDispatcher = new ActivityMessageDispatcher();
 
     public final ConversationViewController viewController;
 
@@ -169,7 +170,7 @@ public class ConversationPanel
             if (hash != null && !hash.equals(projectHash)) {
                 return;
             }
-            viewController.onActivityMessage(message);
+            activityMessageDispatcher.dispatch(message, viewController::onActivityMessage);
         });
     }
 

--- a/src/main/java/com/devoxx/genie/ui/panel/conversation/ConversationPanel.java
+++ b/src/main/java/com/devoxx/genie/ui/panel/conversation/ConversationPanel.java
@@ -170,7 +170,12 @@ public class ConversationPanel
             if (hash != null && !hash.equals(projectHash)) {
                 return;
             }
-            activityMessageDispatcher.dispatch(message, viewController::onActivityMessage);
+            int activityGeneration = viewController.currentActivityGeneration();
+            activityMessageDispatcher.dispatch(
+                    message,
+                    activityGeneration,
+                    viewController::currentActivityGeneration,
+                    activityMessage -> viewController.onActivityMessage(activityMessage, activityGeneration));
         });
     }
 

--- a/src/main/kotlin/com/devoxx/genie/ui/compose/ComposeConversationViewController.kt
+++ b/src/main/kotlin/com/devoxx/genie/ui/compose/ComposeConversationViewController.kt
@@ -170,6 +170,12 @@ class ComposeConversationViewController(
         viewModel.onActivityMessage(message)
     }
 
+    override fun onActivityMessage(message: ActivityMessage, expectedGeneration: Int) {
+        viewModel.onActivityMessage(message, expectedGeneration)
+    }
+
+    override fun currentActivityGeneration(): Int = viewModel.activityGeneration()
+
     override fun deactivateActivityHandlers() {
         viewModel.deactivateActivityHandlers()
     }

--- a/src/main/kotlin/com/devoxx/genie/ui/compose/ConversationViewController.kt
+++ b/src/main/kotlin/com/devoxx/genie/ui/compose/ConversationViewController.kt
@@ -43,6 +43,8 @@ interface ConversationViewController {
     // ---- activity / loading ----
 
     fun onActivityMessage(message: ActivityMessage)
+    fun onActivityMessage(message: ActivityMessage, expectedGeneration: Int)
+    fun currentActivityGeneration(): Int
     fun deactivateActivityHandlers()
     fun hideLoadingIndicator(messageId: String)
     fun markMCPLogsAsCompleted(messageId: String)

--- a/src/main/kotlin/com/devoxx/genie/ui/compose/viewmodel/ConversationViewModel.kt
+++ b/src/main/kotlin/com/devoxx/genie/ui/compose/viewmodel/ConversationViewModel.kt
@@ -256,8 +256,15 @@ class ConversationViewModel(
         }
     }
 
+    fun activityGeneration(): Int = activityGeneration.get()
+
     fun onActivityMessage(message: ActivityMessage) {
+        onActivityMessage(message, activityGeneration())
+    }
+
+    fun onActivityMessage(message: ActivityMessage, expectedGeneration: Int) {
         if (activityDeactivated.get()) return
+        if (expectedGeneration != activityGeneration()) return
 
         // Raw request/response captures carry the full LLM payload JSON as content — they
         // belong to the Activity Log tool window only, never to the in-chat timeline.

--- a/src/test/java/com/devoxx/genie/ui/panel/conversation/ActivityMessageDispatcherTest.java
+++ b/src/test/java/com/devoxx/genie/ui/panel/conversation/ActivityMessageDispatcherTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -30,5 +31,24 @@ class ActivityMessageDispatcherTest {
         queuedTasks.get(0).run();
 
         assertThat(delivered.get()).isSameAs(message);
+    }
+
+    @Test
+    void dispatch_discardsActivityWhenTheActivePromptChangesBeforeTheUiQueueRuns() {
+        List<Runnable> queuedTasks = new ArrayList<>();
+        AtomicInteger activeGeneration = new AtomicInteger(1);
+        ActivityMessage message = ActivityMessage.builder()
+                .source(ActivitySource.AGENT)
+                .build();
+        AtomicReference<ActivityMessage> delivered = new AtomicReference<>();
+
+        ActivityMessageDispatcher dispatcher = new ActivityMessageDispatcher(queuedTasks::add);
+
+        dispatcher.dispatch(message, activeGeneration.get(), activeGeneration::get, delivered::set);
+        activeGeneration.incrementAndGet();
+
+        queuedTasks.get(0).run();
+
+        assertThat(delivered).hasValue(null);
     }
 }

--- a/src/test/java/com/devoxx/genie/ui/panel/conversation/ActivityMessageDispatcherTest.java
+++ b/src/test/java/com/devoxx/genie/ui/panel/conversation/ActivityMessageDispatcherTest.java
@@ -1,0 +1,34 @@
+package com.devoxx.genie.ui.panel.conversation;
+
+import com.devoxx.genie.model.activity.ActivityMessage;
+import com.devoxx.genie.model.activity.ActivitySource;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ActivityMessageDispatcherTest {
+
+    @Test
+    void dispatch_defersActivityHandlingUntilTheUiQueueRuns() {
+        List<Runnable> queuedTasks = new ArrayList<>();
+        ActivityMessage message = ActivityMessage.builder()
+                .source(ActivitySource.AGENT)
+                .build();
+        AtomicReference<ActivityMessage> delivered = new AtomicReference<>();
+
+        ActivityMessageDispatcher dispatcher = new ActivityMessageDispatcher(queuedTasks::add);
+
+        dispatcher.dispatch(message, delivered::set);
+
+        assertThat(delivered).hasValue(null);
+        assertThat(queuedTasks).hasSize(1);
+
+        queuedTasks.get(0).run();
+
+        assertThat(delivered.get()).isSameAs(message);
+    }
+}

--- a/src/test/kotlin/com/devoxx/genie/ui/compose/viewmodel/ConversationViewModelTest.kt
+++ b/src/test/kotlin/com/devoxx/genie/ui/compose/viewmodel/ConversationViewModelTest.kt
@@ -231,6 +231,20 @@ class ConversationViewModelTest {
     }
 
     @Test
+    fun `activity from a prior prompt generation is not attached to the next prompt`() {
+        val viewModel = ConversationViewModel(showToolActivityInChat = { true })
+        viewModel.addUserPromptMessage(ChatMessageContext.builder().id("msg-1").userPrompt("first").build())
+        val firstGeneration = viewModel.activityGeneration()
+
+        viewModel.addUserPromptMessage(ChatMessageContext.builder().id("msg-2").userPrompt("second").build())
+        viewModel.onActivityMessage(toolRequest("run_command", "{\"command\":\"date\"}"), firstGeneration)
+
+        val messages = (viewModel.state as ConversationState.Chat).messages
+        assertThat(messages.first { it.id == "msg-1" }.activityEntries).isEmpty()
+        assertThat(messages.first { it.id == "msg-2" }.activityEntries).isEmpty()
+    }
+
+    @Test
     fun `hide loading indicator also clears the streaming flag`() {
         val viewModel = ConversationViewModel()
         viewModel.addUserPromptMessage(

--- a/src/test/kotlin/com/devoxx/genie/ui/compose/viewmodel/ConversationViewModelTest.kt
+++ b/src/test/kotlin/com/devoxx/genie/ui/compose/viewmodel/ConversationViewModelTest.kt
@@ -197,6 +197,40 @@ class ConversationViewModelTest {
     }
 
     @Test
+    fun `streamed response update preserves an open agent tool entry`() {
+        val viewModel = ConversationViewModel(showToolActivityInChat = { true })
+        viewModel.addUserPromptMessage(ChatMessageContext.builder().id("msg-1").userPrompt("what time is it?").build())
+
+        viewModel.onActivityMessage(toolRequest("run_command", """{"command":"date"}"""))
+        viewModel.updateAiMessageContent(
+            ChatMessageContext.builder()
+                .id("msg-1")
+                .aiMessage(AiMessage.from("The current time is 14:21."))
+                .build()
+        )
+        viewModel.onActivityMessage(toolResponse("run_command", "Fri Jul 24 14:21:00 CEST 2026"))
+
+        val entry = activeMessageEntries(viewModel).single()
+        assertThat(entry.status).isEqualTo(ActivityStatus.SUCCESS)
+        assertThat(entry.result).isEqualTo("Fri Jul 24 14:21:00 CEST 2026")
+    }
+
+    @Test
+    fun `raw activity messages remain excluded from the conversation timeline`() {
+        val viewModel = ConversationViewModel(showToolActivityInChat = { true })
+        viewModel.addUserPromptMessage(ChatMessageContext.builder().id("msg-1").userPrompt("hi").build())
+
+        viewModel.onActivityMessage(
+            ActivityMessage.builder()
+                .source(ActivitySource.RAW)
+                .content("{\"authorization\":\"secret\"}")
+                .build()
+        )
+
+        assertThat(activeMessageEntries(viewModel)).isEmpty()
+    }
+
+    @Test
     fun `hide loading indicator also clears the streaming flag`() {
         val viewModel = ConversationViewModel()
         viewModel.addUserPromptMessage(


### PR DESCRIPTION
## Summary
- Deliver agent activity updates on the IntelliJ EDT during streamed responses.
- Drop queued activity that belongs to an earlier prompt generation.
- Add streaming, RAW-filtering, and prompt-switch regression coverage.

## Test plan
- [x] `./gradlew test --rerun-tasks --tests com.devoxx.genie.ui.panel.conversation.ActivityMessageDispatcherTest --tests com.devoxx.genie.ui.compose.viewmodel.ConversationViewModelTest`
- [x] `./gradlew buildPlugin`
- [x] Manual streaming verification

🤖 Generated with [Codex CLI](https://github.com/openai/codex)
