### PR TITLE
feat(docs): show GitHub star count in landing-page stats band, refreshed daily

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -8,10 +8,11 @@ on:
     paths:
       - 'docusaurus/**'
   # The landing-page stats band reads live active-user / download figures from
-  # devoxx.com at build time (docusaurus/src/plugins/genie-stats), so a rebuild
-  # is what refreshes them. Weekly, Monday 05:00 UTC.
+  # devoxx.com and the GitHub star count from api.github.com at build time
+  # (docusaurus/src/plugins/genie-stats), so a rebuild is what refreshes them.
+  # Daily, 05:00 UTC.
   schedule:
-    - cron: '0 5 * * 1'
+    - cron: '0 5 * * *'
   workflow_dispatch:
 
 jobs:
@@ -37,6 +38,10 @@ jobs:
 
       - name: Build website
         run: npm run build
+        env:
+          # genie-stats fetches the repo's star count; unauthenticated
+          # api.github.com rate limits are per-IP and Actions runners share IPs.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload Build Artifact
         uses: actions/upload-pages-artifact@v3

--- a/docusaurus/src/pages/index.js
+++ b/docusaurus/src/pages/index.js
@@ -110,6 +110,18 @@ export default function Home() {
               <div className={styles.statLabel}>Plugin Downloads</div>
             </div>
             <div className={styles.statCard}>
+              <div className={styles.statNumber}>{withThousandsSeparators(genieStats.githubStars)}</div>
+              <div className={styles.statLabel}>
+                <a
+                  href="https://github.com/devoxx/DevoxxGenieIDEAPlugin"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className={styles.statLabelLink}>
+                  GitHub Stars
+                </a>
+              </div>
+            </div>
+            <div className={styles.statCard}>
               <div className={styles.statNumber}>100%</div>
               <div className={styles.statLabel}>Open Source &amp; Free</div>
             </div>

--- a/docusaurus/src/pages/index.module.css
+++ b/docusaurus/src/pages/index.module.css
@@ -78,6 +78,18 @@
   color: #fff;
 }
 
+/* The stars label links to the repo; keep it looking like its siblings so the
+   band stays uniform, with only hover revealing it is clickable. */
+.statLabelLink {
+  color: #fff;
+  text-decoration: none;
+}
+
+.statLabelLink:hover {
+  color: #fff;
+  text-decoration: underline;
+}
+
 .statsAsOf {
   margin: 1.5rem 0 0;
   text-align: center;

--- a/docusaurus/src/plugins/genie-stats/index.js
+++ b/docusaurus/src/plugins/genie-stats/index.js
@@ -1,21 +1,25 @@
-// Live DevoxxGenie usage figures for the landing-page stats band.
+// Live DevoxxGenie figures for the landing-page stats band.
 //
-// devoxx.com owns these numbers: `GET /api/genie-stats` returns cumulative
-// JetBrains Marketplace downloads and GA4 active users, refreshed server-side
-// every 6 hours. We read it here at BUILD time (Node, so no CORS involved) and
-// bake the result into the static HTML via global data -- the numbers are in
-// the markup for crawlers and there is no loading flash on first paint.
+// Two upstreams, fetched independently so one being down never blanks the other:
+//  - devoxx.com owns the usage numbers: `GET /api/genie-stats` returns cumulative
+//    JetBrains Marketplace downloads and GA4 active users, refreshed server-side
+//    every 6 hours.
+//  - api.github.com owns the star count for devoxx/DevoxxGenieIDEAPlugin.
+// We read both here at BUILD time (Node, so no CORS involved) and bake the
+// result into the static HTML via global data -- the numbers are in the markup
+// for crawlers and there is no loading flash on first paint.
 //
 // Refresh cadence is therefore the deploy cadence: .github/workflows/deploy-docs.yml
-// runs on a weekly cron precisely so this stays current without anyone editing
+// runs on a daily cron precisely so this stays current without anyone editing
 // src/pages/index.js by hand.
 
 const STATS_URL = 'https://devoxx.com/api/genie-stats';
+const GITHUB_REPO_URL = 'https://api.github.com/repos/devoxx/DevoxxGenieIDEAPlugin';
 const TIMEOUT_MS = 5000;
 
 /**
- * Used when the fetch fails -- an offline laptop, a CI runner without egress,
- * or devoxx.com being down must never fail the build or render "0"/"NaN".
+ * Used when a fetch fails -- an offline laptop, a CI runner without egress,
+ * or an upstream being down must never fail the build or render "0"/"NaN".
  * These were the last figures observed live; refresh them if they ever drift
  * far enough that a fallback render would look wrong.
  */
@@ -25,6 +29,8 @@ const FALLBACK = {
   asOf: 'July 2026',
   live: false,
 };
+
+const FALLBACK_GITHUB_STARS = 671;
 
 function formatAsOf(date) {
   // Built once in Node and serialized into global data, so the client never
@@ -37,39 +43,79 @@ function isUsableCount(value) {
   return typeof value === 'number' && Number.isFinite(value) && value > 0;
 }
 
+async function fetchUsageStats() {
+  try {
+    const res = await fetch(STATS_URL, {
+      headers: {Accept: 'application/json'},
+      // Node's fetch has no default overall timeout; an unbounded hang here
+      // would stall the build.
+      signal: AbortSignal.timeout(TIMEOUT_MS),
+    });
+    if (!res.ok) {
+      throw new Error(`responded ${res.status}`);
+    }
+
+    const body = await res.json();
+    if (!isUsableCount(body.activeUsers) || !isUsableCount(body.downloads)) {
+      throw new Error('response has no usable activeUsers/downloads');
+    }
+
+    return {
+      activeUsers: body.activeUsers,
+      downloads: body.downloads,
+      asOf: formatAsOf(new Date()),
+      live: true,
+    };
+  } catch (err) {
+    console.warn(
+      `[genie-stats] ${STATS_URL} unavailable (${err.message}); using baked-in fallback figures.`,
+    );
+    return {...FALLBACK};
+  }
+}
+
+async function fetchGithubStars() {
+  try {
+    const headers = {Accept: 'application/vnd.github+json'};
+    // Unauthenticated api.github.com is limited to 60 requests/hour per IP,
+    // and Actions runners share IPs -- so CI passes its workflow token through.
+    // Local builds work fine without one.
+    if (process.env.GITHUB_TOKEN) {
+      headers.Authorization = `Bearer ${process.env.GITHUB_TOKEN}`;
+    }
+
+    const res = await fetch(GITHUB_REPO_URL, {
+      headers,
+      signal: AbortSignal.timeout(TIMEOUT_MS),
+    });
+    if (!res.ok) {
+      throw new Error(`responded ${res.status}`);
+    }
+
+    const body = await res.json();
+    if (!isUsableCount(body.stargazers_count)) {
+      throw new Error('response has no usable stargazers_count');
+    }
+
+    return body.stargazers_count;
+  } catch (err) {
+    console.warn(
+      `[genie-stats] ${GITHUB_REPO_URL} unavailable (${err.message}); using baked-in fallback star count.`,
+    );
+    return FALLBACK_GITHUB_STARS;
+  }
+}
+
 module.exports = function genieStatsPlugin() {
   return {
     name: 'genie-stats',
 
     async loadContent() {
-      try {
-        const res = await fetch(STATS_URL, {
-          headers: {Accept: 'application/json'},
-          // Node's fetch has no default overall timeout; an unbounded hang here
-          // would stall the build.
-          signal: AbortSignal.timeout(TIMEOUT_MS),
-        });
-        if (!res.ok) {
-          throw new Error(`responded ${res.status}`);
-        }
-
-        const body = await res.json();
-        if (!isUsableCount(body.activeUsers) || !isUsableCount(body.downloads)) {
-          throw new Error('response has no usable activeUsers/downloads');
-        }
-
-        return {
-          activeUsers: body.activeUsers,
-          downloads: body.downloads,
-          asOf: formatAsOf(new Date()),
-          live: true,
-        };
-      } catch (err) {
-        console.warn(
-          `[genie-stats] ${STATS_URL} unavailable (${err.message}); using baked-in fallback figures.`,
-        );
-        return {...FALLBACK};
-      }
+      const [usage, githubStars] = await Promise.all([
+        fetchUsageStats(),
+        fetchGithubStars(),
+      ]);
+      return {...usage, githubStars};
     },
 
     contentLoaded({content, actions}) {


### PR DESCRIPTION
# Pull Request

## Description

Adds a **GitHub Stars** card to the landing-page stats band on genie.devoxx.com, next to Active Users and Plugin Downloads, and moves the docs deploy cron from weekly to daily so the number stays fresh.

The star count is fetched at build time by the existing `genie-stats` Docusaurus plugin — the same pattern already used for the devoxx.com usage figures — so the number is baked into the static HTML: crawler-visible, no client-side fetch, no loading flash. The GitHub fetch and the devoxx.com fetch run in parallel and fail independently to their own fallbacks, so one upstream being down never blanks the other or fails the build.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test addition/improvement

## Related Issue

N/A — requested directly.

## Changes Made

- `docusaurus/src/plugins/genie-stats/index.js`: fetch `stargazers_count` from `api.github.com/repos/devoxx/DevoxxGenieIDEAPlugin` in parallel with the devoxx.com usage stats; independent fallback (671, the count when this was written) so a failed fetch never renders 0/NaN or fails the build; uses `GITHUB_TOKEN` when present since unauthenticated API limits are per-IP and Actions runners share IPs.
- `docusaurus/src/pages/index.js`: fourth stat card "GitHub Stars" between Plugin Downloads and "100% Open Source & Free"; the label links to the repository.
- `docusaurus/src/pages/index.module.css`: link styling for the stars label so it matches its sibling labels, underlining only on hover.
- `.github/workflows/deploy-docs.yml`: deploy cron moved from weekly (Mon 05:00 UTC) to daily (05:00 UTC) — a rebuild is what refreshes the baked-in numbers; build step now passes `secrets.GITHUB_TOKEN` to the site build.

## Testing

**How has this been tested?**

- [ ] Unit tests
- [ ] Integration tests
- [x] Manual testing — full `npm run build` of the Docusaurus site passes, and the built `index.html` contains the stars card with the count baked in. The environment blocks `api.github.com`, which also exercised the fallback path: the build still succeeded and rendered the fallback figure, with the devoxx.com stats unaffected.

**Test Configuration:**
- Node 20 / Docusaurus production build (no Java code touched)

## Documentation

- [x] I have added/updated code comments for complex logic (plugin header documents the two upstreams and the refresh cadence)
- [ ] CLAUDE.md — no architecture/pattern change
- [ ] README.md — not needed

## Checklist

- [x] My code follows the existing code style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing behavior verified via the production site build (the Gradle plugin build is untouched by this docs-only change)

## Screenshots/Videos (if applicable)

The stats band gains a fourth card: `114,000+ Active Users · 83,926 Plugin Downloads · 671 GitHub Stars · 100% Open Source & Free`.

## Additional Notes

Build-time rather than client-side fetching is deliberate, matching the existing stats design: daily freshness comes from the cron, and visitors never hit GitHub's rate limits.

## Breaking Changes

None.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the project's license.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CKCToWfsECge9UsKT9wYCE

---
_Generated by [Claude Code](https://claude.ai/code/session_01CKCToWfsECge9UsKT9wYCE)_