### PR TITLE
docs(blog): add a post calling for user success stories

### DIFF
--- a/docusaurus/blog/2026-08-10-share-your-success-story.md
+++ b/docusaurus/blog/2026-08-10-share-your-success-story.md
@@ -1,0 +1,54 @@
+---
+slug: share-your-success-story
+title: "Tell Us What You Built: Share Your DevoxxGenie Success Story"
+authors: [stephanj]
+tags: [community, success stories, feedback, roadmap, open source, intellij idea]
+date: 2026-08-10
+description: "The dashboards tell us how many people use DevoxxGenie and which models they pick, but not what they actually ship with it. We built a page to collect your stories."
+keywords: [devoxxgenie, success story, user feedback, community, testimonials, intellij plugin, ai code assistant, open source]
+image: /img/devoxxgenie-social-card.jpg
+---
+
+# Tell Us What You Built: Share Your DevoxxGenie Success Story
+
+We have a lot of numbers. The [growth curve](/blog/devoxxgenie-growth-milestone) keeps climbing, and the [analytics deep-dive](/blog/devoxxgenie-plugin-analytics) told us which providers and features people actually reach for. What none of that tells us is the interesting part: **what you are building with DevoxxGenie, and what it changed about your day.**
+
+So we made a page for it: **[genie.devoxx.com/success-stories](/success-stories)**.
+
+<!-- truncate -->
+
+## Why we are asking
+
+Analytics are great at *what* and terrible at *why*. We can see that most usage runs on local models. We cannot see that you moved to a local model because your employer will not let code leave the building, or that a 40 minute review ritual turned into a 5 minute one, or that the feature you rely on most is the one we almost cut.
+
+That gap matters for three reasons:
+
+- **It sets the roadmap.** Every serious feature in the plugin, from agent mode to spec-driven development, exists because someone described a real workflow that did not fit. A dashboard has never once suggested a feature.
+- **It helps other developers.** "Should I put an AI assistant in my IDE, and can it run on my own hardware?" is a question a lot of teams are asking right now. A concrete story from someone with the same constraints answers it far better than a feature list does.
+- **It keeps an open-source project going.** DevoxxGenie is free and [open source](https://github.com/devoxx/DevoxxGenieIDEAPlugin). Knowing the thing is genuinely useful to people is most of the fuel.
+
+## What makes a good story
+
+Do not overthink it. A few honest paragraphs beat a polished case study. The things we are most curious about:
+
+- **What you build.** Language, stack, team size, the kind of codebase (greenfield, legacy, monorepo, embedded, whatever it is).
+- **What you actually use it for.** Reviews, refactoring, tests, docs, understanding unfamiliar code, batch task execution with the [Agent Loop](/docs/features/sdd-agent-loop)?
+- **Local or cloud, and why.** Privacy rules, cost, latency, offline work, or simply because a model on your own machine turned out to be good enough.
+- **What changed.** This is the bit people remember. Anything you can put a number on is gold, but "I stopped dreading dependency upgrades" is a perfectly good outcome too.
+- **What still annoys you.** Genuinely. The critical stories are the useful ones, and nothing gets fixed that we never hear about.
+
+## Where stories end up
+
+With your permission, stories may show up on this site, in a blog post, or in the [newsletter](/newsletter). You decide how you are credited: full name and company, first name only, or completely anonymous. Nothing gets published without your explicit consent, and if you would rather your story stay entirely internal to the project, that option is on the form too.
+
+## Not a success story? Still send it
+
+The form is the general DevoxxGenie feedback form, so it works just as well for "here is what is broken" and "here is what I wish it did". Bug reports are still best filed as [GitHub issues](https://github.com/devoxx/DevoxxGenieIDEAPlugin/issues), where they can be tracked and fixed, but for the fuzzier stuff (workflow friction, missing features, things that feel wrong), the form is the right place.
+
+## Take five minutes
+
+**[Share your story here](/success-stories)**
+
+It is a handful of questions and you can skip anything you would rather not answer. If DevoxxGenie has saved you time, taught you something, or quietly become part of how you work, we would really like to hear about it.
+
+Thank you. 🙏


### PR DESCRIPTION
## Summary
- Adds `/blog/share-your-success-story`, announcing the `/success-stories` page shipped in #1265.
- Explains why we are asking (analytics show what people use, never why), what makes a useful story, how consent and credit work, and that the same form takes critical feedback.

Split out of #1265, which was merged before this commit was pushed.

## Test plan
- [x] `npm run build` passes; `onBrokenLinks: 'throw'` confirms every internal link in the post resolves
- [ ] Review the copy before merge (publish date is 2026-08-10)

🤖 Generated with [Claude Code](https://claude.com/claude-code)