### PR TITLE
fix(docs): landing-page stats never refreshed — devoxx.com WAF 403s the build-time fetch

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -7,8 +7,9 @@ on:
       - main
     paths:
       - 'docusaurus/**'
-  # The landing-page stats band reads live active-user / download figures from
-  # devoxx.com and the GitHub star count from api.github.com at build time
+  # The landing-page stats band reads the download count from
+  # plugins.jetbrains.com, active users from devoxx.com and the GitHub star
+  # count from api.github.com at build time
   # (docusaurus/src/plugins/genie-stats), so a rebuild is what refreshes them.
   # Daily, 05:00 UTC.
   schedule:

--- a/docusaurus/src/plugins/genie-stats/index.js
+++ b/docusaurus/src/plugins/genie-stats/index.js
@@ -1,11 +1,12 @@
 // Live DevoxxGenie figures for the landing-page stats band.
 //
-// Two upstreams, fetched independently so one being down never blanks the other:
-//  - devoxx.com owns the usage numbers: `GET /api/genie-stats` returns cumulative
-//    JetBrains Marketplace downloads and GA4 active users, refreshed server-side
-//    every 6 hours.
+// Three upstreams, fetched independently so one being down never blanks the others:
+//  - plugins.jetbrains.com owns the download counter: `GET /api/plugins/24169`
+//    is the Marketplace's own public API and the authoritative source.
+//  - devoxx.com owns the GA4 active-user figure (and mirrors the download count,
+//    refreshed server-side every 6 hours): `GET /api/genie-stats`.
 //  - api.github.com owns the star count for devoxx/DevoxxGenieIDEAPlugin.
-// We read both here at BUILD time (Node, so no CORS involved) and bake the
+// We read them here at BUILD time (Node, so no CORS involved) and bake the
 // result into the static HTML via global data -- the numbers are in the markup
 // for crawlers and there is no loading flash on first paint.
 //
@@ -14,8 +15,16 @@
 // src/pages/index.js by hand.
 
 const STATS_URL = 'https://devoxx.com/api/genie-stats';
+const MARKETPLACE_PLUGIN_URL = 'https://plugins.jetbrains.com/api/plugins/24169';
 const GITHUB_REPO_URL = 'https://api.github.com/repos/devoxx/DevoxxGenieIDEAPlugin';
 const TIMEOUT_MS = 5000;
+
+// devoxx.com sits behind a WAF that 403s Node's default `User-Agent: node`
+// (browser requests pass, which is why the endpoint looks fine when checked by
+// hand). Identify ourselves explicitly instead -- see the fallback warnings in
+// the deploy-docs Actions logs from before this header existed.
+const USER_AGENT =
+  'Mozilla/5.0 (compatible; DevoxxGenieDocsBuild/1.0; +https://genie.devoxx.com)';
 
 /**
  * Used when a fetch fails -- an offline laptop, a CI runner without egress,
@@ -32,6 +41,15 @@ const FALLBACK = {
 
 const FALLBACK_GITHUB_STARS = 671;
 
+function warn(message) {
+  console.warn(`[genie-stats] ${message}`);
+  // A stale stats band is otherwise invisible inside a green build -- surface
+  // fallback use as an annotation in the Actions run summary.
+  if (process.env.GITHUB_ACTIONS) {
+    console.log(`::warning title=genie-stats::${message}`);
+  }
+}
+
 function formatAsOf(date) {
   // Built once in Node and serialized into global data, so the client never
   // recomputes it -- no locale-dependent hydration mismatch.
@@ -43,19 +61,22 @@ function isUsableCount(value) {
   return typeof value === 'number' && Number.isFinite(value) && value > 0;
 }
 
+async function fetchJson(url, headers) {
+  const res = await fetch(url, {
+    headers: {Accept: 'application/json', 'User-Agent': USER_AGENT, ...headers},
+    // Node's fetch has no default overall timeout; an unbounded hang here
+    // would stall the build.
+    signal: AbortSignal.timeout(TIMEOUT_MS),
+  });
+  if (!res.ok) {
+    throw new Error(`responded ${res.status}`);
+  }
+  return res.json();
+}
+
 async function fetchUsageStats() {
   try {
-    const res = await fetch(STATS_URL, {
-      headers: {Accept: 'application/json'},
-      // Node's fetch has no default overall timeout; an unbounded hang here
-      // would stall the build.
-      signal: AbortSignal.timeout(TIMEOUT_MS),
-    });
-    if (!res.ok) {
-      throw new Error(`responded ${res.status}`);
-    }
-
-    const body = await res.json();
+    const body = await fetchJson(STATS_URL);
     if (!isUsableCount(body.activeUsers) || !isUsableCount(body.downloads)) {
       throw new Error('response has no usable activeUsers/downloads');
     }
@@ -63,14 +84,25 @@ async function fetchUsageStats() {
     return {
       activeUsers: body.activeUsers,
       downloads: body.downloads,
-      asOf: formatAsOf(new Date()),
       live: true,
     };
   } catch (err) {
-    console.warn(
-      `[genie-stats] ${STATS_URL} unavailable (${err.message}); using baked-in fallback figures.`,
-    );
-    return {...FALLBACK};
+    warn(`${STATS_URL} unavailable (${err.message}); using baked-in fallback figures.`);
+    return {activeUsers: FALLBACK.activeUsers, downloads: FALLBACK.downloads, live: false};
+  }
+}
+
+/** The Marketplace's own counter for the plugin; null when unavailable. */
+async function fetchMarketplaceDownloads() {
+  try {
+    const body = await fetchJson(MARKETPLACE_PLUGIN_URL);
+    if (!isUsableCount(body.downloads)) {
+      throw new Error('response has no usable downloads');
+    }
+    return body.downloads;
+  } catch (err) {
+    warn(`${MARKETPLACE_PLUGIN_URL} unavailable (${err.message}); falling back to devoxx.com's download count.`);
+    return null;
   }
 }
 
@@ -84,24 +116,14 @@ async function fetchGithubStars() {
       headers.Authorization = `Bearer ${process.env.GITHUB_TOKEN}`;
     }
 
-    const res = await fetch(GITHUB_REPO_URL, {
-      headers,
-      signal: AbortSignal.timeout(TIMEOUT_MS),
-    });
-    if (!res.ok) {
-      throw new Error(`responded ${res.status}`);
-    }
-
-    const body = await res.json();
+    const body = await fetchJson(GITHUB_REPO_URL, headers);
     if (!isUsableCount(body.stargazers_count)) {
       throw new Error('response has no usable stargazers_count');
     }
 
     return body.stargazers_count;
   } catch (err) {
-    console.warn(
-      `[genie-stats] ${GITHUB_REPO_URL} unavailable (${err.message}); using baked-in fallback star count.`,
-    );
+    warn(`${GITHUB_REPO_URL} unavailable (${err.message}); using baked-in fallback star count.`);
     return FALLBACK_GITHUB_STARS;
   }
 }
@@ -111,11 +133,25 @@ module.exports = function genieStatsPlugin() {
     name: 'genie-stats',
 
     async loadContent() {
-      const [usage, githubStars] = await Promise.all([
+      const [usage, marketplaceDownloads, githubStars] = await Promise.all([
         fetchUsageStats(),
+        fetchMarketplaceDownloads(),
         fetchGithubStars(),
       ]);
-      return {...usage, githubStars};
+
+      // Marketplace is authoritative for its own counter; devoxx.com's mirror
+      // (already in `usage.downloads`) covers a Marketplace outage, and the
+      // baked-in FALLBACK covers both being down.
+      const downloads = marketplaceDownloads ?? usage.downloads;
+      const live = usage.live || marketplaceDownloads !== null;
+
+      return {
+        activeUsers: usage.activeUsers,
+        downloads,
+        githubStars,
+        live,
+        asOf: live ? formatAsOf(new Date()) : FALLBACK.asOf,
+      };
     },
 
     contentLoaded({content, actions}) {


### PR DESCRIPTION
Every deploy-docs build since the stats band landed logged
'[genie-stats] https://devoxx.com/api/genie-stats unavailable (responded 403)'
and silently baked the hardcoded fallback figures into the page, so the
active-user and download numbers never moved. The GitHub-stars fetch in the
same builds succeeded, pinning the 403 on devoxx.com rejecting Node's default
'User-Agent: node' rather than on runner egress.

- Send an explicit User-Agent on all genie-stats fetches so the WAF stops
  rejecting them.
- Fetch the download count from the JetBrains Marketplace public API
  (plugins.jetbrains.com/api/plugins/24169), the authoritative source with no
  bot wall, falling back to devoxx.com's mirror and then the baked-in figure.
- Emit a GitHub Actions ::warning:: annotation whenever a fallback is used,
  so a stale stats band is visible in the run summary instead of buried in a
  green build's logs.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01MB4w9bS6pKjGcwpWEQJG3e