### PR TITLE
docs(tips): add tips for queue and steer while a task runs

### DIFF
--- a/docusaurus/static/api/tips.json
+++ b/docusaurus/static/api/tips.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "lastUpdated": "2026-07-02",
+  "lastUpdated": "2026-07-30",
   "tips": [
     { "text": "Type @ to add a file to the context.", "weight": 2 },
     { "text": "Generate a DEVOXXGENIE.md with /init for project-aware answers.", "weight": 3 },
@@ -34,6 +34,11 @@
     { "text": "With Agent debug logs enabled, click the [Agent] tag in a message to see its input/output log details.", "weight": 1 },
     { "text": "Fix SpotBugs findings with AI — the SpotBugs DevoxxGenie plugin: https://github.com/stephanj/spotbugs-devoxxgenie-plugin", "weight": 1 },
     { "text": "Resolve SonarLint issues with AI — the SonarLint DevoxxGenie plugin: https://github.com/stephanj/sonarlint-devoxxgenie-intellij", "weight": 1 },
-    { "text": "Enable Thinking in Settings to show model reasoning separately when supported.", "weight": 1 }
+    { "text": "Enable Thinking in Settings to show model reasoning separately when supported.", "weight": 1 },
+    { "text": "Keep typing while a task runs — Enter queues your message as the next prompt.", "weight": 2 },
+    { "text": "Hit Steer to correct a running agent mid-task, e.g. \"use snake_case instead\".", "weight": 2 },
+    { "text": "While a task runs, submit becomes Stop and the Queue and Steer buttons appear.", "weight": 1 },
+    { "text": "Queue up follow-up prompts during a long run — each one gets its own answer, in order.", "weight": 1 },
+    { "text": "Stopping a run discards anything you queued — Steer sends it to the agent right away.", "weight": 1 }
   ]
 }

--- a/src/main/java/com/devoxx/genie/service/tips/TipService.java
+++ b/src/main/java/com/devoxx/genie/service/tips/TipService.java
@@ -52,6 +52,11 @@ public final class TipService {
             new Tip("Exclude Javadoc or extra folders when building Full Project Context in Settings.", 1),
             new Tip("In Agent Mode, parallel sub-agents can explore several areas at once.", 1),
             new Tip("Customize the system prompt in Settings → System Prompt.", 1),
+            new Tip("Keep typing while a task runs — Enter queues your message as the next prompt.", 2),
+            new Tip("Hit Steer to correct a running agent mid-task, e.g. \"use snake_case instead\".", 2),
+            new Tip("While a task runs, submit becomes Stop and the Queue and Steer buttons appear.", 1),
+            new Tip("Queue up follow-up prompts during a long run — each one gets its own answer, in order.", 1),
+            new Tip("Stopping a run discards anything you queued — Steer sends it to the agent right away.", 1),
             new Tip("DevoxxGenie is open source — star it on GitHub and join us at Devoxx!", 1));
 
     private static final String TIPS_JSON_URL = "https://genie.devoxx.com/api/tips.json";


### PR DESCRIPTION
## Summary
- Add five tips covering the mid-task queue/steer feature (#1241): Enter queues a message as the next prompt, the **Steer** button injects it into the running agent loop, submit becomes **Stop** while a task runs, queued prompts each get their own answer in order, and stopping a run discards them.
- Added to the live tips feed `docusaurus/static/api/tips.json` (with `lastUpdated` bumped to 2026-07-30) and to `TipService.FALLBACK_TIPS`, so cold-start installs see them before the first remote fetch.

## Test plan
- [x] `./gradlew test --tests '*Tip*'` passes (`TipsJsonTest` validates the JSON parses via the production Gson path and that every tip has non-blank text and weight >= 1)
- [ ] Confirm the new tips render correctly in the prompt tip line (em dashes and the quoted `"use snake_case instead"` example)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
