### PR TITLE
fix(cloudflare): route bare Workers AI model ids and explain compat model naming (#1254)

### DIFF
--- a/docusaurus/docs/llm-providers/cloud-models.md
+++ b/docusaurus/docs/llm-providers/cloud-models.md
@@ -371,6 +371,18 @@ This provider uses Cloudflare's **single-token (BYOK)** model. You give DevoxxGe
 Model discovery uses a fast best-effort probe of the gateway's `/models` endpoint. If your gateway doesn't expose that endpoint, or you already know the exact model id you want, enable the **model name override** and type it in — this skips discovery entirely.
 :::
 
+### Model naming
+
+The `/compat` endpoint addresses models as `provider/model` — the provider prefix tells the gateway where to route the request:
+
+```
+openai/gpt-4o
+anthropic/claude-4-5-sonnet
+workers-ai/@cf/meta/llama-3.3-70b-instruct-fp8-fast
+```
+
+A bare model id (e.g. `kimi-k2.6`) cannot be routed and fails with `400 AiGatewayError` code 2005/2008. **Workers AI** ids copied from the Cloudflare dashboard start with `@cf/` — DevoxxGenie adds the missing `workers-ai/` prefix for those automatically, so `@cf/openai/gpt-oss-20b` is sent as `workers-ai/@cf/openai/gpt-oss-20b`. For every other provider, include the prefix yourself when using the model name override.
+
 ### Advantages
 
 - **One key, every provider** — no per-provider setup inside the plugin

--- a/src/main/java/com/devoxx/genie/chatmodel/cloud/cloudflare/CloudflareChatModelFactory.java
+++ b/src/main/java/com/devoxx/genie/chatmodel/cloud/cloudflare/CloudflareChatModelFactory.java
@@ -82,11 +82,12 @@ public class CloudflareChatModelFactory implements ChatModelFactory {
     public List<LanguageModel> getModels() {
         DevoxxGenieStateService state = DevoxxGenieStateService.getInstance();
 
-        // Honour an explicit model name: skip discovery entirely.
+        // Honour an explicit model name: skip discovery entirely. Normalised so the dropdown
+        // shows the id that is actually sent (issue #1254: '@cf/...' needs 'workers-ai/').
         if (state.isCloudflareModelNameEnabled()) {
             String override = state.getCloudflareModelName();
             if (override != null && !override.isBlank()) {
-                return List.of(toLanguageModel(override.trim()));
+                return List.of(toLanguageModel(CloudflareModelName.normalize(override)));
             }
         }
 
@@ -163,10 +164,12 @@ public class CloudflareChatModelFactory implements ChatModelFactory {
         if (state.isCloudflareModelNameEnabled()) {
             String override = state.getCloudflareModelName();
             if (override != null && !override.isBlank()) {
-                return override.trim();
+                return CloudflareModelName.normalize(override);
             }
         }
         String selected = customChatModel.getModelName();
-        return (selected != null && !selected.isBlank()) ? selected : "default";
+        // Issue #1254: normalise here too, so a bare '@cf/...' id — however it was selected or
+        // persisted — always leaves as the routable 'workers-ai/@cf/...' form.
+        return (selected != null && !selected.isBlank()) ? CloudflareModelName.normalize(selected) : "default";
     }
 }

--- a/src/main/java/com/devoxx/genie/chatmodel/cloud/cloudflare/CloudflareGatewayUrl.java
+++ b/src/main/java/com/devoxx/genie/chatmodel/cloud/cloudflare/CloudflareGatewayUrl.java
@@ -11,11 +11,30 @@ import org.jetbrains.annotations.Nullable;
  */
 public final class CloudflareGatewayUrl {
 
-    private static final String ROOT = "https://gateway.ai.cloudflare.com/v1/";
+    private static final String DEFAULT_ROOT = "https://gateway.ai.cloudflare.com/v1/";
     /** Cloudflare auto-creates a gateway named "default" on first authenticated request. */
     public static final String DEFAULT_GATEWAY = "default";
 
+    /**
+     * The gateway root. Only tests change it, so wire-level tests can point the whole factory
+     * (URL assembly included) at a local mock server instead of the real Cloudflare host.
+     */
+    private static volatile String root = DEFAULT_ROOT;
+
     private CloudflareGatewayUrl() {
+    }
+
+    /**
+     * @param testRoot the root to assemble URLs against (a trailing slash is added when missing),
+     *                 or {@code null} to restore the real Cloudflare gateway root
+     */
+    @org.jetbrains.annotations.TestOnly
+    static void setRootForTests(@Nullable String testRoot) {
+        if (testRoot == null) {
+            root = DEFAULT_ROOT;
+        } else {
+            root = testRoot.endsWith("/") ? testRoot : testRoot + "/";
+        }
     }
 
     /**
@@ -32,7 +51,7 @@ public final class CloudflareGatewayUrl {
         if (gateway.isEmpty()) {
             gateway = DEFAULT_GATEWAY;
         }
-        return ROOT + account + "/" + gateway + "/compat";
+        return root + account + "/" + gateway + "/compat";
     }
 
     private static String stripSlashes(String value) {

--- a/src/main/java/com/devoxx/genie/chatmodel/cloud/cloudflare/CloudflareModelName.java
+++ b/src/main/java/com/devoxx/genie/chatmodel/cloud/cloudflare/CloudflareModelName.java
@@ -1,0 +1,43 @@
+package com.devoxx.genie.chatmodel.cloud.cloudflare;
+
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Normalises model ids for the Cloudflare AI Gateway {@code /compat} endpoint.
+ *
+ * <p>Issue #1254: the compat endpoint addresses models as {@code provider/model}
+ * (e.g. {@code openai/gpt-4o}, {@code workers-ai/@cf/meta/llama-3.3-70b-instruct-fp8-fast}).
+ * Users naturally copy Workers AI model ids straight from the Cloudflare dashboard, where they
+ * appear in their bare {@code @cf/...} form — the gateway then parses {@code @cf} as the provider
+ * segment and rejects the request with {@code 400 AiGatewayError} code 2008 ("Invalid provider").
+ * Since {@code @cf/} is the Workers AI model namespace, the missing {@code workers-ai/} provider
+ * prefix can be added deterministically. Other ids pass through untouched: a bare id such as
+ * {@code kimi-k2.6} could belong to any provider, so no prefix is guessed for it.</p>
+ */
+public final class CloudflareModelName {
+
+    /** Cloudflare's model namespace for Workers AI models, as shown in their dashboard. */
+    private static final String WORKERS_AI_NAMESPACE = "@cf/";
+
+    /** The compat-endpoint provider prefix that routes to Workers AI. */
+    private static final String WORKERS_AI_PROVIDER_PREFIX = "workers-ai/";
+
+    private CloudflareModelName() {
+    }
+
+    /**
+     * @param modelId the model id as configured or selected; may be {@code null}
+     * @return the id trimmed and, for bare Workers AI ids ({@code @cf/...}), prefixed with
+     *         {@code workers-ai/}; {@code null} stays {@code null}
+     */
+    public static @Nullable String normalize(@Nullable String modelId) {
+        if (modelId == null) {
+            return null;
+        }
+        String trimmed = modelId.trim();
+        if (trimmed.startsWith(WORKERS_AI_NAMESPACE)) {
+            return WORKERS_AI_PROVIDER_PREFIX + trimmed;
+        }
+        return trimmed;
+    }
+}

--- a/src/main/java/com/devoxx/genie/service/prompt/error/ProviderErrorTranslator.java
+++ b/src/main/java/com/devoxx/genie/service/prompt/error/ProviderErrorTranslator.java
@@ -80,10 +80,12 @@ public final class ProviderErrorTranslator {
 
     /**
      * Issue #1254: pick guidance matching the failure. The gateway's {@code /compat} endpoint
-     * addresses models as {@code provider/model}, and the two reported failure shapes are both
-     * naming problems: code 2008 ("Invalid provider") when the prefix — or, via Custom OpenAI,
-     * a URL path segment — isn't a provider Cloudflare knows, and an unroutable model (2005)
-     * when the id carries no provider prefix at all.
+     * addresses models as {@code provider/model}, and the reported failure shapes are naming or
+     * routing problems: code 2008 ("Invalid provider") when the prefix — or, via Custom OpenAI,
+     * a URL path segment — isn't a provider Cloudflare knows; code 2005 ("Failed to get response
+     * from provider") when the id carries no usable provider prefix (bare {@code kimi-k2.6} or a
+     * bare Workers AI {@code @cf/...} id) or when the routed provider call itself fails
+     * (e.g. a Cloudflare token without Workers AI permission).
      */
     private static @NotNull String guidanceFor(@Nullable String code, @Nullable String modelName) {
         if ("2008".equals(code)) {
@@ -94,11 +96,24 @@ public final class ProviderErrorTranslator {
                     + "end with '/compat' (https://gateway.ai.cloudflare.com/v1/ACCOUNT_ID/GATEWAY/compat), "
                     + "otherwise Cloudflare reads the next URL segment as a provider name.";
         }
+        if (modelName != null && modelName.startsWith("@cf/")) {
+            return "'" + modelName + "' is a bare Workers AI id: the gateway addresses models as "
+                    + "'provider/model', so it must be sent as 'workers-ai/" + modelName + "'. "
+                    + "The Cloudflare provider adds this prefix automatically — if you configured the gateway "
+                    + "through the Custom OpenAI provider, add the 'workers-ai/' prefix to the model name yourself.";
+        }
         if (modelName != null && !modelName.isBlank() && !modelName.contains("/")) {
             return "The model id has no provider prefix: gateway models must be addressed as 'provider/model', "
                     + "e.g. 'openai/gpt-4o' or 'workers-ai/@cf/meta/llama-3.3-70b-instruct-fp8-fast'. "
                     + "Pick a model from the dropdown (auto-discovered from your gateway), "
                     + "or prefix the model id with the provider configured in your Cloudflare AI Gateway dashboard.";
+        }
+        if ("2005".equals(code) && modelName != null && modelName.startsWith("workers-ai/")) {
+            return "The gateway routed to Workers AI but the provider call failed. "
+                    + "Check that the model id exists on Workers AI (e.g. 'workers-ai/@cf/openai/gpt-oss-20b') and "
+                    + "that your Cloudflare API token includes Workers AI permission (or a Workers AI key is stored "
+                    + "in your gateway's BYOK settings) — a token scoped to AI Gateway alone cannot run Workers AI models. "
+                    + "The gateway's request logs in the Cloudflare dashboard show the upstream provider response.";
         }
         return "This usually means the model isn't available on your gateway, or its provider isn't configured. "
                 + "Pick a model from the dropdown (auto-discovered from your gateway), "

--- a/src/main/java/com/devoxx/genie/service/prompt/error/ProviderErrorTranslator.java
+++ b/src/main/java/com/devoxx/genie/service/prompt/error/ProviderErrorTranslator.java
@@ -74,10 +74,35 @@ public final class ProviderErrorTranslator {
         } else if (detail != null && !detail.isBlank()) {
             sb.append(" (").append(detail).append(')');
         }
-        sb.append(". This usually means the model isn't available on your gateway, or its provider isn't configured. ");
-        sb.append("Pick a model from the dropdown (auto-discovered from your gateway), ");
-        sb.append("or add that provider's API key in your Cloudflare AI Gateway dashboard.");
+        sb.append(". ").append(guidanceFor(code, modelName));
         return Optional.of(sb.toString());
+    }
+
+    /**
+     * Issue #1254: pick guidance matching the failure. The gateway's {@code /compat} endpoint
+     * addresses models as {@code provider/model}, and the two reported failure shapes are both
+     * naming problems: code 2008 ("Invalid provider") when the prefix — or, via Custom OpenAI,
+     * a URL path segment — isn't a provider Cloudflare knows, and an unroutable model (2005)
+     * when the id carries no provider prefix at all.
+     */
+    private static @NotNull String guidanceFor(@Nullable String code, @Nullable String modelName) {
+        if ("2008".equals(code)) {
+            return "Cloudflare didn't recognise the provider it was asked to route to. "
+                    + "Gateway models must be addressed as 'provider/model', e.g. 'openai/gpt-4o' — "
+                    + "Workers AI models need the 'workers-ai/' prefix, e.g. 'workers-ai/@cf/openai/gpt-oss-20b'. "
+                    + "If you configured the gateway through the Custom OpenAI provider instead, the base URL must "
+                    + "end with '/compat' (https://gateway.ai.cloudflare.com/v1/ACCOUNT_ID/GATEWAY/compat), "
+                    + "otherwise Cloudflare reads the next URL segment as a provider name.";
+        }
+        if (modelName != null && !modelName.isBlank() && !modelName.contains("/")) {
+            return "The model id has no provider prefix: gateway models must be addressed as 'provider/model', "
+                    + "e.g. 'openai/gpt-4o' or 'workers-ai/@cf/meta/llama-3.3-70b-instruct-fp8-fast'. "
+                    + "Pick a model from the dropdown (auto-discovered from your gateway), "
+                    + "or prefix the model id with the provider configured in your Cloudflare AI Gateway dashboard.";
+        }
+        return "This usually means the model isn't available on your gateway, or its provider isn't configured. "
+                + "Pick a model from the dropdown (auto-discovered from your gateway), "
+                + "or add that provider's API key in your Cloudflare AI Gateway dashboard.";
     }
 
     /**

--- a/src/main/java/com/devoxx/genie/ui/settings/llm/LLMProvidersComponent.java
+++ b/src/main/java/com/devoxx/genie/ui/settings/llm/LLMProvidersComponent.java
@@ -465,6 +465,8 @@ public class LLMProvidersComponent extends AbstractSettingsComponent {
         addSettingRow(cloudPanel, gbc, "Cloudflare Gateway Name", cloudflareGatewayNameField);
         addHintText(cloudPanel, gbc, "Base URL is built as <code>https://gateway.ai.cloudflare.com/v1/&lt;account&gt;/&lt;gateway&gt;/compat</code>. Gateway defaults to <code>default</code> (auto-created by Cloudflare).");
         addProviderSettingRow(cloudPanel, gbc, "Cloudflare Model", cloudflareModelNameEnabledCheckBox, cloudflareModelNameField);
+        addHintText(cloudPanel, gbc, "Model ids use <code>provider/model</code> form, e.g. <code>openai/gpt-4o</code>. " +
+                "Workers AI ids (<code>@cf/...</code>) get the <code>workers-ai/</code> prefix added automatically.");
         addHintText(cloudPanel, gbc, "When enabled, this exact provider/model name (e.g. <code>openai/gpt-4o-mini</code>) is used and the dropdown is not auto-discovered from <code>/compat/models</code>.");
 
         addAzureOpenAIPanel(cloudPanel, gbc);

--- a/src/test/java/com/devoxx/genie/chatmodel/cloud/cloudflare/CloudflareChatModelFactoryTest.java
+++ b/src/test/java/com/devoxx/genie/chatmodel/cloud/cloudflare/CloudflareChatModelFactoryTest.java
@@ -115,6 +115,50 @@ class CloudflareChatModelFactoryTest {
     }
 
     @Test
+    void getModelsWithBareWorkersAiOverrideShowsThePrefixedIdThatIsSent() {
+        // Issue #1254: '@cf/...' pasted from the Cloudflare dashboard is not routable on /compat
+        // ('@cf' is parsed as the provider -> 400 code 2008 "Invalid provider").
+        when(mockState.isCloudflareModelNameEnabled()).thenReturn(true);
+        when(mockState.getCloudflareModelName()).thenReturn("@cf/openai/gpt-oss-20b");
+        try (MockedStatic<LocalLLMProviderUtil> util = Mockito.mockStatic(LocalLLMProviderUtil.class)) {
+            assertThat(new CloudflareChatModelFactory().getModels())
+                    .extracting(LanguageModel::getModelName)
+                    .containsExactly("workers-ai/@cf/openai/gpt-oss-20b");
+            util.verifyNoInteractions();
+        }
+    }
+
+    @Test
+    void createChatModelPrefixesBareWorkersAiModelIds() {
+        CustomChatModel model = new CustomChatModel();
+        model.setModelName("@cf/openai/gpt-oss-20b");
+        model.setTemperature(0.7);
+        model.setTopP(0.9);
+        model.setMaxTokens(256);
+        model.setMaxRetries(3);
+        model.setTimeout(30);
+
+        ChatModel result = new CloudflareChatModelFactory().createChatModel(model);
+
+        assertThat(result.defaultRequestParameters().modelName())
+                .isEqualTo("workers-ai/@cf/openai/gpt-oss-20b");
+    }
+
+    @Test
+    void createStreamingChatModelPrefixesBareWorkersAiModelIds() {
+        CustomChatModel model = new CustomChatModel();
+        model.setModelName("@cf/zai-org/glm-4.7-flash");
+        model.setTemperature(0.7);
+        model.setTopP(0.9);
+        model.setTimeout(30);
+
+        StreamingChatModel result = new CloudflareChatModelFactory().createStreamingChatModel(model);
+
+        assertThat(result.defaultRequestParameters().modelName())
+                .isEqualTo("workers-ai/@cf/zai-org/glm-4.7-flash");
+    }
+
+    @Test
     void getModelsWithBlankAccountIdReturnsEmpty() {
         when(mockState.getCloudflareAccountId()).thenReturn("");
         assertThat(new CloudflareChatModelFactory().getModels()).isEmpty();

--- a/src/test/java/com/devoxx/genie/chatmodel/cloud/cloudflare/CloudflareCompatWireTest.java
+++ b/src/test/java/com/devoxx/genie/chatmodel/cloud/cloudflare/CloudflareCompatWireTest.java
@@ -1,0 +1,213 @@
+package com.devoxx.genie.chatmodel.cloud.cloudflare;
+
+import com.devoxx.genie.model.CustomChatModel;
+import com.devoxx.genie.service.mcp.MCPService;
+import com.devoxx.genie.service.prompt.error.ProviderErrorTranslator;
+import com.devoxx.genie.ui.settings.DevoxxGenieStateService;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import dev.langchain4j.model.chat.ChatModel;
+import dev.langchain4j.model.chat.StreamingChatModel;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import dev.langchain4j.model.chat.response.StreamingChatResponseHandler;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import java.io.IOException;
+import java.util.Optional;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Issue #1254: wire-level regression tests for the exact Workers AI models from the report,
+ * {@code @cf/openai/gpt-oss-20b} and {@code @cf/zai-org/glm-4.7-flash}. The gateway root is
+ * pointed at a local mock server so the requests run through the real factory, URL assembly and
+ * langchain4j HTTP stack, and the tests assert what Cloudflare would actually receive: the
+ * {@code /v1/{account}/{gateway}/compat/chat/completions} path and the {@code workers-ai/}-prefixed
+ * model id. Without the prefix these ids fail with Cloudflare's 400 {@code AiGatewayError}
+ * (2005 "Failed to get response from provider" / 2008 "Invalid provider").
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class CloudflareCompatWireTest {
+
+    private static final String GPT_OSS_20B = "@cf/openai/gpt-oss-20b";
+    private static final String GLM_4_7_FLASH = "@cf/zai-org/glm-4.7-flash";
+
+    private static final String EXPECTED_COMPAT_PATH = "/v1/acct123/default/compat/chat/completions";
+
+    private static final String CHAT_COMPLETION_RESPONSE = """
+            {
+              "id": "chatcmpl-1",
+              "object": "chat.completion",
+              "model": "workers-ai/@cf/openai/gpt-oss-20b",
+              "choices": [
+                {"index": 0, "message": {"role": "assistant", "content": "ok"}, "finish_reason": "stop"}
+              ],
+              "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2}
+            }
+            """;
+
+    private static final String CHAT_COMPLETION_STREAM_RESPONSE = """
+            data: {"id":"chatcmpl-1","object":"chat.completion.chunk","model":"workers-ai/@cf/zai-org/glm-4.7-flash","choices":[{"index":0,"delta":{"role":"assistant","content":"ok"}}]}
+
+            data: {"id":"chatcmpl-1","object":"chat.completion.chunk","model":"workers-ai/@cf/zai-org/glm-4.7-flash","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}
+
+            data: [DONE]
+
+            """;
+
+    /** The exact 400 body from issue #1254 ("Failed to get response from provider"). */
+    private static final String CLOUDFLARE_2005_BODY =
+            "{\"success\":false,\"result\":[],\"messages\":[],\"error\":[{\"code\":2005,"
+            + "\"message\":\"Failed to get response from provider\"}],\"name\":\"AiGatewayError\","
+            + "\"httpCode\":400,\"internalCode\":2005,\"message\":\"Failed to get response from provider\","
+            + "\"description\":\"Failed to get response from provider\"}";
+
+    private MockWebServer server;
+    private MockedStatic<DevoxxGenieStateService> mockedStateService;
+    private MockedStatic<MCPService> mockedMCPService;
+    private DevoxxGenieStateService mockState;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        server = new MockWebServer();
+        server.start();
+        CloudflareGatewayUrl.setRootForTests(server.url("/v1/").toString());
+
+        mockState = mock(DevoxxGenieStateService.class);
+        when(mockState.getCloudflareAccountId()).thenReturn("acct123");
+        when(mockState.getCloudflareGatewayName()).thenReturn("default");
+        when(mockState.getCloudflareKey()).thenReturn("cf-token");
+        when(mockState.getCloudflareModelName()).thenReturn("");
+        when(mockState.isCloudflareModelNameEnabled()).thenReturn(false);
+        when(mockState.getAgentModeEnabled()).thenReturn(false);
+
+        mockedStateService = Mockito.mockStatic(DevoxxGenieStateService.class);
+        mockedStateService.when(DevoxxGenieStateService::getInstance).thenReturn(mockState);
+
+        mockedMCPService = Mockito.mockStatic(MCPService.class);
+        mockedMCPService.when(MCPService::isMCPEnabled).thenReturn(false);
+    }
+
+    @AfterEach
+    void tearDown() {
+        CloudflareGatewayUrl.setRootForTests(null);
+        if (mockedStateService != null) mockedStateService.close();
+        if (mockedMCPService != null) mockedMCPService.close();
+        try {
+            server.shutdown();
+        } catch (IOException e) {
+            // Ignore shutdown errors from pending responses
+        }
+    }
+
+    @Test
+    void gptOss20bIsSentToCompatWithWorkersAiPrefix() throws InterruptedException {
+        server.enqueue(new MockResponse()
+                .setBody(CHAT_COMPLETION_RESPONSE)
+                .setHeader("Content-Type", "application/json"));
+
+        ChatModel model = new CloudflareChatModelFactory().createChatModel(customChatModel(GPT_OSS_20B));
+        model.chat("hello");
+
+        RecordedRequest request = server.takeRequest(10, TimeUnit.SECONDS);
+        assertThat(request).as("no request reached the mock gateway").isNotNull();
+        assertThat(request.getPath()).isEqualTo(EXPECTED_COMPAT_PATH);
+        assertThat(request.getHeader("Authorization")).isEqualTo("Bearer cf-token");
+        assertThat(bodyOf(request).get("model").getAsString())
+                .isEqualTo("workers-ai/@cf/openai/gpt-oss-20b");
+    }
+
+    @Test
+    void glm47FlashIsStreamedToCompatWithWorkersAiPrefix() throws InterruptedException {
+        server.enqueue(new MockResponse()
+                .setBody(CHAT_COMPLETION_STREAM_RESPONSE)
+                .setHeader("Content-Type", "text/event-stream"));
+
+        StreamingChatModel model =
+                new CloudflareChatModelFactory().createStreamingChatModel(customChatModel(GLM_4_7_FLASH));
+        CountDownLatch done = new CountDownLatch(1);
+        model.chat("hello", new StreamingChatResponseHandler() {
+            @Override
+            public void onPartialResponse(String partialResponse) {
+                // This test is about the request, not the response.
+            }
+
+            @Override
+            public void onCompleteResponse(ChatResponse completeResponse) {
+                done.countDown();
+            }
+
+            @Override
+            public void onError(Throwable error) {
+                done.countDown();
+            }
+        });
+        done.await(10, TimeUnit.SECONDS);
+
+        RecordedRequest request = server.takeRequest(10, TimeUnit.SECONDS);
+        assertThat(request).as("no request reached the mock gateway").isNotNull();
+        assertThat(request.getPath()).isEqualTo(EXPECTED_COMPAT_PATH);
+        assertThat(bodyOf(request).get("model").getAsString())
+                .isEqualTo("workers-ai/@cf/zai-org/glm-4.7-flash");
+    }
+
+    @Test
+    void cloudflare2005ResponseIsTranslatedIntoWorkersAiGuidance() {
+        // Replay the exact issue-#1254 error for a request that already carries the correct
+        // prefix: the surviving cause is gateway-side (token permission / model availability),
+        // and the translated message must say so instead of leaking the raw JSON.
+        for (int i = 0; i < 4; i++) { // cover langchain4j retries, if any
+            server.enqueue(new MockResponse()
+                    .setResponseCode(400)
+                    .setBody(CLOUDFLARE_2005_BODY)
+                    .setHeader("Content-Type", "application/json"));
+        }
+
+        ChatModel model = new CloudflareChatModelFactory().createChatModel(customChatModel(GPT_OSS_20B));
+        Throwable failure = catchThrowable(() -> model.chat("hello"));
+        assertThat(failure).isNotNull();
+
+        Optional<String> translated =
+                ProviderErrorTranslator.translate(failure, "workers-ai/" + GPT_OSS_20B);
+
+        assertThat(translated).isPresent();
+        assertThat(translated.get())
+                .contains("2005")
+                .contains("Failed to get response from provider")
+                .contains("Workers AI")
+                .contains("workers-ai/@cf/openai/gpt-oss-20b")
+                .doesNotContain("{").doesNotContain("httpCode");
+    }
+
+    private static JsonObject bodyOf(RecordedRequest request) {
+        return JsonParser.parseString(request.getBody().readUtf8()).getAsJsonObject();
+    }
+
+    private static CustomChatModel customChatModel(String modelName) {
+        CustomChatModel customChatModel = new CustomChatModel();
+        customChatModel.setModelName(modelName);
+        customChatModel.setTemperature(0.7);
+        customChatModel.setTopP(0.9);
+        customChatModel.setMaxTokens(256);
+        customChatModel.setMaxRetries(1);
+        customChatModel.setTimeout(10);
+        return customChatModel;
+    }
+}

--- a/src/test/java/com/devoxx/genie/chatmodel/cloud/cloudflare/CloudflareModelNameTest.java
+++ b/src/test/java/com/devoxx/genie/chatmodel/cloud/cloudflare/CloudflareModelNameTest.java
@@ -1,0 +1,56 @@
+package com.devoxx.genie.chatmodel.cloud.cloudflare;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Issue #1254: Cloudflare AI Gateway's {@code /compat} endpoint addresses models as
+ * {@code provider/model}. Users copy Workers AI ids from the Cloudflare dashboard in their bare
+ * {@code @cf/...} form, which the gateway rejects with 400 code 2008 ("Invalid provider") because
+ * {@code @cf} is parsed as the provider segment. {@code @cf/} is the Workers AI namespace, so the
+ * {@code workers-ai/} prefix is added deterministically.
+ */
+class CloudflareModelNameTest {
+
+    @Test
+    void prefixesBareWorkersAiIdsWithWorkersAiProvider() {
+        // The exact models from issue #1254.
+        assertThat(CloudflareModelName.normalize("@cf/openai/gpt-oss-20b"))
+                .isEqualTo("workers-ai/@cf/openai/gpt-oss-20b");
+        assertThat(CloudflareModelName.normalize("@cf/zai-org/glm-4.7-flash"))
+                .isEqualTo("workers-ai/@cf/zai-org/glm-4.7-flash");
+    }
+
+    @Test
+    void leavesAlreadyPrefixedWorkersAiIdsUntouched() {
+        assertThat(CloudflareModelName.normalize("workers-ai/@cf/meta/llama-3.3-70b-instruct-fp8-fast"))
+                .isEqualTo("workers-ai/@cf/meta/llama-3.3-70b-instruct-fp8-fast");
+    }
+
+    @Test
+    void leavesRegularProviderPrefixedIdsUntouched() {
+        assertThat(CloudflareModelName.normalize("openai/gpt-4o")).isEqualTo("openai/gpt-4o");
+        assertThat(CloudflareModelName.normalize("anthropic/claude-4-5-sonnet"))
+                .isEqualTo("anthropic/claude-4-5-sonnet");
+    }
+
+    @Test
+    void doesNotGuessAProviderForBareModelIds() {
+        // 'kimi-k2.6' from the issue could belong to any provider — no prefix is invented for it;
+        // the ProviderErrorTranslator guidance covers this case instead.
+        assertThat(CloudflareModelName.normalize("kimi-k2.6")).isEqualTo("kimi-k2.6");
+    }
+
+    @Test
+    void trimsWhitespaceBeforeInspectingTheId() {
+        assertThat(CloudflareModelName.normalize("  @cf/openai/gpt-oss-20b  "))
+                .isEqualTo("workers-ai/@cf/openai/gpt-oss-20b");
+        assertThat(CloudflareModelName.normalize(" openai/gpt-4o ")).isEqualTo("openai/gpt-4o");
+    }
+
+    @Test
+    void passesNullThrough() {
+        assertThat(CloudflareModelName.normalize(null)).isNull();
+    }
+}

--- a/src/test/java/com/devoxx/genie/service/prompt/error/ProviderErrorTranslatorTest.java
+++ b/src/test/java/com/devoxx/genie/service/prompt/error/ProviderErrorTranslatorTest.java
@@ -53,6 +53,60 @@ class ProviderErrorTranslatorTest {
                 .satisfies(m -> assertThat(m).contains("the selected model").doesNotContain("model ''"));
     }
 
+    /** The body from issue #1254: '@cf' (or a stray URL segment) parsed as an unknown provider. */
+    private static final String CLOUDFLARE_2008_BODY =
+            "{\"success\":false,\"result\":[],\"messages\":[],\"error\":[{\"code\":2008,"
+            + "\"message\":\"Invalid provider\"}],\"name\":\"AiGatewayError\","
+            + "\"httpCode\":400,\"internalCode\":2008,\"message\":\"Invalid provider\","
+            + "\"description\":\"Invalid provider\"}";
+
+    @Test
+    void explainsProviderModelNamingForInvalidProviderErrors() {
+        // Issue #1254: a bare Workers AI id makes /compat parse '@cf' as the provider -> code 2008.
+        Throwable error = new RuntimeException("Provider unavailable: " + CLOUDFLARE_2008_BODY);
+
+        Optional<String> result = ProviderErrorTranslator.translate(error, "@cf/openai/gpt-oss-20b");
+
+        assertThat(result).isPresent();
+        assertThat(result.get())
+                .contains("2008")
+                .contains("Invalid provider")
+                .contains("provider/model")
+                .contains("workers-ai/@cf/openai/gpt-oss-20b")
+                .contains("/compat")
+                .doesNotContain("{").doesNotContain("httpCode");
+    }
+
+    @Test
+    void explainsMissingProviderPrefixForUnroutableBareModelIds() {
+        // Issue #1254: 'kimi-k2.6' carries no provider prefix, so the gateway cannot route it.
+        Throwable error = new RuntimeException("status code: 400; body: " + CLOUDFLARE_2005_BODY);
+
+        Optional<String> result = ProviderErrorTranslator.translate(error, "kimi-k2.6");
+
+        assertThat(result).isPresent();
+        assertThat(result.get())
+                .contains("kimi-k2.6")
+                .contains("no provider prefix")
+                .contains("provider/model")
+                .contains("dropdown")
+                .doesNotContain("{").doesNotContain("httpCode");
+    }
+
+    @Test
+    void keepsGenericGuidanceForPrefixedModelsOnOtherErrorCodes() {
+        // A correctly-prefixed model failing with 2005 is a gateway-side problem (provider key
+        // missing, model unavailable) — the pre-#1254 guidance remains the right one.
+        Throwable error = new RuntimeException(CLOUDFLARE_2005_BODY);
+
+        assertThat(ProviderErrorTranslator.translate(error, "openai/gpt-4o"))
+                .get()
+                .satisfies(m -> assertThat(m)
+                        .contains("dropdown")
+                        .contains("Cloudflare AI Gateway dashboard")
+                        .doesNotContain("no provider prefix"));
+    }
+
     @Test
     void returnsEmptyForNonCloudflareErrors() {
         assertThat(ProviderErrorTranslator.translate(

--- a/src/test/java/com/devoxx/genie/service/prompt/error/ProviderErrorTranslatorTest.java
+++ b/src/test/java/com/devoxx/genie/service/prompt/error/ProviderErrorTranslatorTest.java
@@ -94,6 +94,39 @@ class ProviderErrorTranslatorTest {
     }
 
     @Test
+    void suggestsWorkersAiPrefixForBareCfIdsFailingWith2005() {
+        // Issue #1254: the reporter's exact models, failing with "Failed to get response from
+        // provider" — the fix is the 'workers-ai/' prefix, and the message must say so.
+        for (String model : new String[]{"@cf/openai/gpt-oss-20b", "@cf/zai-org/glm-4.7-flash"}) {
+            Throwable error = new RuntimeException("Provider unavailable: " + CLOUDFLARE_2005_BODY);
+
+            Optional<String> result = ProviderErrorTranslator.translate(error, model);
+
+            assertThat(result).isPresent();
+            assertThat(result.get())
+                    .contains("2005")
+                    .contains("workers-ai/" + model)
+                    .doesNotContain("{").doesNotContain("httpCode");
+        }
+    }
+
+    @Test
+    void explainsWorkersAiPermissionsWhenAPrefixedWorkersAiModelFailsWith2005() {
+        // Correctly-prefixed Workers AI model still failing 2005: the request routed, so the
+        // remaining causes are gateway-side — token permission or model availability.
+        Throwable error = new RuntimeException("status code: 400; body: " + CLOUDFLARE_2005_BODY);
+
+        Optional<String> result =
+                ProviderErrorTranslator.translate(error, "workers-ai/@cf/openai/gpt-oss-20b");
+
+        assertThat(result).isPresent();
+        assertThat(result.get())
+                .contains("Workers AI")
+                .contains("permission")
+                .doesNotContain("{").doesNotContain("httpCode");
+    }
+
+    @Test
     void keepsGenericGuidanceForPrefixedModelsOnOtherErrorCodes() {
         // A correctly-prefixed model failing with 2005 is a gateway-side problem (provider key
         // missing, model unavailable) — the pre-#1254 guidance remains the right one.


### PR DESCRIPTION
Cloudflare AI Gateway's /compat endpoint addresses models as
'provider/model'. Users copy Workers AI ids from the Cloudflare
dashboard in their bare '@cf/...' form, which the gateway rejects with
400 AiGatewayError code 2008 ('Invalid provider') because '@cf' is
parsed as the provider segment; ids with no prefix at all (e.g.
'kimi-k2.6') fail as unroutable with code 2005.

- Add CloudflareModelName.normalize(): '@cf/...' ids get the
  'workers-ai/' provider prefix deterministically ('@cf/' is the
  Workers AI namespace); no provider is ever guessed for other bare
  ids. Applied on both the chat and streaming paths and to the model
  override shown in the dropdown.
- Teach ProviderErrorTranslator code-aware guidance: 2008 now explains
  the provider/model format, the workers-ai/ prefix, and the '/compat'
  URL requirement for hand-built Custom OpenAI gateway URLs; an
  unroutable bare id now names the missing provider prefix.
- Add a settings hint under the Cloudflare Model field and a 'Model
  naming' docs section spelling out the format.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01T7tc35CAePyJCqjiqP4jBw