### PR TITLE
fix(custom-openai): add setting to omit top_p from requests (#1240)

### DIFF
--- a/src/main/java/com/devoxx/genie/chatmodel/local/customopenai/CustomOpenAIChatModelFactory.java
+++ b/src/main/java/com/devoxx/genie/chatmodel/local/customopenai/CustomOpenAIChatModelFactory.java
@@ -65,7 +65,7 @@ public class CustomOpenAIChatModelFactory implements ChatModelFactory {
                 .maxRetries(customChatModel.getMaxRetries())
                 .temperature(customChatModel.getTemperature())
                 .timeout(Duration.ofSeconds(customChatModel.getTimeout()))
-                .topP(customChatModel.getTopP())
+                .topP(resolveTopP(customChatModel))
                 .returnThinking(ThinkingSupport.isEnabled())
                 .listeners(getListener())
                 .httpClientBuilder(getHttpClientBuilder());
@@ -73,6 +73,23 @@ public class CustomOpenAIChatModelFactory implements ChatModelFactory {
         applyOutputTokenLimit(builder, customChatModel);
 
         return builder.build();
+    }
+
+    /**
+     * Resolve the {@code top_p} value to send, or {@code null} to leave the field out of the request.
+     *
+     * <p>Issue #1240: some endpoints reject {@code top_p} with
+     * {@code 400 "Unsupported parameter: 'top_p' is not supported with this model."} — the same class
+     * of failure as {@code max_tokens} in issue #1225. A {@code null} makes the OpenAI client omit the
+     * field entirely, which is what such a model needs: it is the parameter's presence, not its value,
+     * that is rejected. As with the output-token cap, the model name is deliberately not sniffed —
+     * gateways such as LiteLLM expose arbitrary aliases no naming pattern can classify — so the user
+     * opts out via the "Custom OpenAI omit top_p" setting.</p>
+     */
+    private static Double resolveTopP(@NotNull CustomChatModel customChatModel) {
+        return DevoxxGenieStateService.getInstance().isCustomOpenAIOmitTopP()
+                ? null
+                : customChatModel.getTopP();
     }
 
     /**
@@ -102,7 +119,7 @@ public class CustomOpenAIChatModelFactory implements ChatModelFactory {
                 .apiKey(stateInstance.isCustomOpenAIApiKeyEnabled() ? stateInstance.getCustomOpenAIApiKey() : "na")
                 .modelName(resolveModelName(customChatModel))
                 .temperature(customChatModel.getTemperature())
-                .topP(customChatModel.getTopP())
+                .topP(resolveTopP(customChatModel))
                 .timeout(Duration.ofSeconds(customChatModel.getTimeout()))
                 .returnThinking(ThinkingSupport.isEnabled())
                 .listeners(getListener())

--- a/src/main/java/com/devoxx/genie/ui/settings/DevoxxGenieStateService.java
+++ b/src/main/java/com/devoxx/genie/ui/settings/DevoxxGenieStateService.java
@@ -172,6 +172,13 @@ public final class DevoxxGenieStateService implements PersistentStateComponent<D
      * the new name. Off by default so existing endpoints keep their current wire format.
      */
     private boolean isCustomOpenAIUseMaxCompletionTokens = false;
+    /**
+     * Issue #1240: some OpenAI-compatible endpoints reject {@code top_p} outright with
+     * {@code 400 "Unsupported parameter: 'top_p' is not supported with this model."}. When enabled,
+     * {@code top_p} is left out of the request entirely. Off by default so endpoints that accept it
+     * keep honouring the configured value.
+     */
+    private boolean isCustomOpenAIOmitTopP = false;
 
     // Remote LLM Providers
     private boolean isOpenAIEnabled = false;

--- a/src/main/java/com/devoxx/genie/ui/settings/llm/LLMProvidersComponent.java
+++ b/src/main/java/com/devoxx/genie/ui/settings/llm/LLMProvidersComponent.java
@@ -180,6 +180,8 @@ public class LLMProvidersComponent extends AbstractSettingsComponent {
     @Getter
     private final JCheckBox customOpenAIUseMaxCompletionTokensCheckBox = new JCheckBox("", stateService.isCustomOpenAIUseMaxCompletionTokens());
     @Getter
+    private final JCheckBox customOpenAIOmitTopPCheckBox = new JCheckBox("", stateService.isCustomOpenAIOmitTopP());
+    @Getter
     private final JCheckBox openAIEnabledCheckBox = new JCheckBox("", stateService.isOpenAIEnabled());
     @Getter
     private final JCheckBox mistralEnabledCheckBox = new JCheckBox("", stateService.isMistralEnabled());
@@ -411,6 +413,11 @@ public class LLMProvidersComponent extends AbstractSettingsComponent {
         addHintText(customOpenAIPanel, gbc, "Send the output token limit as <code>max_completion_tokens</code> instead of <code>max_tokens</code>. " +
                 "Enable this for reasoning models (o1, o3, GPT-5) and gateways such as LiteLLM fronting them, which reject <code>max_tokens</code> with " +
                 "<i>\"Unsupported parameter: 'max_tokens' is not supported with this model\"</i>.");
+        addProviderSettingRow(customOpenAIPanel, gbc, "Omit top_p", customOpenAIOmitTopPCheckBox);
+        addHintText(customOpenAIPanel, gbc, "Leave <code>top_p</code> out of the request entirely. " +
+                "Enable this for models and gateways that reject it with " +
+                "<i>\"Unsupported parameter: 'top_p' is not supported with this model\"</i>. " +
+                "The Top-P value in LLM Settings is then ignored for this provider; temperature is still sent.");
         addProviderSettingRow(customOpenAIPanel, gbc, "Context Window", customOpenAIContextWindowEnabledCheckBox, customOpenAIContextWindowField);
         addHintText(customOpenAIPanel, gbc, "Token window used for the usage bar and token calculation. When unchecked, DevoxxGenie assumes " + CustomOpenAIContextWindow.DEFAULT_CONTEXT_WINDOW + " tokens. Set this to your internal model's real context size to avoid a false red 'context exceeded' warning (the request is sent either way).");
         addSettingRow(customOpenAIPanel, gbc, "Input Cost", customOpenAIInputCostField);

--- a/src/main/java/com/devoxx/genie/ui/settings/llm/LLMProvidersConfigurable.java
+++ b/src/main/java/com/devoxx/genie/ui/settings/llm/LLMProvidersConfigurable.java
@@ -139,6 +139,7 @@ public class LLMProvidersConfigurable implements Configurable {
         isModified |= stateService.isCustomOpenAIModelNameEnabled() != llmSettingsComponent.getCustomOpenAIModelNameEnabledCheckBox().isSelected();
         isModified |= stateService.isCustomOpenAIForceHttp11() != llmSettingsComponent.getCustomOpenAIForceHttp11CheckBox().isSelected();
         isModified |= stateService.isCustomOpenAIUseMaxCompletionTokens() != llmSettingsComponent.getCustomOpenAIUseMaxCompletionTokensCheckBox().isSelected();
+        isModified |= stateService.isCustomOpenAIOmitTopP() != llmSettingsComponent.getCustomOpenAIOmitTopPCheckBox().isSelected();
 
         isModified |= stateService.isOpenAIEnabled() != llmSettingsComponent.getOpenAIEnabledCheckBox().isSelected();
         isModified |= stateService.isMistralEnabled() != llmSettingsComponent.getMistralEnabledCheckBox().isSelected();
@@ -197,6 +198,7 @@ public class LLMProvidersConfigurable implements Configurable {
         settings.setCustomOpenAIApiKeyEnabled(llmSettingsComponent.getEnableCustomOpenAIApiKeyCheckBox().isSelected());
         settings.setCustomOpenAIForceHttp11(llmSettingsComponent.getCustomOpenAIForceHttp11CheckBox().isSelected());
         settings.setCustomOpenAIUseMaxCompletionTokens(llmSettingsComponent.getCustomOpenAIUseMaxCompletionTokensCheckBox().isSelected());
+        settings.setCustomOpenAIOmitTopP(llmSettingsComponent.getCustomOpenAIOmitTopPCheckBox().isSelected());
         settings.setCustomOpenAIContextWindow(
                 llmSettingsComponent.getCustomOpenAIContextWindowEnabledCheckBox().isSelected()
                         ? llmSettingsComponent.getCustomOpenAIContextWindowField().getNumber()
@@ -507,6 +509,7 @@ public class LLMProvidersConfigurable implements Configurable {
         llmSettingsComponent.getCustomOpenAIModelNameEnabledCheckBox().setSelected(settings.isCustomOpenAIModelNameEnabled());
         llmSettingsComponent.getCustomOpenAIForceHttp11CheckBox().setSelected(settings.isCustomOpenAIForceHttp11());
         llmSettingsComponent.getCustomOpenAIUseMaxCompletionTokensCheckBox().setSelected(settings.isCustomOpenAIUseMaxCompletionTokens());
+        llmSettingsComponent.getCustomOpenAIOmitTopPCheckBox().setSelected(settings.isCustomOpenAIOmitTopP());
 
 
         llmSettingsComponent.getOpenAIEnabledCheckBox().setSelected(settings.isOpenAIEnabled());

--- a/src/test/java/com/devoxx/genie/chatmodel/local/customopenai/CustomOpenAIOmitTopPTest.java
+++ b/src/test/java/com/devoxx/genie/chatmodel/local/customopenai/CustomOpenAIOmitTopPTest.java
@@ -1,0 +1,201 @@
+package com.devoxx.genie.chatmodel.local.customopenai;
+
+import com.devoxx.genie.model.CustomChatModel;
+import com.devoxx.genie.service.mcp.MCPService;
+import com.devoxx.genie.ui.settings.DevoxxGenieStateService;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import dev.langchain4j.model.chat.ChatModel;
+import dev.langchain4j.model.chat.StreamingChatModel;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import dev.langchain4j.model.chat.response.StreamingChatResponseHandler;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import java.io.IOException;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Issue #1240: some OpenAI-compatible endpoints reject {@code top_p} with
+ * {@code 400 "Unsupported parameter: 'top_p' is not supported with this model."} — the same class of
+ * failure as issue #1225's {@code max_tokens}. Since a gateway can expose arbitrary model aliases,
+ * the model name cannot be sniffed; the user opts out of sending {@code top_p} via a setting.
+ *
+ * <p>These tests assert the actual JSON on the wire, since the whole bug is whether the field is
+ * serialised at all.</p>
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class CustomOpenAIOmitTopPTest {
+
+    private static final String CHAT_COMPLETION_RESPONSE = """
+            {
+              "id": "chatcmpl-1",
+              "object": "chat.completion",
+              "model": "custom-model",
+              "choices": [
+                {"index": 0, "message": {"role": "assistant", "content": "ok"}, "finish_reason": "stop"}
+              ],
+              "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2}
+            }
+            """;
+
+    private static final String CHAT_COMPLETION_STREAM_RESPONSE = """
+            data: {"id":"chatcmpl-1","object":"chat.completion.chunk","model":"custom-model","choices":[{"index":0,"delta":{"role":"assistant","content":"ok"}}]}
+
+            data: {"id":"chatcmpl-1","object":"chat.completion.chunk","model":"custom-model","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}
+
+            data: [DONE]
+
+            """;
+
+    private MockWebServer server;
+    private MockedStatic<DevoxxGenieStateService> mockedStateService;
+    private MockedStatic<MCPService> mockedMCPService;
+    private DevoxxGenieStateService mockState;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        server = new MockWebServer();
+        server.start();
+
+        mockState = mock(DevoxxGenieStateService.class);
+        when(mockState.getCustomOpenAIUrl()).thenReturn(server.url("/v1/").toString());
+        when(mockState.isCustomOpenAIApiKeyEnabled()).thenReturn(false);
+        when(mockState.getCustomOpenAIApiKey()).thenReturn("");
+        when(mockState.isCustomOpenAIModelNameEnabled()).thenReturn(false);
+        when(mockState.getCustomOpenAIModelName()).thenReturn("");
+        when(mockState.isCustomOpenAIForceHttp11()).thenReturn(false);
+        when(mockState.isCustomOpenAIUseMaxCompletionTokens()).thenReturn(false);
+        when(mockState.isCustomOpenAIOmitTopP()).thenReturn(false);
+        when(mockState.getAgentModeEnabled()).thenReturn(false);
+
+        mockedStateService = Mockito.mockStatic(DevoxxGenieStateService.class);
+        mockedStateService.when(DevoxxGenieStateService::getInstance).thenReturn(mockState);
+
+        mockedMCPService = Mockito.mockStatic(MCPService.class);
+        mockedMCPService.when(MCPService::isMCPEnabled).thenReturn(false);
+    }
+
+    @AfterEach
+    void tearDown() throws IOException {
+        if (mockedStateService != null) mockedStateService.close();
+        if (mockedMCPService != null) mockedMCPService.close();
+        try {
+            server.shutdown();
+        } catch (IOException e) {
+            // Ignore shutdown errors from pending responses
+        }
+    }
+
+    @Test
+    void omitsTopPWhenSettingEnabled() throws InterruptedException {
+        when(mockState.isCustomOpenAIOmitTopP()).thenReturn(true);
+
+        JsonObject body = chat();
+
+        // The whole point of the setting: its mere presence is what such a model rejects.
+        assertThat(body.has("top_p")).isFalse();
+        // Temperature is a separate parameter and must keep travelling.
+        assertThat(body.has("temperature")).isTrue();
+    }
+
+    @Test
+    void sendsTopPWhenSettingDisabled() throws InterruptedException {
+        JsonObject body = chat();
+
+        // Default stays unchanged so endpoints that accept top_p keep honouring the configured value.
+        assertThat(body.has("top_p")).isTrue();
+        assertThat(body.get("top_p").getAsDouble()).isEqualTo(0.9);
+    }
+
+    @Test
+    void omitsTopPWhenSettingEnabledForStreaming() throws InterruptedException {
+        when(mockState.isCustomOpenAIOmitTopP()).thenReturn(true);
+
+        JsonObject body = streamingChat();
+
+        // Issue #1240 was reported on the streaming path, so it needs the same treatment.
+        assertThat(body.has("top_p")).isFalse();
+        assertThat(body.has("temperature")).isTrue();
+    }
+
+    @Test
+    void sendsTopPWhenSettingDisabledForStreaming() throws InterruptedException {
+        JsonObject body = streamingChat();
+
+        assertThat(body.has("top_p")).isTrue();
+        assertThat(body.get("top_p").getAsDouble()).isEqualTo(0.9);
+    }
+
+    private JsonObject chat() throws InterruptedException {
+        server.enqueue(new MockResponse()
+                .setBody(CHAT_COMPLETION_RESPONSE)
+                .setHeader("Content-Type", "application/json"));
+
+        ChatModel model = new CustomOpenAIChatModelFactory().createChatModel(customChatModel());
+        model.chat("hello");
+
+        return recordedBody();
+    }
+
+    private JsonObject streamingChat() throws InterruptedException {
+        server.enqueue(new MockResponse()
+                .setBody(CHAT_COMPLETION_STREAM_RESPONSE)
+                .setHeader("Content-Type", "text/event-stream"));
+
+        StreamingChatModel model = new CustomOpenAIChatModelFactory().createStreamingChatModel(customChatModel());
+        CountDownLatch done = new CountDownLatch(1);
+        model.chat("hello", new StreamingChatResponseHandler() {
+            @Override
+            public void onPartialResponse(String partialResponse) {
+                // Not asserted here — this test is about the request, not the response.
+            }
+
+            @Override
+            public void onCompleteResponse(ChatResponse completeResponse) {
+                done.countDown();
+            }
+
+            @Override
+            public void onError(Throwable error) {
+                done.countDown();
+            }
+        });
+        done.await(10, TimeUnit.SECONDS);
+
+        return recordedBody();
+    }
+
+    private JsonObject recordedBody() throws InterruptedException {
+        RecordedRequest recordedRequest = server.takeRequest(10, TimeUnit.SECONDS);
+        assertThat(recordedRequest).as("no request reached the mock server").isNotNull();
+        return JsonParser.parseString(recordedRequest.getBody().readUtf8()).getAsJsonObject();
+    }
+
+    private static CustomChatModel customChatModel() {
+        CustomChatModel customChatModel = new CustomChatModel();
+        customChatModel.setModelName("custom-model");
+        customChatModel.setTemperature(0.7);
+        customChatModel.setTopP(0.9);
+        customChatModel.setMaxTokens(256);
+        customChatModel.setMaxRetries(1);
+        customChatModel.setTimeout(10);
+        return customChatModel;
+    }
+}

--- a/src/test/java/com/devoxx/genie/ui/settings/llm/LLMProvidersConfigurableTest.java
+++ b/src/test/java/com/devoxx/genie/ui/settings/llm/LLMProvidersConfigurableTest.java
@@ -137,6 +137,31 @@ class LLMProvidersConfigurableTest {
     }
 
     @Test
+    void shouldApplyCustomOpenAIOmitTopPSetting() throws ConfigurationException {
+        // Issue #1240: the checkbox that drops 'top_p' from the request must survive the
+        // isModified/apply round-trip, or endpoints rejecting the parameter stay broken
+        // after the user ticks it.
+        LLMProvidersComponent component = getSettingsComponent();
+
+        component.getCustomOpenAIOmitTopPCheckBox().setSelected(true);
+
+        assertThat(configurable.isModified()).isTrue();
+
+        configurable.apply();
+
+        assertThat(stateService.isCustomOpenAIOmitTopP()).isTrue();
+    }
+
+    @Test
+    void shouldResetCustomOpenAIOmitTopPSetting() {
+        stateService.setCustomOpenAIOmitTopP(true);
+
+        configurable.reset();
+
+        assertThat(getSettingsComponent().getCustomOpenAIOmitTopPCheckBox().isSelected()).isTrue();
+    }
+
+    @Test
     void shouldApplyCustomOpenAIContextWindowSetting() throws ConfigurationException {
         LLMProvidersComponent component = getSettingsComponent();
 


### PR DESCRIPTION
## Summary
- Fixes #1240: some OpenAI-compatible endpoints and gateways (e.g. LiteLLM) reject `top_p` with `400 "Unsupported parameter: 'top_p' is not supported with this model."`, breaking every prompt against that endpoint — the same class of failure as `max_tokens` in #1225.
- Adds an **"Omit top_p"** checkbox to Settings → LLM Providers → Custom OpenAI. When enabled, `top_p` is left out of the request entirely (it's the parameter's *presence*, not its value, that servers reject) on both the blocking and streaming paths. Temperature keeps travelling.
- Off by default, so endpoints that accept `top_p` keep honouring the configured value. The model name is deliberately not sniffed, since gateways expose arbitrary aliases no naming pattern can classify.

## Test plan
- [x] `CustomOpenAIOmitTopPTest` — asserts the JSON on the wire: `top_p` absent when enabled / present (0.9) when disabled, for both non-streaming and streaming, with `temperature` still sent.
- [x] `LLMProvidersConfigurableTest` — new `isModified`/`apply`/`reset` round-trip coverage for the setting.
- [ ] Manual: point Custom OpenAI at an endpoint that rejects `top_p`, tick "Omit top_p", confirm prompts succeed in both stream and non-stream mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)