### PR TITLE
feat(docs): pull landing-page stats live from devoxx.com

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -7,6 +7,12 @@ on:
       - main
     paths:
       - 'docusaurus/**'
+  # The landing-page stats band reads live active-user / download figures from
+  # devoxx.com at build time (docusaurus/src/plugins/genie-stats), so a rebuild
+  # is what refreshes them. Weekly, Monday 05:00 UTC.
+  schedule:
+    - cron: '0 5 * * 1'
+  workflow_dispatch:
 
 jobs:
   build:

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ With [Agent Mode](https://genie.devoxx.com/docs/features/agent-mode), MCPs and f
 We also support RAG-based prompt context based on your vectorized project files, Git Diff viewer, and LLM-driven web search with [Google](https://developers.google.com/custom-search) and [Tavily](https://tavily.com/).
 
 [<img width="200" alt="Marketplace" src="https://github.com/devoxx/DevoxxGenieIDEAPlugin/assets/179457/1c24d692-37ea-445d-8015-2c25f63e2f90">](https://plugins.jetbrains.com/plugin/24169-devoxxgenie)
-112K+ Active Users
+114K+ Active Users
 
 ## 📚 Documentation
 

--- a/docusaurus/docusaurus.config.js
+++ b/docusaurus/docusaurus.config.js
@@ -52,6 +52,9 @@ const config = {
   clientModules: ['./src/clientModules/algoliaResultLinks.js'],
 
   plugins: [
+    // Fetches live DevoxxGenie active-user / download figures from
+    // devoxx.com at build time for the landing-page stats band.
+    './src/plugins/genie-stats',
     // Algolia Experiences documentation search.
     // Injects the Algolia Experiences library which renders into the
     // #autocomplete container provided by src/theme/SearchBar.

--- a/docusaurus/src/pages/index.js
+++ b/docusaurus/src/pages/index.js
@@ -3,6 +3,7 @@ import clsx from 'clsx';
 import Link from '@docusaurus/Link';
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 import useBaseUrl from '@docusaurus/useBaseUrl';
+import {usePluginData} from '@docusaurus/useGlobalData';
 import Layout from '@theme/Layout';
 import Head from '@docusaurus/Head';
 import HomepageFeatures from '@site/src/components/HomepageFeatures';
@@ -62,8 +63,22 @@ function HomepageHeader() {
   );
 }
 
+// Deliberately not toLocaleString(): that is locale-dependent, and a server/client
+// disagreement here would be a hydration mismatch on the very first thing above the fold.
+function withThousandsSeparators(value) {
+  return String(value).replace(/\B(?=(\d{3})+(?!\d))/g, ',');
+}
+
+// Active users comes from a GA4 rolling window, so the exact figure is noise —
+// round down to a round thousand and let the "+" carry the remainder.
+function formatActiveUsers(value) {
+  return `${withThousandsSeparators(Math.floor(value / 1000) * 1000)}+`;
+}
+
 export default function Home() {
   const {siteConfig} = useDocusaurusContext();
+  // Fetched from devoxx.com at build time — see src/plugins/genie-stats.
+  const genieStats = usePluginData('genie-stats');
 
   return (
     <Layout
@@ -87,11 +102,11 @@ export default function Home() {
         <div className="container">
           <div className={styles.statsGrid}>
             <div className={styles.statCard}>
-              <div className={styles.statNumber}>112,000+</div>
+              <div className={styles.statNumber}>{formatActiveUsers(genieStats.activeUsers)}</div>
               <div className={styles.statLabel}>Active Users</div>
             </div>
             <div className={styles.statCard}>
-              <div className={styles.statNumber}>82,800</div>
+              <div className={styles.statNumber}>{withThousandsSeparators(genieStats.downloads)}</div>
               <div className={styles.statLabel}>Plugin Downloads</div>
             </div>
             <div className={styles.statCard}>
@@ -99,7 +114,7 @@ export default function Home() {
               <div className={styles.statLabel}>Open Source &amp; Free</div>
             </div>
           </div>
-          <p className={styles.statsAsOf}>As of July 2026</p>
+          <p className={styles.statsAsOf}>As of {genieStats.asOf}</p>
         </div>
       </section>
       <main>

--- a/docusaurus/src/plugins/genie-stats/index.js
+++ b/docusaurus/src/plugins/genie-stats/index.js
@@ -1,0 +1,79 @@
+// Live DevoxxGenie usage figures for the landing-page stats band.
+//
+// devoxx.com owns these numbers: `GET /api/genie-stats` returns cumulative
+// JetBrains Marketplace downloads and GA4 active users, refreshed server-side
+// every 6 hours. We read it here at BUILD time (Node, so no CORS involved) and
+// bake the result into the static HTML via global data -- the numbers are in
+// the markup for crawlers and there is no loading flash on first paint.
+//
+// Refresh cadence is therefore the deploy cadence: .github/workflows/deploy-docs.yml
+// runs on a weekly cron precisely so this stays current without anyone editing
+// src/pages/index.js by hand.
+
+const STATS_URL = 'https://devoxx.com/api/genie-stats';
+const TIMEOUT_MS = 5000;
+
+/**
+ * Used when the fetch fails -- an offline laptop, a CI runner without egress,
+ * or devoxx.com being down must never fail the build or render "0"/"NaN".
+ * These were the last figures observed live; refresh them if they ever drift
+ * far enough that a fallback render would look wrong.
+ */
+const FALLBACK = {
+  activeUsers: 114000,
+  downloads: 83926,
+  asOf: 'July 2026',
+  live: false,
+};
+
+function formatAsOf(date) {
+  // Built once in Node and serialized into global data, so the client never
+  // recomputes it -- no locale-dependent hydration mismatch.
+  return `${date.toLocaleString('en-US', {month: 'long'})} ${date.getFullYear()}`;
+}
+
+/** A positive, finite count -- anything else means the upstream gave us junk. */
+function isUsableCount(value) {
+  return typeof value === 'number' && Number.isFinite(value) && value > 0;
+}
+
+module.exports = function genieStatsPlugin() {
+  return {
+    name: 'genie-stats',
+
+    async loadContent() {
+      try {
+        const res = await fetch(STATS_URL, {
+          headers: {Accept: 'application/json'},
+          // Node's fetch has no default overall timeout; an unbounded hang here
+          // would stall the build.
+          signal: AbortSignal.timeout(TIMEOUT_MS),
+        });
+        if (!res.ok) {
+          throw new Error(`responded ${res.status}`);
+        }
+
+        const body = await res.json();
+        if (!isUsableCount(body.activeUsers) || !isUsableCount(body.downloads)) {
+          throw new Error('response has no usable activeUsers/downloads');
+        }
+
+        return {
+          activeUsers: body.activeUsers,
+          downloads: body.downloads,
+          asOf: formatAsOf(new Date()),
+          live: true,
+        };
+      } catch (err) {
+        console.warn(
+          `[genie-stats] ${STATS_URL} unavailable (${err.message}); using baked-in fallback figures.`,
+        );
+        return {...FALLBACK};
+      }
+    },
+
+    contentLoaded({content, actions}) {
+      actions.setGlobalData(content);
+    },
+  };
+};


### PR DESCRIPTION
## Summary
- The landing-page stats band no longer hardcodes the active-user and download figures. A new build-time Docusaurus plugin (`docusaurus/src/plugins/genie-stats`) reads `https://devoxx.com/api/genie-stats` — which devoxx.com already serves from GA4 + the JetBrains Marketplace API, server-cached for 6h — and publishes it as global data for `src/pages/index.js` to render.
- Fetching at **build time** rather than in the browser keeps the numbers in the static markup for crawlers, avoids a loading flash, and sidesteps CORS: the endpoint sends no `Access-Control-Allow-Origin` today, so a client-side `fetch()` would be blocked.
- Since a rebuild is now what refreshes the figures, `deploy-docs.yml` gains a weekly cron (Mon 05:00 UTC) plus `workflow_dispatch`. Previously it only ran on pushes touching `docusaurus/**`.
- `README.md` bumped 112K+ → 114K+ by hand; it's static markdown and can't fetch anything.

### Notes
- Every upstream failure mode falls back to baked-in figures rather than failing the build or rendering `0`/`NaN`.
- Number formatting is hand-rolled rather than `toLocaleString` — the band is the first thing above the fold and a server/client locale disagreement there would be a hydration mismatch.
- ⚠️ `/api/genie-stats` currently returns `"stale": true`: `activeUsers` is falling back to the hardcoded `114_000` in devoxx.com's `genie-stats.model.ts`, not GA4. Downloads is genuinely live. Until `GA_SERVICE_ACCOUNT_KEY` / `GA_PROPERTY_ID` are set in devoxx.com's prod env, the user count won't move — it'll just be maintained in one repo instead of three.

## Test plan
- [x] `npm run build` succeeds; built `index.html` contains `114,000+`, `83,926`, `As of July 2026` baked into the markup
- [x] Fallback path exercised against stubbed responses — network error, HTTP 503, and a junk body (`activeUsers: 0` / `downloads: null`) each warn and return the fallback without throwing
- [x] A good body (`114231`) renders as `114,000+` (rounded down, `+` carries the remainder)
- [ ] Confirm the scheduled workflow run fires and redeploys with refreshed numbers

🤖 Generated with [Claude Code](https://claude.com/claude-code)