### PR TITLE
docs: mention Nativ in provider lists across docs pages

### DIFF
--- a/docusaurus/docs/getting-started/faq.md
+++ b/docusaurus/docs/getting-started/faq.md
@@ -35,7 +35,7 @@ import Head from '@docusaurus/Head';
           "name": "Which LLMs does DevoxxGenie support?",
           "acceptedAnswer": {
             "@type": "Answer",
-            "text": "DevoxxGenie supports a wide range of LLMs. Cloud providers include OpenAI (GPT-4o, o3, o4-mini), Anthropic (Claude 3.5/4), Google (Gemini 1.5/2.x), Grok (xAI), Mistral, Groq, DeepInfra, DeepSeek (R1, Coder), Kimi (Moonshot AI), GLM (Zhipu AI), OpenRouter, Azure OpenAI, and Amazon Bedrock. Local providers include Ollama, LM Studio, GPT4All, Llama.cpp, and Jan. It also supports any OpenAI-compatible custom endpoint."
+            "text": "DevoxxGenie supports a wide range of LLMs. Cloud providers include OpenAI (GPT-4o, o3, o4-mini), Anthropic (Claude 3.5/4), Google (Gemini 1.5/2.x), Grok (xAI), Mistral, Groq, DeepInfra, DeepSeek (R1, Coder), Kimi (Moonshot AI), GLM (Zhipu AI), OpenRouter, Azure OpenAI, and Amazon Bedrock. Local providers include Ollama, LM Studio, GPT4All, Llama.cpp, Jan, and Nativ (MLX on Apple Silicon). It also supports any OpenAI-compatible custom endpoint."
           }
         },
         {
@@ -140,7 +140,7 @@ Yes — if you use a local model provider like **Ollama**. Once you've downloade
 
 **Cloud providers**: OpenAI (GPT-4o, o3, o4-mini), Anthropic (Claude 3.5/4), Google (Gemini 1.5/2.x), Grok (xAI), Mistral, Groq, DeepInfra, DeepSeek (R1, Coder), Kimi (Moonshot AI), GLM (Zhipu AI), OpenRouter, Azure OpenAI, Amazon Bedrock
 
-**Local providers**: Ollama, LM Studio, GPT4All, Llama.cpp, Jan, any OpenAI-compatible endpoint
+**Local providers**: Ollama, LM Studio, GPT4All, Llama.cpp, Jan, Nativ (MLX on Apple Silicon), any OpenAI-compatible endpoint
 
 ### How do I use Ollama with DevoxxGenie?
 

--- a/docusaurus/docs/getting-started/introduction.md
+++ b/docusaurus/docs/getting-started/introduction.md
@@ -21,7 +21,7 @@ With DevoxxGenie, developers can leverage the power of artificial intelligence t
 
 DevoxxGenie provides a rich set of features to enhance your development workflow:
 
-- **[Multiple LLM Providers](../llm-providers/overview.md)**: Connect to local LLMs like Ollama, LMStudio, and GPT4All, as well as cloud-based providers like OpenAI, Anthropic, Google, Grok, Mistral, Groq, Kimi, GLM, and more.
+- **[Multiple LLM Providers](../llm-providers/overview.md)**: Connect to local LLMs like Ollama, LMStudio, Nativ, and GPT4All, as well as cloud-based providers like OpenAI, Anthropic, Google, Grok, Mistral, Groq, Kimi, GLM, and more.
 - **[MCP Support](../features/mcp_expanded.md)**: Model Context Protocol servers for agent-like capabilities, with a built-in Marketplace for discovering and installing servers.
 - **[Agent Mode](../features/agent-mode.md)** *(v0.9.4+)*: Enable agent mode for autonomous codebase exploration using read-only tools. Parallel sub-agents allow concurrent investigation of multiple aspects, each configurable with a different LLM from any provider.
 - **[Spec Driven Development](../features/spec-driven-development.md)** *(v0.9.7+)*: Define tasks in Backlog.md, browse them in the Spec Browser with Task List and Kanban Board views, then let the Agent implement them autonomously.

--- a/docusaurus/docs/getting-started/quick-start-local.md
+++ b/docusaurus/docs/getting-started/quick-start-local.md
@@ -25,6 +25,7 @@ DevoxxGenie supports several local LLM providers:
 - [GPT4All](https://gpt4all.io/index.html)
 - [Llama.cpp](https://github.com/ggerganov/llama.cpp)
 - [Jan](https://jan.ai/)
+- [Nativ](https://github.com/Blaizzy/nativ) (MLX on Apple Silicon)
 - Custom OpenAI-compatible providers
 
 ## Setting Up with Ollama (Recommended)

--- a/docusaurus/docs/llm-providers/overview.md
+++ b/docusaurus/docs/llm-providers/overview.md
@@ -29,6 +29,7 @@ Supported local providers:
 - [GPT4All](local-models.md#gpt4all)
 - [Llama.cpp](local-models.md#llamacpp)
 - [Jan](local-models.md#jan)
+- [Nativ](local-models.md#nativ) (MLX on Apple Silicon)
 - [Exo](exo.md) (Distributed AI cluster)
 - [Custom OpenAI-compatible](local-models.md#custom-openai-compatible-providers)
 
@@ -74,6 +75,7 @@ You can select and configure LLM providers in two ways:
 | GPT4All | High | Low | Free | Basic | No |
 | Llama.cpp | High | High | Free | Varies by hardware | Some models |
 | Jan | High | Low | Free | Basic | No |
+| Nativ | High | Low | Free | Optimized for Apple Silicon | Some models |
 | **Cloud Providers** |
 | OpenAI | Low | Low | Pay-per-token | Excellent | GPT-4V+ |
 | Anthropic | Low | Low | Pay-per-token | Excellent | Claude 3+ |

--- a/docusaurus/docusaurus.config.js
+++ b/docusaurus/docusaurus.config.js
@@ -165,7 +165,7 @@ const config = {
       // SEO and Social cards
       image: 'img/devoxxgenie-social-card.jpg',
       metadata: [
-        {name: 'keywords', content: 'java, jetbrains plugin, intellij idea, pycharm, webstorm, phpstorm, rubymine, clion, goland, rider, datagrip, dataspell, rustrover, aqua, llm, code assistant, spec-driven development, sdd, backlog.md, rag, ai coding, local llm, cloud llm, mcp, openai, anthropic, ollama'},
+        {name: 'keywords', content: 'java, jetbrains plugin, intellij idea, pycharm, webstorm, phpstorm, rubymine, clion, goland, rider, datagrip, dataspell, rustrover, aqua, llm, code assistant, spec-driven development, sdd, backlog.md, rag, ai coding, local llm, cloud llm, mcp, openai, anthropic, ollama, nativ, mlx'},
         {name: 'description', content: 'DevoxxGenie is a free, open-source LLM Code Assistant plugin for JetBrains IDEs (IntelliJ IDEA, PyCharm, WebStorm, and more). Supports local models (Ollama, LMStudio) and cloud providers (OpenAI, Anthropic, Google). Features include MCP, RAG, web search, custom commands, and LLM-activated skills.'},
         {property: 'og:type', content: 'website'},
         {property: 'og:site_name', content: 'DevoxxGenie'},

--- a/docusaurus/src/components/HomepageFeatures/index.js
+++ b/docusaurus/src/components/HomepageFeatures/index.js
@@ -62,7 +62,7 @@ const FeatureList = [
     link: '/docs/llm-providers/overview',
     description: (
       <>
-        Connect to local LLMs like Ollama, LMStudio, and GPT4All, as well as cloud-based providers like OpenAI, Anthropic, Mistral, Groq, Kimi, GLM, Gemini, and more.
+        Connect to local LLMs like Ollama, LMStudio, Nativ, and GPT4All, as well as cloud-based providers like OpenAI, Anthropic, Mistral, Groq, Kimi, GLM, Gemini, and more.
       </>
     ),
   },


### PR DESCRIPTION
## Summary
- Follow-up to #1246: adds Nativ to every docs page that enumerates the local providers
- LLM providers overview (list + comparison table), local quick-start, introduction feature bullet, FAQ (visible list + JSON-LD answer), homepage feature card, and site keywords meta
- Pages referencing Ollama for provider-specific reasons (RAG embeddings, agent auto-detect, Ollama setup guide) intentionally unchanged

## Test plan
- [x] `npm run build` in docusaurus/ passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)