### PR TITLE
docs: success stories page, blog call for stories, footer and README links

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,12 @@ We also support RAG-based prompt context based on your vectorized project files,
 [<img width="200" alt="Marketplace" src="https://github.com/devoxx/DevoxxGenieIDEAPlugin/assets/179457/1c24d692-37ea-445d-8015-2c25f63e2f90">](https://plugins.jetbrains.com/plugin/24169-devoxxgenie)
 114K+ Active Users
 
+### 💬 Using DevoxxGenie at work?
+
+**[Share your success story →](https://genie.devoxx.com/success-stories)** Tell us what you built, what got
+faster, and which models you rely on. Stories may be featured on the site, the blog or the newsletter (only with
+your consent).
+
 ## 📚 Documentation
 
 **[📖 Visit our comprehensive documentation at genie.devoxx.com](https://genie.devoxx.com)**

--- a/docusaurus/docusaurus.config.js
+++ b/docusaurus/docusaurus.config.js
@@ -236,6 +236,10 @@ const config = {
             title: 'Community',
             items: [
               {
+                label: 'Share your Success Story',
+                to: '/success-stories',
+              },
+              {
                 label: 'X (Twitter)',
                 href: 'https://x.com/DevoxxGenie',
               },

--- a/docusaurus/src/pages/success-stories.js
+++ b/docusaurus/src/pages/success-stories.js
@@ -1,0 +1,63 @@
+import React from 'react';
+import Layout from '@theme/Layout';
+import Link from '@docusaurus/Link';
+
+// The forms.gle short link resolves to this; using the long form directly so the
+// iframe embed works (embedded=true is only honoured on the docs.google.com URL).
+const FORM_ID = '1FAIpQLSejzxYodZDK-hb2JupMRaL4-OaKSt9t4HAkjaGjJq0dLRK_uw';
+const FORM_URL = `https://docs.google.com/forms/d/e/${FORM_ID}/viewform`;
+const FORM_EMBED_URL = `${FORM_URL}?embedded=true`;
+
+export default function SuccessStories() {
+  return (
+    <Layout
+      title="Share your DevoxxGenie success story"
+      description="Tell us how DevoxxGenie helps you and your team ship code. Your story may be featured on the site, the blog or the newsletter.">
+      <main>
+        <div className="container home-section">
+          <div className="row">
+            <div className="col col--8 col--offset-2 text--center">
+              <h1>Share your DevoxxGenie success story</h1>
+              <p style={{fontSize: '1.15rem'}}>
+                DevoxxGenie is used by developers and teams all over the world. We would
+                love to hear what you are building with it: what you automated, what got
+                faster, and which models and features you rely on.
+              </p>
+              <p>
+                Stories may be featured on this site, on the{' '}
+                <Link to="/blog">blog</Link> or in the{' '}
+                <Link to="/newsletter">newsletter</Link>. Nothing is published without
+                your consent, and you decide how you are credited.
+              </p>
+              <p>
+                <Link
+                  className="button button--primary button--lg"
+                  href={FORM_URL}
+                  target="_blank"
+                  rel="noopener noreferrer">
+                  Open the form in a new tab
+                </Link>
+              </p>
+            </div>
+          </div>
+
+          <div className="row">
+            <div className="col col--8 col--offset-2">
+              <iframe
+                title="DevoxxGenie success story form"
+                src={FORM_EMBED_URL}
+                width="100%"
+                height="1200"
+                frameBorder="0"
+                marginHeight="0"
+                marginWidth="0"
+                style={{border: 0, maxWidth: '100%'}}>
+                Loading…
+              </iframe>
+            </div>
+          </div>
+        </div>
+      </main>
+    </Layout>
+  );
+}


### PR DESCRIPTION
## Summary
- New `/success-stories` page on genie.devoxx.com that embeds the DevoxxGenie user feedback Google Form inline, with an "open in a new tab" fallback. A single page means every placement uses one stable URL and swapping the form later is a one-file change.
- New blog post (`/blog/share-your-success-story`) announcing the call for stories. The blog feeds the RSS feed, the newsletter and social in one publish, so it is the highest-reach one-off channel.
- Linked from the site footer's Community column (appears on every page) and from the README, directly under the marketplace badge and active-user count.
- The `forms.gle` short link is expanded to its `docs.google.com` form URL, since `?embedded=true` is only honoured on the long form.

## Test plan
- [x] `npm run build` passes; `onBrokenLinks: 'throw'` confirms the new footer link and every internal link in the blog post resolve
- [x] Built `success-stories.html` contains the embedded form
- [x] Page verified in a browser: form renders inside the site layout, button opens the form in a new tab
- [ ] Confirm the form title ("DevoxxGenie Plugin User Feedback") reads well against the page's success-story framing, or retitle the form
- [ ] Review the blog post copy before merge (publish date is 2026-08-10)

🤖 Generated with [Claude Code](https://claude.com/claude-code)