### PR TITLE
fix(ui): guard code highlighting against malformed ranges

### DIFF
--- a/backlog/completed/task-258 - Fix-crash-rendering-code-blocks-whose-text-contains-an-unmatched-comment-terminator.md
+++ b/backlog/completed/task-258 - Fix-crash-rendering-code-blocks-whose-text-contains-an-unmatched-comment-terminator.md
@@ -1,0 +1,75 @@
+---
+id: TASK-258
+title: >-
+  Fix crash rendering code blocks whose text contains an unmatched comment
+  terminator
+status: Done
+assignee: []
+created_date: '2026-08-25 16:19'
+updated_date: '2026-08-25 16:39'
+labels:
+  - bug
+  - ui
+  - compose
+dependencies: []
+references:
+  - src/main/kotlin/com/devoxx/genie/ui/compose/components/AiBubble.kt
+  - src/main/kotlin/com/devoxx/genie/ui/compose/components/UserBubble.kt
+  - build.gradle.kts
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+The Compose conversation panel dies with `IllegalArgumentException: Reversed range is not supported` whenever an assistant or user message contains a fenced code block whose text has a `*/` occurring before the first `/*`. This happens routinely when an LLM streams a snippet that starts mid-Javadoc or shows a diff hunk containing the tail of a comment block.
+
+Root cause: the syntax highlighter (`dev.snipme:highlights:1.0.0`, `MultilineCommentLocator.locate`) pairs the Nth `/*` index with the Nth `*/` index positionally, without checking that the end follows the start. For input such as `*/ /* */` it emits a highlight location with `end < start`. The markdown renderer (`com.mikepenz:multiplatform-markdown-renderer-code:0.38.1`, `MarkdownHighlightedCode.kt:166`) passes that location straight to `AnnotatedString.Builder.addStyle`, which rejects a reversed range. The exception is thrown from a `produceState` coroutine on `Dispatchers.Default` and goes unhandled, tearing down the Compose frame clock — so the entire chat panel stops rendering, not just the offending code block.
+
+Both `AiBubble.kt` and `UserBubble.kt` render code through the affected library composables, so both are impacted.
+
+Upgrading the renderer or highlighter is out of scope: the build pins these versions to the IntelliJ 253 Compose/Skiko toolchain for documented ABI and classloader reasons.
+
+**User value:** a malformed or partial code snippet in a reply degrades to unstyled code instead of killing the conversation view.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 A code block whose text contains `*/` before the first `/*` renders without throwing, in both the AI bubble and the user bubble
+- [x] #2 Highlight ranges that fall outside the code text, or whose end does not follow their start, are discarded rather than applied
+- [x] #3 An unexpected failure anywhere in the syntax-highlighting pass degrades that code block to unstyled text and leaves the rest of the conversation panel rendering
+- [x] #4 A unit test pins the upstream highlighter behaviour that triggers the crash, so a future dependency bump that fixes it is detected
+- [x] #5 A unit test covers the reversed, out-of-bounds, and well-formed highlight cases against the code path used by the bubbles
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Added `SafeHighlightedCode.kt` in `com.devoxx.genie.ui.compose.components`: a local reimplementation of the renderer's `MarkdownHighlightedCodeFence` / `MarkdownHighlightedCodeBlock` built on the library's public `MarkdownCodeFence`, `MarkdownCodeBlock`, `MarkdownCodeBackground` and `MarkdownBasicText`, so no library internals are copied beyond the composition shape.
+
+Two guards:
+- `buildSafeHighlightedAnnotatedString(code, highlights)` clamps each location into `[0, code.length]` and drops anything left with `end <= start`, which covers the reversed, empty and fully out-of-range cases.
+- An overload taking a highlights provider wraps the whole highlighting pass, falling back to unstyled `AnnotatedString(code)` on any `Throwable`. `CancellationException` is rethrown so `produceState` disposal still works.
+
+`AiBubble.kt` and `UserBubble.kt` now call the safe composables; no unguarded use of the library composables remains in `src/main`.
+
+Verified with `./gradlew test`: 8 new tests in `SafeHighlightedCodeTest` pass, including a characterization test pinning that upstream emits `end < start`, and one asserting the unguarded code path still throws `IllegalArgumentException: Reversed range is not supported` for the same input. Full suite green.
+
+Branch: `fix/task-258-reversed-highlight-range`, cut from `master` (this repo has no `develop` branch).
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Code blocks whose text contains a multiline-comment terminator before the first opener no longer crash the conversation panel.
+
+`dev.snipme:highlights` pairs the Nth `/*` index with the Nth `*/` index positionally, so such a snippet — an LLM streaming a Javadoc excerpt or a diff hunk — yields a highlight location whose end precedes its start. The renderer passed it straight to `AnnotatedString.Builder.addStyle`, which threw `IllegalArgumentException: Reversed range is not supported` from a `produceState` coroutine on `Dispatchers.Default` where nothing caught it, tearing down the Compose frame clock and stopping the entire panel from rendering.
+
+New `SafeHighlightedCode.kt` reimplements `MarkdownHighlightedCodeFence` / `MarkdownHighlightedCodeBlock` on top of the renderer's public `MarkdownCodeFence`, `MarkdownCodeBlock`, `MarkdownCodeBackground` and `MarkdownBasicText`, adding two guards: highlight locations are clamped into `[0, code.length]` and dropped when `end <= start`, and the whole highlighting pass falls back to unstyled text on any `Throwable` (rethrowing `CancellationException` so `produceState` disposal still works). `AiBubble` and `UserBubble` now use the safe composables; no unguarded use of the library composables remains.
+
+No dependency upgrade: the build pins the renderer and highlighter to the IntelliJ 253 Compose/Skiko toolchain for documented ABI and classloader reasons.
+
+Verified with `./gradlew test` on the rebased branch: 3646 tests, 0 failures. `SafeHighlightedCodeTest` adds 8 tests, including a characterization test pinning the upstream defect (it fails if a future bump fixes it) and one asserting the unguarded code path still throws the reported exception for the same input.
+
+Known follow-up, out of scope here: `UserBubble` shares one mutable `Highlights.Builder` across every code block in a message, and `.code()` mutates it, so concurrent highlighting can compute highlights against the wrong block's text. The new guard downgrades that from a crash to at-worst mis-coloring.
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/backlog/completed/task-258 - Fix-crash-rendering-code-blocks-whose-text-contains-an-unmatched-comment-terminator.md
+++ b/backlog/completed/task-258 - Fix-crash-rendering-code-blocks-whose-text-contains-an-unmatched-comment-terminator.md
@@ -72,4 +72,5 @@ No dependency upgrade: the build pins the renderer and highlighter to the Intell
 Verified with `./gradlew test` on the rebased branch: 3646 tests, 0 failures. `SafeHighlightedCodeTest` adds 8 tests, including a characterization test pinning the upstream defect (it fails if a future bump fixes it) and one asserting the unguarded code path still throws the reported exception for the same input.
 
 Known follow-up, out of scope here: `UserBubble` shares one mutable `Highlights.Builder` across every code block in a message, and `.code()` mutates it, so concurrent highlighting can compute highlights against the wrong block's text. The new guard downgrades that from a crash to at-worst mis-coloring.
+PR: https://github.com/devoxx/DevoxxGenieIDEAPlugin/pull/1277
 <!-- SECTION:FINAL_SUMMARY:END -->

--- a/src/main/kotlin/com/devoxx/genie/ui/compose/components/AiBubble.kt
+++ b/src/main/kotlin/com/devoxx/genie/ui/compose/components/AiBubble.kt
@@ -30,8 +30,6 @@ import com.devoxx.genie.ui.compose.theme.*
 import com.mikepenz.markdown.compose.Markdown
 import com.mikepenz.markdown.compose.components.MarkdownComponent
 import com.mikepenz.markdown.compose.components.markdownComponents
-import com.mikepenz.markdown.compose.elements.MarkdownHighlightedCodeBlock
-import com.mikepenz.markdown.compose.elements.MarkdownHighlightedCodeFence
 import com.mikepenz.markdown.model.DefaultMarkdownColors
 import com.mikepenz.markdown.model.DefaultMarkdownTypography
 import dev.snipme.highlights.Highlights
@@ -149,7 +147,7 @@ private fun createHighlightsBuilder(isDark: Boolean): Highlights.Builder =
 private fun codeFenceWithCopy(isDark: Boolean): MarkdownComponent = { model ->
     val codeText = extractCodeText(model.content, model.node)
     Box(modifier = Modifier.fillMaxWidth()) {
-        MarkdownHighlightedCodeFence(model.content, model.node, highlightsBuilder = createHighlightsBuilder(isDark))
+        SafeMarkdownHighlightedCodeFence(model.content, model.node, highlightsBuilder = createHighlightsBuilder(isDark))
         CopyButton(
             textToCopy = codeText,
             modifier = Modifier.align(Alignment.TopEnd).padding(4.dp),
@@ -164,7 +162,7 @@ private fun codeFenceWithCopy(isDark: Boolean): MarkdownComponent = { model ->
 private fun codeBlockWithCopy(isDark: Boolean): MarkdownComponent = { model ->
     val codeText = extractCodeText(model.content, model.node)
     Box(modifier = Modifier.fillMaxWidth()) {
-        MarkdownHighlightedCodeBlock(model.content, model.node, highlightsBuilder = createHighlightsBuilder(isDark))
+        SafeMarkdownHighlightedCodeBlock(model.content, model.node, highlightsBuilder = createHighlightsBuilder(isDark))
         CopyButton(
             textToCopy = codeText,
             modifier = Modifier.align(Alignment.TopEnd).padding(4.dp),

--- a/src/main/kotlin/com/devoxx/genie/ui/compose/components/SafeHighlightedCode.kt
+++ b/src/main/kotlin/com/devoxx/genie/ui/compose/components/SafeHighlightedCode.kt
@@ -1,0 +1,171 @@
+package com.devoxx.genie.ui.compose.components
+
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.State
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.produceState
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.mikepenz.markdown.compose.LocalMarkdownColors
+import com.mikepenz.markdown.compose.LocalMarkdownDimens
+import com.mikepenz.markdown.compose.LocalMarkdownPadding
+import com.mikepenz.markdown.compose.LocalMarkdownTypography
+import com.mikepenz.markdown.compose.elements.MarkdownCodeBackground
+import com.mikepenz.markdown.compose.elements.MarkdownCodeBlock
+import com.mikepenz.markdown.compose.elements.MarkdownCodeFence
+import com.mikepenz.markdown.compose.elements.material.MarkdownBasicText
+import dev.snipme.highlights.Highlights
+import dev.snipme.highlights.model.BoldHighlight
+import dev.snipme.highlights.model.CodeHighlight
+import dev.snipme.highlights.model.ColorHighlight
+import dev.snipme.highlights.model.SyntaxLanguage
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import org.intellij.markdown.ast.ASTNode
+
+/**
+ * Syntax-highlighted code blocks that survive malformed highlight ranges.
+ *
+ * This mirrors `MarkdownHighlightedCodeFence` / `MarkdownHighlightedCodeBlock` from
+ * multiplatform-markdown-renderer, with one difference: highlight locations are validated
+ * before they reach [AnnotatedString.Builder.addStyle].
+ *
+ * The upstream highlighter (`dev.snipme:highlights`) pairs the Nth multiline-comment opener
+ * with the Nth terminator positionally, so a snippet containing a terminator before the first
+ * opener — an LLM streaming a Javadoc excerpt or a diff hunk, routinely — yields a location
+ * whose end precedes its start. `addStyle` rejects that with "Reversed range is not supported",
+ * thrown from a background coroutine where nothing catches it, which tears down the Compose
+ * frame clock and stops the whole conversation panel from rendering (TASK-258).
+ */
+
+/**
+ * Applies [highlights] to [code], discarding any location that does not describe a non-empty
+ * range within the text. Out-of-bounds ends are clamped; reversed, empty and fully out-of-range
+ * locations are dropped.
+ */
+internal fun buildSafeHighlightedAnnotatedString(
+    code: String,
+    highlights: List<CodeHighlight>,
+): AnnotatedString = buildAnnotatedString {
+    append(code)
+    highlights.forEach { highlight ->
+        val start = highlight.location.start.coerceIn(0, code.length)
+        val end = highlight.location.end.coerceIn(0, code.length)
+        if (end <= start) return@forEach
+
+        val style = when (highlight) {
+            is ColorHighlight -> SpanStyle(color = Color(highlight.rgb).copy(alpha = 1f))
+            is BoldHighlight -> SpanStyle(fontWeight = FontWeight.Bold)
+        }
+        addStyle(style = style, start = start, end = end)
+    }
+}
+
+/**
+ * Runs [highlightsProvider] and applies its result to [code], falling back to unstyled code if
+ * the highlighter itself fails. A future defect in a locator then costs this one code block its
+ * colours instead of the entire panel.
+ */
+internal fun buildSafeHighlightedAnnotatedString(
+    code: String,
+    highlightsProvider: () -> List<CodeHighlight>,
+): AnnotatedString = try {
+    buildSafeHighlightedAnnotatedString(code, highlightsProvider())
+} catch (cancellation: CancellationException) {
+    throw cancellation
+} catch (throwable: Throwable) {
+    AnnotatedString(code)
+}
+
+@Composable
+fun SafeMarkdownHighlightedCodeFence(
+    content: String,
+    node: ASTNode,
+    style: TextStyle = LocalMarkdownTypography.current.code,
+    highlightsBuilder: Highlights.Builder,
+    showHeader: Boolean = false,
+) {
+    MarkdownCodeFence(content, node, style) { code, language, codeStyle ->
+        SafeMarkdownHighlightedCode(code, language, codeStyle, highlightsBuilder, showHeader)
+    }
+}
+
+@Composable
+fun SafeMarkdownHighlightedCodeBlock(
+    content: String,
+    node: ASTNode,
+    style: TextStyle = LocalMarkdownTypography.current.code,
+    highlightsBuilder: Highlights.Builder,
+    showHeader: Boolean = false,
+) {
+    MarkdownCodeBlock(content, node, style) { code, language, codeStyle ->
+        SafeMarkdownHighlightedCode(code, language, codeStyle, highlightsBuilder, showHeader)
+    }
+}
+
+@Composable
+private fun SafeMarkdownHighlightedCode(
+    code: String,
+    language: String?,
+    style: TextStyle,
+    highlightsBuilder: Highlights.Builder,
+    showHeader: Boolean,
+) {
+    val backgroundCodeColor = LocalMarkdownColors.current.codeBackground
+    val codeBackgroundCornerSize = LocalMarkdownDimens.current.codeBackgroundCornerSize
+    val codeBlockPadding = LocalMarkdownPadding.current.codeBlock
+    val codeHighlights: AnnotatedString by produceSafeHighlightsState(code, language, highlightsBuilder)
+
+    MarkdownCodeBackground(
+        color = backgroundCodeColor,
+        shape = RoundedCornerShape(codeBackgroundCornerSize),
+        modifier = Modifier.fillMaxWidth().padding(vertical = 8.dp),
+        showHeader = showHeader,
+        language = language,
+        code = code,
+    ) {
+        MarkdownBasicText(
+            text = codeHighlights,
+            style = style,
+            modifier = Modifier
+                .horizontalScroll(rememberScrollState())
+                .padding(codeBlockPadding),
+        )
+    }
+}
+
+@Composable
+private fun produceSafeHighlightsState(
+    code: String,
+    language: String?,
+    highlightsBuilder: Highlights.Builder,
+): State<AnnotatedString> = produceState(
+    initialValue = AnnotatedString(text = code),
+    key1 = code,
+) {
+    val syntaxLanguage = language?.let { SyntaxLanguage.getByName(it) }
+    val job = launch(Dispatchers.Default) {
+        value = buildSafeHighlightedAnnotatedString(code) {
+            highlightsBuilder
+                .code(code)
+                .let { if (syntaxLanguage != null) it.language(syntaxLanguage) else it }
+                .build()
+                .getHighlights()
+        }
+    }
+    awaitDispose {
+        job.cancel()
+    }
+}

--- a/src/main/kotlin/com/devoxx/genie/ui/compose/components/UserBubble.kt
+++ b/src/main/kotlin/com/devoxx/genie/ui/compose/components/UserBubble.kt
@@ -19,8 +19,6 @@ import com.devoxx.genie.ui.compose.theme.DevoxxGenieThemeAccessor
 import com.devoxx.genie.ui.compose.theme.DevoxxOrange
 import com.mikepenz.markdown.compose.Markdown
 import com.mikepenz.markdown.compose.components.markdownComponents
-import com.mikepenz.markdown.compose.elements.MarkdownHighlightedCodeBlock
-import com.mikepenz.markdown.compose.elements.MarkdownHighlightedCodeFence
 import com.mikepenz.markdown.model.DefaultMarkdownColors
 import com.mikepenz.markdown.model.DefaultMarkdownTypography
 import dev.snipme.highlights.Highlights
@@ -79,13 +77,13 @@ fun UserBubble(
 
     val codeFence: com.mikepenz.markdown.compose.components.MarkdownComponent = { model ->
         Box(modifier = Modifier.fillMaxWidth()) {
-            MarkdownHighlightedCodeFence(model.content, model.node, highlightsBuilder = highlightsBuilder)
+            SafeMarkdownHighlightedCodeFence(model.content, model.node, highlightsBuilder = highlightsBuilder)
         }
     }
 
     val codeBlock: com.mikepenz.markdown.compose.components.MarkdownComponent = { model ->
         Box(modifier = Modifier.fillMaxWidth()) {
-            MarkdownHighlightedCodeBlock(model.content, model.node, highlightsBuilder = highlightsBuilder)
+            SafeMarkdownHighlightedCodeBlock(model.content, model.node, highlightsBuilder = highlightsBuilder)
         }
     }
 

--- a/src/test/kotlin/com/devoxx/genie/ui/compose/components/SafeHighlightedCodeTest.kt
+++ b/src/test/kotlin/com/devoxx/genie/ui/compose/components/SafeHighlightedCodeTest.kt
@@ -1,0 +1,152 @@
+package com.devoxx.genie.ui.compose.components
+
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import dev.snipme.highlights.Highlights
+import dev.snipme.highlights.model.BoldHighlight
+import dev.snipme.highlights.model.ColorHighlight
+import dev.snipme.highlights.model.PhraseLocation
+import dev.snipme.highlights.model.SyntaxLanguage
+import dev.snipme.highlights.model.SyntaxThemes
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatCode
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+
+/**
+ * Reproduces TASK-258: the conversation panel dies with
+ * `IllegalArgumentException: Reversed range is not supported` when a code block
+ * contains a multiline-comment terminator before the first comment opener.
+ *
+ * Upstream `dev.snipme:highlights` pairs the Nth comment-start index with the Nth
+ * comment-end index positionally, so an unmatched terminator yields a highlight
+ * whose end precedes its start. The markdown renderer hands that straight to
+ * `AnnotatedString.Builder.addStyle`, which rejects it — from a background
+ * coroutine, taking the whole Compose frame clock with it.
+ */
+class SafeHighlightedCodeTest {
+
+    /** A snippet that starts mid-comment, as an LLM streaming a Javadoc excerpt or a diff hunk produces. */
+    private val codeWithUnmatchedCommentTerminator = """
+        */
+        public void doWork() { /* inline */ }
+    """.trimIndent()
+
+    private fun highlightsFor(code: String) =
+        Highlights.Builder()
+            .theme(SyntaxThemes.default(darkMode = true))
+            .code(code)
+            .language(SyntaxLanguage.JAVA)
+            .build()
+            .getHighlights()
+
+    /**
+     * Characterization test pinning the upstream defect. If a future dependency bump
+     * fixes `MultilineCommentLocator`, this test fails and the sanitising wrapper can
+     * be reconsidered.
+     */
+    @Test
+    fun `upstream highlighter emits a reversed range for an unmatched comment terminator`() {
+        val highlights = highlightsFor(codeWithUnmatchedCommentTerminator)
+
+        assertThat(highlights)
+            .describedAs("expected at least one highlight with end < start")
+            .anyMatch { it.location.end < it.location.start }
+    }
+
+    /** The exact crash: what the renderer does with those highlights today. */
+    @Test
+    fun `applying upstream highlights unguarded throws the reported exception`() {
+        val code = codeWithUnmatchedCommentTerminator
+        val highlights = highlightsFor(code)
+
+        assertThatThrownBy {
+            buildAnnotatedString {
+                append(code)
+                highlights.forEach {
+                    addStyle(SpanStyle(), it.location.start, it.location.end)
+                }
+            }
+        }
+            .isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("Reversed range is not supported")
+    }
+
+    @Test
+    fun `safe builder renders code containing an unmatched comment terminator`() {
+        val code = codeWithUnmatchedCommentTerminator
+
+        assertThatCode {
+            val result = buildSafeHighlightedAnnotatedString(code, highlightsFor(code))
+            assertThat(result.text).isEqualTo(code)
+        }.doesNotThrowAnyException()
+    }
+
+    @Test
+    fun `safe builder drops reversed ranges`() {
+        val code = "abcdef"
+
+        val result = buildSafeHighlightedAnnotatedString(
+            code,
+            listOf(ColorHighlight(PhraseLocation(start = 4, end = 2), rgb = 0xFF0000)),
+        )
+
+        assertThat(result.text).isEqualTo(code)
+        assertThat(result.spanStyles).isEmpty()
+    }
+
+    @Test
+    fun `safe builder drops ranges that fall outside the code`() {
+        val code = "abcdef"
+
+        val result = buildSafeHighlightedAnnotatedString(
+            code,
+            listOf(
+                ColorHighlight(PhraseLocation(start = 10, end = 20), rgb = 0xFF0000),
+                BoldHighlight(PhraseLocation(start = -3, end = -1)),
+            ),
+        )
+
+        assertThat(result.spanStyles).isEmpty()
+    }
+
+    @Test
+    fun `safe builder clamps a range that runs past the end of the code`() {
+        val code = "abcdef"
+
+        val result = buildSafeHighlightedAnnotatedString(
+            code,
+            listOf(ColorHighlight(PhraseLocation(start = 4, end = 99), rgb = 0xFF0000)),
+        )
+
+        assertThat(result.spanStyles).hasSize(1)
+        assertThat(result.spanStyles.first().start).isEqualTo(4)
+        assertThat(result.spanStyles.first().end).isEqualTo(code.length)
+    }
+
+    @Test
+    fun `safe builder applies well-formed ranges`() {
+        val code = "abcdef"
+
+        val result = buildSafeHighlightedAnnotatedString(
+            code,
+            listOf(
+                ColorHighlight(PhraseLocation(start = 0, end = 3), rgb = 0x00FF00),
+                BoldHighlight(PhraseLocation(start = 3, end = 6)),
+            ),
+        )
+
+        assertThat(result.text).isEqualTo(code)
+        assertThat(result.spanStyles).hasSize(2)
+    }
+
+    @Test
+    fun `safe builder returns unstyled code when highlighting blows up`() {
+        val code = "abcdef"
+
+        val result = buildSafeHighlightedAnnotatedString(code) { error("highlighter exploded") }
+
+        assertThat(result.text).isEqualTo(code)
+        assertThat(result.spanStyles).isEmpty()
+    }
+}


### PR DESCRIPTION
## Summary

- A fenced code block containing a multiline-comment terminator before the first opener crashed the **entire** conversation panel with `IllegalArgumentException: Reversed range is not supported`. `dev.snipme:highlights` pairs the Nth `/*` index with the Nth `*/` index positionally, so a snippet like a streamed Javadoc excerpt or a diff hunk produces a highlight whose end precedes its start; the renderer handed it to `AnnotatedString.Builder.addStyle` from a `produceState` coroutine on `Dispatchers.Default` where nothing caught it, taking down the Compose frame clock.
- New `SafeHighlightedCode.kt` reimplements the two highlighted-code composables on the renderer's public `MarkdownCodeFence` / `MarkdownCodeBlock` / `MarkdownCodeBackground` / `MarkdownBasicText`, clamping highlight locations into `[0, code.length]`, dropping any left with `end <= start`, and falling back to unstyled text on any `Throwable` (rethrowing `CancellationException` so disposal still works). `AiBubble` and `UserBubble` now use it; no unguarded library usage remains.
- No dependency upgrade — the build pins the renderer and highlighter to the IJ 253 Compose/Skiko toolchain for documented ABI/classloader reasons.

## Test plan

- [x] `./gradlew test` — 3646 tests, 0 failures
- [x] `SafeHighlightedCodeTest` characterization test pins the upstream defect, so a future dependency bump that fixes it fails loudly
- [x] `SafeHighlightedCodeTest` asserts the *unguarded* code path still throws the reported exception for the same input, proving the reproduction
- [x] Guard covered for reversed, out-of-bounds, clamped, well-formed, and highlighter-throws cases
- [ ] Manual: paste a snippet starting with `*/` into the chat and confirm it renders unstyled-but-intact instead of blanking the panel

Known follow-up, out of scope: `UserBubble` shares one mutable `Highlights.Builder` across every code block in a message and `.code()` mutates it, so concurrent highlighting can compute against the wrong block's text. This guard downgrades that from a crash to at-worst mis-colouring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)