### PR TITLE
ci: stop link-checking Docusaurus images against the live site

### DIFF
--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -3,10 +3,10 @@ name: Check Documentation Links
 on:
   push:
     branches: [master, main]
-    paths: ['docusaurus/**']
+    paths: ['docusaurus/**', '.lychee.toml', '.github/workflows/link-check.yml']
   pull_request:
     branches: [master, main]
-    paths: ['docusaurus/**']
+    paths: ['docusaurus/**', '.lychee.toml', '.github/workflows/link-check.yml']
   schedule:
     - cron: '0 3 * * 0'   # Weekly Sunday 03:00 UTC
   workflow_dispatch:

--- a/.lychee.toml
+++ b/.lychee.toml
@@ -29,7 +29,13 @@ exclude = [
   # Docusaurus internal .md links — resolved incorrectly by lychee against --base.
   # These relative links are validated by Docusaurus build, not lychee.
   "https://genie\\.devoxx\\.com/.*\\.md",
-  # Static images served by Docusaurus — not present on the live site at these paths.
+  # Static images served by Docusaurus. Markdown references them as /img/... (the
+  # /static/ prefix is stripped at build time), so lychee resolves them against
+  # --base-url and fetches them from the live site — which 404s for any image added
+  # before the deploy lands, failing every PR that introduces one. Nothing is lost by
+  # skipping them: the Docusaurus build itself hard-errors on a markdown image that
+  # has no matching file under static/, so it already covers the real failure case.
+  "https://genie\\.devoxx\\.com/img/.*",
   "https://genie\\.devoxx\\.com/static/img/.*",
   # New doc pages added in this PR — will exist on the live site after next deploy.
   # TODO(post-deploy): remove these two lines once the renamed/new pages are live.


### PR DESCRIPTION
## Summary
- Fixes the false 404s that fail the `Check Documentation Links` job on **every PR that adds an image** to the docs or blog
- Lychee runs with `--base-url https://genie.devoxx.com`, so `/img/Foo.png` is resolved against the *live* site and fetched over HTTP. The link check and the docs deploy fire on the same push, so a newly added image 404s until the deploy lands
- Also adds `.lychee.toml` and the workflow itself to the `paths:` filter, so changes to the link checker's own config actually re-run it

## Evidence
Run [30448410689](https://github.com/devoxx/DevoxxGenieIDEAPlugin/actions/runs/30448410689) reported six 404s for the Nativ blog post images, then **passed on a plain re-run with no code change** once the deploy completed. All six URLs return `200` today.

## Why this loses no coverage
The Docusaurus build already hard-errors on a markdown image with no matching file under `static/`, and that runs on every PR:

```
Markdown image with URL `/img/definitely-does-not-exist-xyz.png` in source file
"blog/..." (12:1) couldn't be resolved to an existing local image file.
```

That is the real failure case, caught earlier and more reliably than an HTTP fetch of the deployed site. The live-site check could only ever add false negatives.

Note: the pre-existing `/static/img/` exclusion never matched anything, because Docusaurus strips the `/static/` prefix and serves those files at `/img/`. It is left in place for clarity.

## Test plan
- [x] `lychee --base-url https://genie.devoxx.com --config .lychee.toml <nativ post>` → exit 0, `0 Errors`, the 6 images reported as `Excluded` rather than fetched
- [x] Verified the Docusaurus build fails on a deliberately broken image reference
- [ ] This PR's own link-check run is green (now triggered by the `paths:` change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)