### PR TITLE
fix(cloudflare): agent tool calls rejected by Workers AI schema (#1256)

### DIFF
--- a/src/main/java/com/devoxx/genie/chatmodel/cloud/cloudflare/CloudflareChatModelFactory.java
+++ b/src/main/java/com/devoxx/genie/chatmodel/cloud/cloudflare/CloudflareChatModelFactory.java
@@ -50,6 +50,7 @@ public class CloudflareChatModelFactory implements ChatModelFactory {
     public ChatModel createChatModel(@NotNull CustomChatModel customChatModel) {
         DevoxxGenieStateService state = DevoxxGenieStateService.getInstance();
         return OpenAiChatModel.builder()
+                .httpClientBuilder(CloudflareCompatHttpClient.builder())
                 .baseUrl(baseUrl(state))
                 .apiKey(apiKeyOrPlaceholder(state))
                 .modelName(resolveModelName(customChatModel))
@@ -67,6 +68,7 @@ public class CloudflareChatModelFactory implements ChatModelFactory {
     public StreamingChatModel createStreamingChatModel(@NotNull CustomChatModel customChatModel) {
         DevoxxGenieStateService state = DevoxxGenieStateService.getInstance();
         return OpenAiStreamingChatModel.builder()
+                .httpClientBuilder(CloudflareCompatHttpClient.builder())
                 .baseUrl(baseUrl(state))
                 .apiKey(apiKeyOrPlaceholder(state))
                 .modelName(resolveModelName(customChatModel))

--- a/src/main/java/com/devoxx/genie/chatmodel/cloud/cloudflare/CloudflareCompatHttpClient.java
+++ b/src/main/java/com/devoxx/genie/chatmodel/cloud/cloudflare/CloudflareCompatHttpClient.java
@@ -1,0 +1,95 @@
+package com.devoxx.genie.chatmodel.cloud.cloudflare;
+
+import dev.langchain4j.exception.HttpException;
+import dev.langchain4j.http.client.HttpClient;
+import dev.langchain4j.http.client.HttpClientBuilder;
+import dev.langchain4j.http.client.HttpRequest;
+import dev.langchain4j.http.client.SuccessfulHttpResponse;
+import dev.langchain4j.http.client.jdk.JdkHttpClientBuilder;
+import dev.langchain4j.http.client.sse.ServerSentEventListener;
+import dev.langchain4j.http.client.sse.ServerSentEventParser;
+import org.jetbrains.annotations.NotNull;
+
+import java.time.Duration;
+
+/**
+ * An {@link HttpClient} that runs every outgoing request body through
+ * {@link CloudflareCompatRequestNormalizer} before handing it to the real client.
+ *
+ * <p>Issue #1256: langchain4j speaks correct OpenAI, but Cloudflare's {@code /compat} endpoint
+ * passes the messages on to Workers AI, whose schema is stricter. This is the only seam
+ * langchain4j offers for touching the serialised request, so the Cloudflare-specific reshaping
+ * lives here instead of leaking into the shared OpenAI code path.</p>
+ */
+public class CloudflareCompatHttpClient implements HttpClient {
+
+    private final HttpClient delegate;
+
+    public CloudflareCompatHttpClient(@NotNull HttpClient delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public SuccessfulHttpResponse execute(HttpRequest request) throws HttpException {
+        return delegate.execute(normalize(request));
+    }
+
+    @Override
+    public void execute(HttpRequest request, ServerSentEventParser parser, ServerSentEventListener listener) {
+        delegate.execute(normalize(request), parser, listener);
+    }
+
+    private static HttpRequest normalize(@NotNull HttpRequest request) {
+        String body = request.body();
+        String normalized = CloudflareCompatRequestNormalizer.normalize(body);
+        if (normalized == null || normalized.equals(body)) {
+            return request;
+        }
+        return HttpRequest.builder()
+                .method(request.method())
+                .url(request.url())
+                .headers(request.headers())
+                .body(normalized)
+                .build();
+    }
+
+    /**
+     * Wraps the JDK client builder so langchain4j's timeout settings still reach the real client.
+     * The concrete {@link JdkHttpClientBuilder} is created directly rather than via
+     * {@code HttpClientBuilderLoader}, which throws when several HTTP client SPI factories share
+     * the classpath — a real risk inside an IDE plugin.
+     */
+    public static @NotNull HttpClientBuilder builder() {
+        return new Builder(new JdkHttpClientBuilder());
+    }
+
+    private record Builder(HttpClientBuilder delegate) implements HttpClientBuilder {
+
+        @Override
+        public Duration connectTimeout() {
+            return delegate.connectTimeout();
+        }
+
+        @Override
+        public HttpClientBuilder connectTimeout(Duration timeout) {
+            delegate.connectTimeout(timeout);
+            return this;
+        }
+
+        @Override
+        public Duration readTimeout() {
+            return delegate.readTimeout();
+        }
+
+        @Override
+        public HttpClientBuilder readTimeout(Duration timeout) {
+            delegate.readTimeout(timeout);
+            return this;
+        }
+
+        @Override
+        public HttpClient build() {
+            return new CloudflareCompatHttpClient(delegate.build());
+        }
+    }
+}

--- a/src/main/java/com/devoxx/genie/chatmodel/cloud/cloudflare/CloudflareCompatRequestNormalizer.java
+++ b/src/main/java/com/devoxx/genie/chatmodel/cloud/cloudflare/CloudflareCompatRequestNormalizer.java
@@ -1,0 +1,117 @@
+package com.devoxx.genie.chatmodel.cloud.cloudflare;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import org.jetbrains.annotations.Contract;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Reshapes an OpenAI chat-completions request body into the message shape Cloudflare's
+ * {@code /compat} endpoint can hand to Workers AI.
+ *
+ * <p>Issue #1256: the gateway forwards the request to the Workers AI model, whose native schema
+ * requires every message to carry a <em>string</em> {@code content}. Two things trip it up:</p>
+ * <ul>
+ *   <li>langchain4j omits {@code content} on an assistant message that only carries
+ *       {@code tool_calls} (perfectly valid OpenAI), which Workers AI rejects with
+ *       {@code required properties at '/messages/N' are 'role,content'}. This is what breaks agent
+ *       mode: the first round trip succeeds, the one replaying the tool call 400s.</li>
+ *   <li>A multi-part (array) {@code content} is rejected with
+ *       {@code Type mismatch of '/messages/N/content', 'array' not in 'string'}.</li>
+ * </ul>
+ *
+ * <p>So: a missing or null {@code content} becomes {@code ""}, and a text-only parts array is
+ * flattened into a single string. Arrays holding non-text parts (images) are left alone — vision
+ * models need them, and flattening would silently drop the image. Everything else in the body is
+ * passed through untouched, and a body we cannot parse is returned as-is.</p>
+ */
+public final class CloudflareCompatRequestNormalizer {
+
+    private static final Gson GSON = new GsonBuilder().disableHtmlEscaping().create();
+
+    private CloudflareCompatRequestNormalizer() {
+    }
+
+    /**
+     * @param body the JSON request body, or {@code null}
+     * @return the normalised body, or the input unchanged when there is nothing to do
+     */
+    @Contract("null -> null; !null -> !null")
+    public static @Nullable String normalize(@Nullable String body) {
+        if (body == null || body.isBlank()) {
+            return body;
+        }
+
+        JsonObject root;
+        try {
+            JsonElement parsed = JsonParser.parseString(body);
+            if (!parsed.isJsonObject()) {
+                return body;
+            }
+            root = parsed.getAsJsonObject();
+        } catch (Exception e) {
+            return body;
+        }
+
+        JsonElement messages = root.get("messages");
+        if (messages == null || !messages.isJsonArray()) {
+            return body;
+        }
+
+        boolean changed = false;
+        for (JsonElement element : messages.getAsJsonArray()) {
+            if (element.isJsonObject()) {
+                changed |= normalizeMessage(element.getAsJsonObject());
+            }
+        }
+        return changed ? GSON.toJson(root) : body;
+    }
+
+    private static boolean normalizeMessage(JsonObject message) {
+        JsonElement content = message.get("content");
+
+        if (content == null || content.isJsonNull()) {
+            message.addProperty("content", "");
+            return true;
+        }
+
+        if (content.isJsonArray() && isTextOnly(content.getAsJsonArray())) {
+            message.addProperty("content", flattenText(content.getAsJsonArray()));
+            return true;
+        }
+
+        return false;
+    }
+
+    private static boolean isTextOnly(JsonArray parts) {
+        for (JsonElement part : parts) {
+            if (!part.isJsonObject()) {
+                return false;
+            }
+            JsonObject partObject = part.getAsJsonObject();
+            JsonElement type = partObject.get("type");
+            if (type == null || !type.isJsonPrimitive() || !"text".equals(type.getAsString())) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static String flattenText(JsonArray parts) {
+        StringBuilder text = new StringBuilder();
+        for (JsonElement part : parts) {
+            JsonElement value = part.getAsJsonObject().get("text");
+            if (value != null && value.isJsonPrimitive()) {
+                if (!text.isEmpty()) {
+                    text.append('\n');
+                }
+                text.append(value.getAsString());
+            }
+        }
+        return text.toString();
+    }
+}

--- a/src/main/java/com/devoxx/genie/chatmodel/cloud/cloudflare/CloudflareCompatRequestNormalizer.java
+++ b/src/main/java/com/devoxx/genie/chatmodel/cloud/cloudflare/CloudflareCompatRequestNormalizer.java
@@ -58,7 +58,7 @@ public final class CloudflareCompatRequestNormalizer {
         }
 
         JsonElement messages = root.get("messages");
-        if (messages == null || !messages.isJsonArray()) {
+        if (messages == null || !messages.isJsonArray() || !isWorkersAi(root)) {
             return body;
         }
 
@@ -69,6 +69,18 @@ public final class CloudflareCompatRequestNormalizer {
             }
         }
         return changed ? GSON.toJson(root) : body;
+    }
+
+    /**
+     * The strict message schema belongs to Workers AI. The same gateway also fronts OpenAI,
+     * Anthropic and friends, whose own translations are happy with what langchain4j sends — those
+     * requests are handed on byte for byte rather than risk breaking a working round trip.
+     */
+    private static boolean isWorkersAi(JsonObject root) {
+        JsonElement model = root.get("model");
+        return model != null
+                && model.isJsonPrimitive()
+                && model.getAsString().startsWith(CloudflareModelName.WORKERS_AI_PROVIDER_PREFIX);
     }
 
     private static boolean normalizeMessage(JsonObject message) {

--- a/src/main/java/com/devoxx/genie/chatmodel/cloud/cloudflare/CloudflareModelName.java
+++ b/src/main/java/com/devoxx/genie/chatmodel/cloud/cloudflare/CloudflareModelName.java
@@ -20,7 +20,7 @@ public final class CloudflareModelName {
     private static final String WORKERS_AI_NAMESPACE = "@cf/";
 
     /** The compat-endpoint provider prefix that routes to Workers AI. */
-    private static final String WORKERS_AI_PROVIDER_PREFIX = "workers-ai/";
+    public static final String WORKERS_AI_PROVIDER_PREFIX = "workers-ai/";
 
     private CloudflareModelName() {
     }

--- a/src/main/java/com/devoxx/genie/service/prompt/error/ProviderErrorTranslator.java
+++ b/src/main/java/com/devoxx/genie/service/prompt/error/ProviderErrorTranslator.java
@@ -47,7 +47,9 @@ public final class ProviderErrorTranslator {
     }
 
     private static @NotNull Optional<String> translateCloudflare(@NotNull String message, @Nullable String modelName) {
-        if (!message.contains("AiGatewayError")) {
+        // 'AiGatewayError' is the gateway's own routing failure (issue #1254); 'AiError' comes from
+        // the model behind it rejecting the request (issue #1256). Both reach the chat as raw JSON.
+        if (!message.contains("AiGatewayError") && !message.contains("AiError")) {
             return Optional.empty();
         }
 
@@ -59,7 +61,7 @@ public final class ProviderErrorTranslator {
                 code = body.get("internalCode").getAsString();
             }
             if (body.has("message") && !body.get("message").isJsonNull()) {
-                detail = body.get("message").getAsString();
+                detail = shorten(body.get("message").getAsString());
             }
         }
 
@@ -88,6 +90,15 @@ public final class ProviderErrorTranslator {
      * (e.g. a Cloudflare token without Workers AI permission).
      */
     private static @NotNull String guidanceFor(@Nullable String code, @Nullable String modelName) {
+        if ("5006".equals(code)) {
+            return "The model behind the gateway rejected the request: its schema wants every message "
+                    + "to carry a plain string 'content'. This shows up in Agent mode, where the tool "
+                    + "call and its result are sent back to the model in the next round trip. "
+                    + "DevoxxGenie already reshapes those messages for Workers AI — if the error "
+                    + "persists, the gateway's own conversion is at fault: try another Workers AI model "
+                    + "with function calling (e.g. 'workers-ai/@cf/meta/llama-3.3-70b-instruct-fp8-fast') "
+                    + "or turn Agent mode off for this model.";
+        }
         if ("2008".equals(code)) {
             return "Cloudflare didn't recognise the provider it was asked to route to. "
                     + "Gateway models must be addressed as 'provider/model', e.g. 'openai/gpt-4o' — "
@@ -118,6 +129,25 @@ public final class ProviderErrorTranslator {
         return "This usually means the model isn't available on your gateway, or its provider isn't configured. "
                 + "Pick a model from the dropdown (auto-discovered from your gateway), "
                 + "or add that provider's API key in your Cloudflare AI Gateway dashboard.";
+    }
+
+    /**
+     * Keep the headline of a provider message and drop the rest. Cloudflare's {@code AiError}
+     * messages append the full JSON-schema validation dump ("Error: oneOf at '/' not met, 0 matches:
+     * Type mismatch of '/messages/0/content' ..." — one line per message in the conversation), which
+     * is noise to a user and would swamp the guidance that follows.
+     */
+    private static @NotNull String shorten(@NotNull String detail) {
+        // Strip the envelope name first — otherwise "AiError:" is itself mistaken for the dump marker.
+        String headline = detail.replace("AiError:", "").trim();
+        int schemaDump = headline.indexOf("Error:");
+        if (schemaDump > 0) {
+            headline = headline.substring(0, schemaDump).trim();
+        }
+        while (headline.endsWith(":") || headline.endsWith(",") || headline.endsWith(".")) {
+            headline = headline.substring(0, headline.length() - 1).trim();
+        }
+        return headline.isBlank() ? detail : headline;
     }
 
     /**

--- a/src/test/java/com/devoxx/genie/chatmodel/cloud/cloudflare/CloudflareAgentToolWireTest.java
+++ b/src/test/java/com/devoxx/genie/chatmodel/cloud/cloudflare/CloudflareAgentToolWireTest.java
@@ -1,0 +1,200 @@
+package com.devoxx.genie.chatmodel.cloud.cloudflare;
+
+import com.devoxx.genie.model.CustomChatModel;
+import com.devoxx.genie.service.mcp.MCPService;
+import com.devoxx.genie.ui.settings.DevoxxGenieStateService;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import dev.langchain4j.agent.tool.ToolExecutionRequest;
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.data.message.SystemMessage;
+import dev.langchain4j.data.message.ToolExecutionResultMessage;
+import dev.langchain4j.data.message.UserMessage;
+import dev.langchain4j.model.chat.ChatModel;
+import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.agent.tool.ToolSpecification;
+import dev.langchain4j.model.chat.request.json.JsonObjectSchema;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Issue #1256: the agent's second round trip (assistant tool_calls + tool result) is rejected by
+ * Cloudflare with a Workers AI schema error complaining that {@code messages[].content} is an
+ * 'array' not a 'string' and that one message is missing 'role,content'.
+ *
+ * <p>This test characterises what the plugin actually puts on the wire for that exact round trip,
+ * so we can tell a client-side bug from a gateway-side one. Workers AI's native message schema
+ * requires every message to carry a string {@code content}
+ * (<a href="https://developers.cloudflare.com/workers-ai/models/gpt-oss-20b/">gpt-oss-20b</a>).</p>
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class CloudflareAgentToolWireTest {
+
+    private static final String GPT_OSS_20B = "workers-ai/@cf/openai/gpt-oss-20b";
+
+    private static final String CHAT_COMPLETION_RESPONSE = """
+            {
+              "id": "chatcmpl-2",
+              "object": "chat.completion",
+              "model": "workers-ai/@cf/openai/gpt-oss-20b",
+              "choices": [
+                {"index": 0, "message": {"role": "assistant", "content": "done"}, "finish_reason": "stop"}
+              ],
+              "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2}
+            }
+            """;
+
+    private MockWebServer server;
+    private MockedStatic<DevoxxGenieStateService> mockedStateService;
+    private MockedStatic<MCPService> mockedMCPService;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        server = new MockWebServer();
+        server.start();
+        CloudflareGatewayUrl.setRootForTests(server.url("/v1/").toString());
+
+        DevoxxGenieStateService mockState = mock(DevoxxGenieStateService.class);
+        when(mockState.getCloudflareAccountId()).thenReturn("acct123");
+        when(mockState.getCloudflareGatewayName()).thenReturn("default");
+        when(mockState.getCloudflareKey()).thenReturn("cf-token");
+        when(mockState.getCloudflareModelName()).thenReturn("");
+        when(mockState.isCloudflareModelNameEnabled()).thenReturn(false);
+        when(mockState.getAgentModeEnabled()).thenReturn(true);
+
+        mockedStateService = Mockito.mockStatic(DevoxxGenieStateService.class);
+        mockedStateService.when(DevoxxGenieStateService::getInstance).thenReturn(mockState);
+
+        mockedMCPService = Mockito.mockStatic(MCPService.class);
+        mockedMCPService.when(MCPService::isMCPEnabled).thenReturn(false);
+    }
+
+    @AfterEach
+    void tearDown() {
+        CloudflareGatewayUrl.setRootForTests(null);
+        if (mockedStateService != null) mockedStateService.close();
+        if (mockedMCPService != null) mockedMCPService.close();
+        try {
+            server.shutdown();
+        } catch (IOException e) {
+            // Ignore shutdown errors from pending responses
+        }
+    }
+
+    @Test
+    void everyMessageOfAToolRoundTripCarriesAStringContent() throws InterruptedException {
+        server.enqueue(new MockResponse()
+                .setBody(CHAT_COMPLETION_RESPONSE)
+                .setHeader("Content-Type", "application/json"));
+
+        ChatModel model = new CloudflareChatModelFactory().createChatModel(customChatModel());
+        model.chat(searchFilesRoundTrip());
+
+        RecordedRequest request = server.takeRequest(10, TimeUnit.SECONDS);
+        assertThat(request).as("no request reached the mock gateway").isNotNull();
+
+        JsonArray messages = bodyOf(request).getAsJsonArray("messages");
+        assertThat(messages).hasSize(4);
+
+        for (int i = 0; i < messages.size(); i++) {
+            JsonObject message = messages.get(i).getAsJsonObject();
+            assertThat(message.has("role")).as("messages[%d] has no role", i).isTrue();
+
+            JsonElement content = message.get("content");
+            assertThat(content).as("messages[%d] has no content (Workers AI requires role+content)", i).isNotNull();
+            assertThat(content.isJsonNull()).as("messages[%d] content is null", i).isFalse();
+            assertThat(content.isJsonPrimitive() && content.getAsJsonPrimitive().isString())
+                    .as("messages[%d] content is not a string but %s", i, content)
+                    .isTrue();
+        }
+    }
+
+    @Test
+    void toolSpecificationsAreSentAsOpenAiTools() throws InterruptedException {
+        server.enqueue(new MockResponse()
+                .setBody(CHAT_COMPLETION_RESPONSE)
+                .setHeader("Content-Type", "application/json"));
+
+        ChatModel model = new CloudflareChatModelFactory().createChatModel(customChatModel());
+        model.chat(searchFilesRoundTrip());
+
+        RecordedRequest request = server.takeRequest(10, TimeUnit.SECONDS);
+        assertThat(request).isNotNull();
+
+        JsonObject body = bodyOf(request);
+        assertThat(body.getAsJsonArray("tools")).hasSize(1);
+        assertThat(body.getAsJsonArray("tools").get(0).getAsJsonObject()
+                .getAsJsonObject("function").get("name").getAsString()).isEqualTo("search_files");
+
+        JsonObject assistant = body.getAsJsonArray("messages").get(2).getAsJsonObject();
+        assertThat(assistant.get("role").getAsString()).isEqualTo("assistant");
+        assertThat(assistant.getAsJsonArray("tool_calls")).hasSize(1);
+        // langchain4j omits content here; the normalizer must add the empty string Workers AI wants.
+        assertThat(assistant.get("content").getAsString()).isEmpty();
+
+        JsonObject toolResult = body.getAsJsonArray("messages").get(3).getAsJsonObject();
+        assertThat(toolResult.get("role").getAsString()).isEqualTo("tool");
+        assertThat(toolResult.get("tool_call_id").getAsString()).isEqualTo("call_1");
+    }
+
+    /** The exact agent turn from the report: 'find null warns' answered with a search_files call. */
+    private static @org.jetbrains.annotations.NotNull ChatRequest searchFilesRoundTrip() {
+        ToolExecutionRequest searchFiles = ToolExecutionRequest.builder()
+                .id("call_1")
+                .name("search_files")
+                .arguments("{\"path\": \"\", \"pattern\": \"null\", \"file_pattern\": \"*.*\"}")
+                .build();
+
+        return ChatRequest.builder()
+                .messages(
+                        SystemMessage.from("You are a helpful coding assistant."),
+                        UserMessage.from("find null warns"),
+                        AiMessage.from(searchFiles),
+                        ToolExecutionResultMessage.from(searchFiles, "src/Foo.java:12: null"))
+                .toolSpecifications(ToolSpecification.builder()
+                        .name("search_files")
+                        .description("Search files for a pattern")
+                        .parameters(JsonObjectSchema.builder()
+                                .addStringProperty("path")
+                                .addStringProperty("pattern")
+                                .addStringProperty("file_pattern")
+                                .build())
+                        .build())
+                .build();
+    }
+
+    private static JsonObject bodyOf(RecordedRequest request) {
+        return JsonParser.parseString(request.getBody().readUtf8()).getAsJsonObject();
+    }
+
+    private static CustomChatModel customChatModel() {
+        CustomChatModel customChatModel = new CustomChatModel();
+        customChatModel.setModelName(CloudflareAgentToolWireTest.GPT_OSS_20B);
+        customChatModel.setTemperature(0.7);
+        customChatModel.setTopP(0.9);
+        customChatModel.setMaxTokens(256);
+        customChatModel.setMaxRetries(1);
+        customChatModel.setTimeout(10);
+        return customChatModel;
+    }
+}

--- a/src/test/java/com/devoxx/genie/chatmodel/cloud/cloudflare/CloudflareAgentToolWireTest.java
+++ b/src/test/java/com/devoxx/genie/chatmodel/cloud/cloudflare/CloudflareAgentToolWireTest.java
@@ -13,7 +13,10 @@ import dev.langchain4j.data.message.SystemMessage;
 import dev.langchain4j.data.message.ToolExecutionResultMessage;
 import dev.langchain4j.data.message.UserMessage;
 import dev.langchain4j.model.chat.ChatModel;
+import dev.langchain4j.model.chat.StreamingChatModel;
 import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import dev.langchain4j.model.chat.response.StreamingChatResponseHandler;
 import dev.langchain4j.agent.tool.ToolSpecification;
 import dev.langchain4j.model.chat.request.json.JsonObjectSchema;
 import okhttp3.mockwebserver.MockResponse;
@@ -30,6 +33,7 @@ import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 
 import java.io.IOException;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -62,6 +66,15 @@ class CloudflareAgentToolWireTest {
               ],
               "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2}
             }
+            """;
+
+    private static final String CHAT_COMPLETION_STREAM_RESPONSE = """
+            data: {"id":"chatcmpl-2","object":"chat.completion.chunk","model":"workers-ai/@cf/openai/gpt-oss-20b","choices":[{"index":0,"delta":{"role":"assistant","content":"done"}}]}
+
+            data: {"id":"chatcmpl-2","object":"chat.completion.chunk","model":"workers-ai/@cf/openai/gpt-oss-20b","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}
+
+            data: [DONE]
+
             """;
 
     private MockWebServer server;
@@ -155,6 +168,42 @@ class CloudflareAgentToolWireTest {
         JsonObject toolResult = body.getAsJsonArray("messages").get(3).getAsJsonObject();
         assertThat(toolResult.get("role").getAsString()).isEqualTo("tool");
         assertThat(toolResult.get("tool_call_id").getAsString()).isEqualTo("call_1");
+    }
+
+    @Test
+    void streamedToolRoundTripIsNormalizedToo() throws InterruptedException {
+        // Agent mode normally streams, so the SSE path needs the same reshaping as the sync one.
+        server.enqueue(new MockResponse()
+                .setBody(CHAT_COMPLETION_STREAM_RESPONSE)
+                .setHeader("Content-Type", "text/event-stream"));
+
+        StreamingChatModel model =
+                new CloudflareChatModelFactory().createStreamingChatModel(customChatModel());
+        CountDownLatch done = new CountDownLatch(1);
+        model.chat(searchFilesRoundTrip(), new StreamingChatResponseHandler() {
+            @Override
+            public void onPartialResponse(String partialResponse) {
+                // This test is about the request, not the response.
+            }
+
+            @Override
+            public void onCompleteResponse(ChatResponse completeResponse) {
+                done.countDown();
+            }
+
+            @Override
+            public void onError(Throwable error) {
+                done.countDown();
+            }
+        });
+        done.await(10, TimeUnit.SECONDS);
+
+        RecordedRequest request = server.takeRequest(10, TimeUnit.SECONDS);
+        assertThat(request).as("no request reached the mock gateway").isNotNull();
+
+        JsonObject assistant = bodyOf(request).getAsJsonArray("messages").get(2).getAsJsonObject();
+        assertThat(assistant.getAsJsonArray("tool_calls")).hasSize(1);
+        assertThat(assistant.get("content").getAsString()).isEmpty();
     }
 
     /** The exact agent turn from the report: 'find null warns' answered with a search_files call. */

--- a/src/test/java/com/devoxx/genie/chatmodel/cloud/cloudflare/CloudflareCompatRequestNormalizerTest.java
+++ b/src/test/java/com/devoxx/genie/chatmodel/cloud/cloudflare/CloudflareCompatRequestNormalizerTest.java
@@ -19,6 +19,22 @@ import static org.assertj.core.api.Assertions.assertThat;
 class CloudflareCompatRequestNormalizerTest {
 
     @Test
+    void otherGatewayProvidersAreLeftCompletelyAlone() {
+        // Only Workers AI has the strict message schema. Rewriting requests bound for openai/,
+        // anthropic/ etc. would change round trips that work today — those keep the exact bytes
+        // langchain4j produced, omitted assistant content and all.
+        String body = """
+                {"model":"openai/gpt-4o","messages":[
+                  {"role":"assistant","tool_calls":[{"id":"call_1","type":"function",
+                    "function":{"name":"search_files","arguments":"{}"}}]},
+                  {"role":"user","content":[{"type":"text","text":"and now?"}]}
+                ]}
+                """;
+
+        assertThat(CloudflareCompatRequestNormalizer.normalize(body)).isEqualTo(body);
+    }
+
+    @Test
     void assistantToolCallMessageWithoutContentGetsAnEmptyStringContent() {
         String body = """
                 {"model":"workers-ai/@cf/openai/gpt-oss-20b","messages":[
@@ -37,7 +53,8 @@ class CloudflareCompatRequestNormalizerTest {
     @Test
     void nullContentBecomesAnEmptyString() {
         String body = """
-                {"messages":[{"role":"assistant","content":null}]}
+                {"model":"workers-ai/@cf/openai/gpt-oss-20b",
+                 "messages":[{"role":"assistant","content":null}]}
                 """;
 
         JsonObject normalized = parse(CloudflareCompatRequestNormalizer.normalize(body));
@@ -48,7 +65,8 @@ class CloudflareCompatRequestNormalizerTest {
     @Test
     void textOnlyContentArrayIsFlattenedIntoAString() {
         String body = """
-                {"messages":[{"role":"user","content":[
+                {"model":"workers-ai/@cf/openai/gpt-oss-20b",
+                 "messages":[{"role":"user","content":[
                   {"type":"text","text":"find null warns"},
                   {"type":"text","text":"in src/"}
                 ]}]}
@@ -64,7 +82,8 @@ class CloudflareCompatRequestNormalizerTest {
     void contentArrayWithAnImageIsLeftUntouched() {
         // Vision models on the gateway need the parts array; flattening it would drop the image.
         String body = """
-                {"messages":[{"role":"user","content":[
+                {"model":"workers-ai/@cf/meta/llama-3.2-11b-vision-instruct",
+                 "messages":[{"role":"user","content":[
                   {"type":"text","text":"what is this?"},
                   {"type":"image_url","image_url":{"url":"data:image/png;base64,AAA"}}
                 ]}]}
@@ -103,6 +122,9 @@ class CloudflareCompatRequestNormalizerTest {
         assertThat(CloudflareCompatRequestNormalizer.normalize("not json")).isEqualTo("not json");
         assertThat(CloudflareCompatRequestNormalizer.normalize("{\"input\":\"hi\"}"))
                 .isEqualTo("{\"input\":\"hi\"}");
+        // No model to identify: leave it be rather than guess.
+        assertThat(CloudflareCompatRequestNormalizer.normalize("{\"messages\":[{\"role\":\"assistant\"}]}"))
+                .isEqualTo("{\"messages\":[{\"role\":\"assistant\"}]}");
     }
 
     private static JsonObject parse(String json) {

--- a/src/test/java/com/devoxx/genie/chatmodel/cloud/cloudflare/CloudflareCompatRequestNormalizerTest.java
+++ b/src/test/java/com/devoxx/genie/chatmodel/cloud/cloudflare/CloudflareCompatRequestNormalizerTest.java
@@ -1,0 +1,115 @@
+package com.devoxx.genie.chatmodel.cloud.cloudflare;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Issue #1256: Cloudflare's {@code /compat} endpoint hands the request to Workers AI, whose native
+ * message schema requires every message to carry a <em>string</em> {@code content}. langchain4j
+ * omits {@code content} on an assistant message that only carries {@code tool_calls} — valid
+ * OpenAI, rejected by Workers AI with
+ * {@code required properties at '/messages/N' are 'role,content'} — and sends an array of content
+ * parts for multimodal user messages, rejected with
+ * {@code Type mismatch of '/messages/N/content', 'array' not in 'string'}.
+ */
+class CloudflareCompatRequestNormalizerTest {
+
+    @Test
+    void assistantToolCallMessageWithoutContentGetsAnEmptyStringContent() {
+        String body = """
+                {"model":"workers-ai/@cf/openai/gpt-oss-20b","messages":[
+                  {"role":"assistant","tool_calls":[{"id":"call_1","type":"function",
+                    "function":{"name":"search_files","arguments":"{}"}}]}
+                ]}
+                """;
+
+        JsonObject normalized = parse(CloudflareCompatRequestNormalizer.normalize(body));
+
+        JsonObject assistant = messages(normalized).get(0).getAsJsonObject();
+        assertThat(assistant.get("content").getAsString()).isEmpty();
+        assertThat(assistant.getAsJsonArray("tool_calls")).hasSize(1);
+    }
+
+    @Test
+    void nullContentBecomesAnEmptyString() {
+        String body = """
+                {"messages":[{"role":"assistant","content":null}]}
+                """;
+
+        JsonObject normalized = parse(CloudflareCompatRequestNormalizer.normalize(body));
+
+        assertThat(messages(normalized).get(0).getAsJsonObject().get("content").getAsString()).isEmpty();
+    }
+
+    @Test
+    void textOnlyContentArrayIsFlattenedIntoAString() {
+        String body = """
+                {"messages":[{"role":"user","content":[
+                  {"type":"text","text":"find null warns"},
+                  {"type":"text","text":"in src/"}
+                ]}]}
+                """;
+
+        JsonObject normalized = parse(CloudflareCompatRequestNormalizer.normalize(body));
+
+        assertThat(messages(normalized).get(0).getAsJsonObject().get("content").getAsString())
+                .isEqualTo("find null warns\nin src/");
+    }
+
+    @Test
+    void contentArrayWithAnImageIsLeftUntouched() {
+        // Vision models on the gateway need the parts array; flattening it would drop the image.
+        String body = """
+                {"messages":[{"role":"user","content":[
+                  {"type":"text","text":"what is this?"},
+                  {"type":"image_url","image_url":{"url":"data:image/png;base64,AAA"}}
+                ]}]}
+                """;
+
+        JsonObject normalized = parse(CloudflareCompatRequestNormalizer.normalize(body));
+
+        assertThat(messages(normalized).get(0).getAsJsonObject().get("content").isJsonArray()).isTrue();
+        assertThat(messages(normalized).get(0).getAsJsonObject().getAsJsonArray("content")).hasSize(2);
+    }
+
+    @Test
+    void stringContentAndEverythingElseIsPreserved() {
+        String body = """
+                {"model":"workers-ai/@cf/openai/gpt-oss-20b","temperature":0.7,"messages":[
+                  {"role":"system","content":"you are helpful"},
+                  {"role":"user","content":"find null warns"},
+                  {"role":"tool","tool_call_id":"call_1","content":"src/Foo.java:12"}
+                ],"tools":[{"type":"function","function":{"name":"search_files"}}]}
+                """;
+
+        JsonObject normalized = parse(CloudflareCompatRequestNormalizer.normalize(body));
+
+        assertThat(normalized.get("model").getAsString()).isEqualTo("workers-ai/@cf/openai/gpt-oss-20b");
+        assertThat(normalized.get("temperature").getAsDouble()).isEqualTo(0.7);
+        assertThat(normalized.getAsJsonArray("tools")).hasSize(1);
+        assertThat(messages(normalized).get(0).getAsJsonObject().get("content").getAsString())
+                .isEqualTo("you are helpful");
+        assertThat(messages(normalized).get(2).getAsJsonObject().get("tool_call_id").getAsString())
+                .isEqualTo("call_1");
+    }
+
+    @Test
+    void nonJsonOrUnrelatedBodiesAreReturnedUnchanged() {
+        assertThat(CloudflareCompatRequestNormalizer.normalize(null)).isNull();
+        assertThat(CloudflareCompatRequestNormalizer.normalize("not json")).isEqualTo("not json");
+        assertThat(CloudflareCompatRequestNormalizer.normalize("{\"input\":\"hi\"}"))
+                .isEqualTo("{\"input\":\"hi\"}");
+    }
+
+    private static JsonObject parse(String json) {
+        return JsonParser.parseString(json).getAsJsonObject();
+    }
+
+    private static JsonArray messages(JsonObject body) {
+        return body.getAsJsonArray("messages");
+    }
+}

--- a/src/test/java/com/devoxx/genie/service/prompt/error/ProviderErrorTranslatorTest.java
+++ b/src/test/java/com/devoxx/genie/service/prompt/error/ProviderErrorTranslatorTest.java
@@ -140,6 +140,58 @@ class ProviderErrorTranslatorTest {
                         .doesNotContain("no provider prefix"));
     }
 
+    /**
+     * The body from issue #1256, verbatim (abridged in the middle only where the same
+     * "Type mismatch" line repeats per message): agent mode replaying a tool call to
+     * {@code workers-ai/@cf/openai/gpt-oss-20b}. Note {@code "name":"AiError"} — a different
+     * envelope from the {@code AiGatewayError} of #1254, which is why it used to slip through
+     * untranslated and dump this whole blob into the chat.
+     */
+    private static final String CLOUDFLARE_5006_BAD_INPUT_BODY =
+            "{\"name\":\"AiError\",\"internalCode\":5006,\"httpCode\":400,"
+            + "\"message\":\"AiError: Bad input: Error: oneOf at '/' not met, 0 matches: "
+            + "required properties at '/' are 'prompt', "
+            + "Type mismatch of '/messages/0/content', 'array' not in 'string', "
+            + "Type mismatch of '/messages/1/content', 'array' not in 'string', "
+            + "required properties at '/messages/11' are 'role,content', "
+            + "oneOf at '/' not met, 0 matches, required properties at '/' are 'input', "
+            + "required properties at '/' are 'requests' (56c5fa5f-0ff6-4968-9800-04cd0445838a)\","
+            + "\"description\":\"Error: oneOf at '/' not met, 0 matches\","
+            + "\"requestId\":\"56c5fa5f-0ff6-4968-9800-04cd0445838a\"}";
+
+    @Test
+    void translatesWorkersAiBadInputSchemaErrorIntoAgentModeGuidance() {
+        // Issue #1256: the raw schema dump reached the chat because the envelope says 'AiError'.
+        Throwable error = new RuntimeException("Provider unavailable: " + CLOUDFLARE_5006_BAD_INPUT_BODY);
+
+        Optional<String> result =
+                ProviderErrorTranslator.translate(error, "workers-ai/@cf/openai/gpt-oss-20b");
+
+        assertThat(result).isPresent();
+        assertThat(result.get())
+                .contains("5006")
+                .contains("Bad input")
+                .contains("workers-ai/@cf/openai/gpt-oss-20b")
+                .contains("tool")
+                .contains("Agent mode")
+                // None of the raw payload — neither JSON nor the schema dump — may leak.
+                .doesNotContain("{")
+                .doesNotContain("httpCode")
+                .doesNotContain("oneOf")
+                .doesNotContain("Type mismatch");
+    }
+
+    @Test
+    void findsWorkersAiBadInputBodyDeepInTheCauseChain() {
+        // The plugin wraps it twice: ExecutionException -> CompletionException -> ModelException.
+        Throwable root = new RuntimeException("status code: 400; body: " + CLOUDFLARE_5006_BAD_INPUT_BODY);
+        Throwable wrapped = new IllegalStateException("Error occurred while processing chat message", root);
+
+        assertThat(ProviderErrorTranslator.translate(wrapped, "workers-ai/@cf/openai/gpt-oss-20b"))
+                .get()
+                .satisfies(m -> assertThat(m).contains("5006").doesNotContain("Type mismatch"));
+    }
+
     @Test
     void returnsEmptyForNonCloudflareErrors() {
         assertThat(ProviderErrorTranslator.translate(


### PR DESCRIPTION
## Summary

- **Agent mode is broken on Workers AI models.** Workers AI's native message schema requires every message to carry a *string* `content`. langchain4j builds the assistant message as `AssistantMessage.content(aiMessage.text())`, and `text()` is `null` when the model returned only tool calls — so Jackson drops the field. Valid OpenAI, but it is exactly the reported `required properties at '/messages/11' are 'role,content'`, and it is why the first round trip succeeds and the one replaying the tool call 400s. `CloudflareCompatRequestNormalizer` now fills in an empty string and flattens text-only content arrays (arrays holding images are left alone so vision models keep working), applied through `CloudflareCompatHttpClient` — `.httpClientBuilder()` is the only seam langchain4j offers for touching the serialised request. Scoped to `workers-ai/*` model ids, so other providers behind the same gateway are handed on byte for byte.
- **The error was unreadable.** `ProviderErrorTranslator` only recognised the `AiGatewayError` envelope; issue #1256 carries an `AiError` one, so the raw JSON blob — including the full schema validation dump — landed in the chat. `internalCode` 5006 now renders as short agent-mode guidance instead.
- **Necessary but possibly not sufficient.** The same error also reports `'array' not in 'string'` starting at `/messages/0/content` — the system message, whose content is typed `String` client-side and cannot be serialised as an array. Those arrays are manufactured inside Cloudflare's compat→Workers AI translation, which nothing here can prevent. If the 400 survives this fix, that is the reason and it needs a Cloudflare-side report; the reporter has been asked to retest.

Note for review: the translator gate is substring-based (`AiError` is a fairly generic token). It is a Cloudflare envelope name so real-world collision risk is low — worth tightening if it ever false-positives on another provider.

## Test plan

- [x] `CloudflareAgentToolWireTest` drives the exact reported turn (`find null warns` → `search_files`) through the real factory into a mock gateway and asserts the wire body — it went red on `messages[2] has no content` before the fix
- [x] Streaming path covered too (agent mode streams); verified by mutation that the test fails if the SSE `execute` overload skips the normalizer
- [x] `CloudflareCompatRequestNormalizerTest` — 7 cases: missing/null content, text-only flattening, image arrays untouched, non-Workers-AI models byte-identical, unparseable bodies passed through
- [x] `ProviderErrorTranslatorTest` — 2 new cases for the 5006 body (verbatim from the issue, and buried in a cause chain); all pre-existing 2005/2008 cases still green
- [x] Full `./gradlew test` suite green
- [ ] Reporter retests against a build with this fix and pastes any surviving error

🤖 Generated with [Claude Code](https://claude.com/claude-code)