### PR TITLE
fix(ui): prevent Activity Log from freezing the IDE

### DIFF
--- a/backlog/tasks/task-260 - Prevent-Activity-Log-from-freezing-the-IDE.md
+++ b/backlog/tasks/task-260 - Prevent-Activity-Log-from-freezing-the-IDE.md
@@ -1,0 +1,86 @@
+---
+id: TASK-260
+title: Prevent Activity Log from freezing the IDE
+status: Done
+assignee:
+  - Codex
+created_date: '2026-08-26 11:28'
+updated_date: '2026-08-26 11:48'
+labels:
+  - bug
+  - performance
+  - ui
+dependencies: []
+references:
+  - src/main/java/com/devoxx/genie/ui/panel/log/AgentMcpLogPanel.java
+  - src/main/java/com/devoxx/genie/service/mcp/MCPLogMessageHandler.java
+  - /Users/stephan/Library/Logs/JetBrains/IntelliJIdea2026.2/idea.log
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+The DevoxxGenie Activity Log can block IntelliJ's UI thread for tens of seconds after MCP and agent debug traffic accumulates. Keep diagnostic logging usable without degrading overall IDE responsiveness, while preserving access to complete log payloads.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Activity Log updates remain responsive after the configured retention limit is reached under sustained MCP or agent traffic
+- [x] #2 Displayed row previews are bounded while complete log content remains available through existing detailed-view and copy workflows
+- [x] #3 Automatic scrolling follows new entries only when the user is already following the log tail
+- [x] #4 Log retention and filtering remain correct when entries are added or pruned in batches
+- [x] #5 Pause, clear, filtering, source colors, and double-click behavior continue to work
+- [x] #6 Automated regression tests cover preview bounding and the updated list behavior
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Bound the displayed preview for every Activity Log source while preserving each entry's full content for double-click and copy/export workflows.
+2. Replace Swing HTML row rendering with a lightweight plain-text colored renderer and fixed single-line cells so list layout does not repeatedly parse HTML or measure variable-height entries.
+3. Track whether the viewport is following the tail and autoscroll only in that state; preserve manual scroll position when the user scrolls upward.
+4. Coalesce pending additions and retention pruning into bulk list-model notifications, keeping filtering and ordering correct.
+5. Add regression tests for MCP preview bounding, bulk retention/filter behavior, and tail-follow decisions while preserving pause, clear, colors, filtering, and double-click behavior.
+6. Run focused Activity Log tests followed by the relevant project test suite; document evidence and finalize TASK-260.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Investigation evidence: IntelliJ IDEA 2026.2.1 attributed a 26.625-second UI freeze to com.devoxx.genie. All 20 captured freeze reports contain AgentMcpLogPanel; the EDT stack runs through scrollToBottom, variable-height JList layout, the HTML cell renderer, and BasicHTML parsing. Both MCP and agent debug logging were enabled.
+
+Implementation plan approved by the user on 2026-08-26.
+
+Implemented bounded 500-character single-line previews for every source while retaining full copy/editor payloads.
+
+Replaced Swing HTML and variable-height rows with plain-text fixed-height rendering; removed ensureIndexIsVisible from the append path.
+
+Added tail-aware scrolling, a single disposable flush timer, and bulk add/remove/replace model operations.
+
+Focused tests: AgentMcpLogPanelFormatTest and AgentMcpLogPanelPerformanceTest passed (26 tests).
+
+Final verification: full ./gradlew test -q passed; focused Activity Log tests passed again after lowering default retention to 250; git diff --check passed.
+
+Final review removed the redundant multiline agent-preview allocation so large agent results are bounded during the first formatting pass.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Implemented the Activity Log freeze fix on branch `fix/task-260-activity-log-freeze`.
+
+- Replaced variable-height Swing HTML rows with fixed-height plain-text rendering, eliminating repeated BasicHTML parsing and full-list row measurement on the EDT.
+- Bounded every displayed preview to 500 characters in a single pass while preserving complete clipboard and double-click editor content.
+- Changed automatic scrolling to follow new entries only when the visible viewport was already at the tail, using the scrollbar instead of `JList.ensureIndexIsVisible`.
+- Added one disposable coalescing timer and bulk model add/remove/replace operations; retention remains correct for filtered views and oversized incoming batches.
+- Reduced default in-memory retention from 1,000 to 250 entries while retaining the configurable override.
+- Added regression tests covering million-character payload bounding, 1,000-row bulk retention events, filtered pruning, and tail-follow decisions; updated formatting tests for the single-line preview contract.
+
+Verification:
+- Focused Activity Log tests passed after the final change.
+- Full `./gradlew test -q` suite passed.
+- `git diff --check` passed.
+
+Behavioral note: list rows intentionally show bounded single-line previews separated by ↵ markers; full multi-line payloads remain available through copy and double-click.
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/src/main/java/com/devoxx/genie/ui/panel/log/AgentMcpLogPanel.java
+++ b/src/main/java/com/devoxx/genie/ui/panel/log/AgentMcpLogPanel.java
@@ -42,8 +42,10 @@ import java.awt.event.MouseEvent;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.function.Function;
+import java.util.function.Predicate;
 
 /**
  * Unified log panel that merges Agent and MCP log streams with source-based filtering.
@@ -52,22 +54,11 @@ import java.util.function.Function;
 @Slf4j
 public class AgentMcpLogPanel extends SimpleToolWindowPanel implements ActivityLoggingMessage, MCPLoggingMessage, RAGLoggingMessage, Disposable {
 
-    private static final int DEFAULT_MAX_LOG_ENTRIES = 1000;
+    private static final int DEFAULT_MAX_LOG_ENTRIES = 250;
     private static final int BATCH_SIZE = 20;
-    /**
-     * Maximum characters per individual line shown in the panel preview. Very long single lines
-     * are truncated with an ellipsis; the full content remains available via tooltip and the
-     * double-click editor view.
-     */
-    private static final int INLINE_PREVIEW_MAX_LINE_LEN = 500;
-    /**
-     * Maximum number of lines rendered in a single panel row. Multi-line tool output beyond
-     * this cap is collapsed into a "(N more lines)" hint so a giant {@code ps -ef} doesn't eat
-     * the whole panel.
-     */
-    private static final int INLINE_PREVIEW_MAX_LINES = 10;
+    private static final int LIST_ROW_PREVIEW_MAX_LEN = 500;
+    private static final int LIST_ROW_HEIGHT = 24;
 
-    /** Maximum characters shown in the hover tooltip. Beyond this, content is truncated with an ellipsis. */
     private static final DateTimeFormatter TIME_FORMATTER = DateTimeFormatter.ofPattern("HH:mm:ss.SSS");
     private static final ObjectMapper JSON_MAPPER = new ObjectMapper().enable(SerializationFeature.INDENT_OUTPUT);
 
@@ -94,10 +85,13 @@ public class AgentMcpLogPanel extends SimpleToolWindowPanel implements ActivityL
     private LogFilter currentFilter = LogFilter.ALL;
 
     private final transient Project project;
-    private final DefaultListModel<LogEntry> logListModel = new DefaultListModel<>();
+    private final ActivityLogListModel<LogEntry> logListModel = new ActivityLogListModel<>();
     private final JBList<LogEntry> logList;
+    private final JBScrollPane logScrollPane;
+    private final Timer pendingLogsTimer;
     private final List<LogEntry> fullLogs = new ArrayList<>();
     private final List<LogEntry> pendingLogs = new ArrayList<>();
+    private boolean disposed;
 
     public AgentMcpLogPanel(@NotNull Project project) {
         super(true);
@@ -115,7 +109,10 @@ public class AgentMcpLogPanel extends SimpleToolWindowPanel implements ActivityL
         };
         logList.setCellRenderer(new CombinedLogEntryRenderer());
         logList.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
-        // No fixed cell height — multi-line entries grow to fit their content.
+        // Rows are deliberately fixed-height and single-line. A variable-height list asks Swing
+        // to measure every retained row whenever the model changes; at 1,000 HTML rows that froze
+        // the EDT for tens of seconds (TASK-260).
+        logList.setFixedCellHeight(JBUI.scale(LIST_ROW_HEIGHT));
         logList.setVisibleRowCount(20);
         // No hover expansion popup: with large entries the popup repaints on every
         // mouse move and flickers. Full content stays reachable via double-click.
@@ -133,10 +130,13 @@ public class AgentMcpLogPanel extends SimpleToolWindowPanel implements ActivityL
             }
         });
 
-        JBScrollPane scrollPane = new JBScrollPane(logList);
-        scrollPane.setBorder(JBUI.Borders.empty());
-        scrollPane.setHorizontalScrollBarPolicy(ScrollPaneConstants.HORIZONTAL_SCROLLBAR_NEVER);
-        setContent(scrollPane);
+        logScrollPane = new JBScrollPane(logList);
+        logScrollPane.setBorder(JBUI.Borders.empty());
+        logScrollPane.setHorizontalScrollBarPolicy(ScrollPaneConstants.HORIZONTAL_SCROLLBAR_NEVER);
+        setContent(logScrollPane);
+
+        pendingLogsTimer = new Timer(100, e -> processPendingLogs());
+        pendingLogsTimer.setRepeats(false);
 
         setupToolbar();
 
@@ -265,10 +265,10 @@ public class AgentMcpLogPanel extends SimpleToolWindowPanel implements ActivityL
 
         private void applyFilter() {
             ApplicationManager.getApplication().invokeLater(() -> {
-                logListModel.clear();
-                fullLogs.stream()
+                List<LogEntry> filteredLogs = fullLogs.stream()
                         .filter(AgentMcpLogPanel.this::matchesFilter)
-                        .forEach(logListModel::addElement);
+                        .toList();
+                logListModel.replaceAll(filteredLogs);
                 scrollToBottom();
             });
         }
@@ -285,9 +285,16 @@ public class AgentMcpLogPanel extends SimpleToolWindowPanel implements ActivityL
     }
 
     private void scrollToBottom() {
-        if (!logListModel.isEmpty()) {
-            logList.ensureIndexIsVisible(logListModel.size() - 1);
-        }
+        if (logListModel.isEmpty() || !logScrollPane.isShowing()) return;
+
+        // Scrolling via the scrollbar avoids JList.ensureIndexIsVisible(), which forces a full
+        // variable-row layout pass. Run after the model event has updated the scrollbar range.
+        ApplicationManager.getApplication().invokeLater(() -> {
+            if (!disposed && logScrollPane.isShowing()) {
+                JScrollBar scrollBar = logScrollPane.getVerticalScrollBar();
+                scrollBar.setValue(scrollBar.getMaximum());
+            }
+        });
     }
 
     @Override
@@ -301,7 +308,7 @@ public class AgentMcpLogPanel extends SimpleToolWindowPanel implements ActivityL
         }
 
         if (message.getSource() == ActivitySource.AGENT) {
-            String displayText = formatAgentActivityMessage(message, AgentMcpLogPanel::formatForRow);
+            String displayText = formatAgentActivityRow(message);
             String clipboardText = formatAgentActivityMessage(message, AgentMcpLogPanel::formatForClipboard);
             String fullContent = buildAgentActivityFullContent(message);
             LogEntry entry = new LogEntry(
@@ -322,7 +329,7 @@ public class AgentMcpLogPanel extends SimpleToolWindowPanel implements ActivityL
                     LogSource.RAW,
                     null,
                     message.getRawTrafficType(),
-                    summary,
+                    formatForListRow(summary),
                     summary,
                     content
             );
@@ -334,7 +341,7 @@ public class AgentMcpLogPanel extends SimpleToolWindowPanel implements ActivityL
                     LogSource.MCP,
                     null,
                     null,
-                    content,
+                    formatForListRow(content),
                     content,
                     content
             );
@@ -362,7 +369,7 @@ public class AgentMcpLogPanel extends SimpleToolWindowPanel implements ActivityL
                 LogSource.MCP,
                 null,
                 null,
-                content,
+                formatForListRow(content),
                 content,
                 content
         );
@@ -387,7 +394,7 @@ public class AgentMcpLogPanel extends SimpleToolWindowPanel implements ActivityL
                 LogSource.RAG,
                 null,
                 null,
-                formatRagRow(message),
+                formatForListRow(formatRagRow(message)),
                 formatRagForClipboard(message),
                 formatRagFullContent(message)
         );
@@ -396,10 +403,8 @@ public class AgentMcpLogPanel extends SimpleToolWindowPanel implements ActivityL
 
     private static @NotNull String formatRagRow(@NotNull RAGLogMessage m) {
         // Single-line summary. The multi-line bullet list of hits used to be inlined here,
-        // but the resulting tall variable-height JList cells caused continuous repaint of the
-        // tool window (visible as IDE-wide flicker) while MCP/Agent rows — always single-line —
-        // were fine. Full per-hit detail is still available via the hover tooltip and the
-        // double-click "open in editor" view.
+        // but tall variable-height JList cells caused continuous tool-window repaint. Full
+        // per-hit detail remains available through copy and the double-click editor view.
         StringBuilder sb = new StringBuilder();
         int hitCount = m.getHits() == null ? 0 : m.getHits().size();
         sb.append("RAG: \"").append(summarize(m.getQuery(), 80))
@@ -482,48 +487,64 @@ public class AgentMcpLogPanel extends SimpleToolWindowPanel implements ActivityL
     }
 
     private void addToPending(LogEntry entry) {
+        boolean flushImmediately;
         synchronized (pendingLogs) {
             pendingLogs.add(entry);
-            if (pendingLogs.size() >= BATCH_SIZE) {
-                processPendingLogs();
-            } else if (pendingLogs.size() == 1) {
-                Timer timer = new Timer(100, e -> processPendingLogs());
-                timer.setRepeats(false);
-                timer.start();
-            }
+            flushImmediately = pendingLogs.size() >= BATCH_SIZE;
         }
-    }
-
-    private synchronized void processPendingLogs() {
-        if (pendingLogs.isEmpty()) {
-            return;
-        }
-        List<LogEntry> logsToProcess = new ArrayList<>(pendingLogs);
-        pendingLogs.clear();
 
         ApplicationManager.getApplication().invokeLater(() -> {
-            int excess = (fullLogs.size() + logsToProcess.size()) - maxLogEntries;
-            if (excess > 0) {
-                trimExcessLogs(excess);
+            if (disposed) return;
+            if (flushImmediately) {
+                pendingLogsTimer.stop();
+                processPendingLogs();
+            } else if (!pendingLogsTimer.isRunning()) {
+                pendingLogsTimer.start();
             }
-            fullLogs.addAll(logsToProcess);
-            for (LogEntry entry : logsToProcess) {
-                if (matchesFilter(entry)) {
-                    logListModel.addElement(entry);
-                }
-            }
-            scrollToBottom();
         });
     }
 
-    private void trimExcessLogs(int excess) {
-        int toRemove = Math.min(excess, fullLogs.size());
-        List<LogEntry> removed = new ArrayList<>(fullLogs.subList(0, toRemove));
-        fullLogs.subList(0, toRemove).clear();
-        long filteredCount = removed.stream().filter(this::matchesFilter).count();
-        for (int i = 0; i < filteredCount && !logListModel.isEmpty(); i++) {
-            logListModel.remove(0);
+    private void processPendingLogs() {
+        List<LogEntry> logsToProcess;
+        synchronized (pendingLogs) {
+            if (pendingLogs.isEmpty()) return;
+            logsToProcess = new ArrayList<>(pendingLogs);
+            pendingLogs.clear();
         }
+
+        ApplicationManager.getApplication().invokeLater(() -> {
+            if (disposed) return;
+            boolean followTail = isFollowingTail(
+                    logScrollPane.isShowing(),
+                    logListModel.isEmpty(),
+                    logScrollPane.getVerticalScrollBar().getModel());
+
+            int oldLogCount = fullLogs.size();
+            int excess = (oldLogCount + logsToProcess.size()) - maxLogEntries;
+            int visibleEntriesToRemove = trimOldestAndCountMatching(
+                    fullLogs, Math.min(excess, oldLogCount), this::matchesFilter);
+            int incomingEntriesToDiscard = Math.max(0, excess - oldLogCount);
+            List<LogEntry> retainedIncomingLogs = logsToProcess.subList(
+                    Math.min(incomingEntriesToDiscard, logsToProcess.size()), logsToProcess.size());
+            fullLogs.addAll(retainedIncomingLogs);
+            List<LogEntry> visibleEntriesToAdd = retainedIncomingLogs.stream()
+                    .filter(this::matchesFilter)
+                    .toList();
+            logListModel.appendAllAndRemoveFirst(visibleEntriesToAdd, visibleEntriesToRemove);
+            if (followTail) scrollToBottom();
+        });
+    }
+
+    static <E> int trimOldestAndCountMatching(@NotNull List<E> entries,
+                                               int excess,
+                                               @NotNull Predicate<E> visiblePredicate) {
+        int toRemove = Math.min(Math.max(excess, 0), entries.size());
+        int visibleCount = 0;
+        for (int i = 0; i < toRemove; i++) {
+            if (visiblePredicate.test(entries.get(i))) visibleCount++;
+        }
+        if (toRemove > 0) entries.subList(0, toRemove).clear();
+        return visibleCount;
     }
 
     static @NotNull String formatAgentActivityMessage(@NotNull ActivityMessage message,
@@ -576,6 +597,11 @@ public class AgentMcpLogPanel extends SimpleToolWindowPanel implements ActivityL
         return sb.toString();
     }
 
+    static @NotNull String formatAgentActivityRow(@NotNull ActivityMessage message) {
+        return formatForListRow(
+                formatAgentActivityMessage(message, AgentMcpLogPanel::formatForListRow));
+    }
+
     private static void formatToolRequest(@NotNull StringBuilder sb, @NotNull ActivityMessage message,
                                           @NotNull Function<String, String> contentFormatter) {
         sb.append("▶ ").append(message.getToolName());
@@ -603,36 +629,56 @@ public class AgentMcpLogPanel extends SimpleToolWindowPanel implements ActivityL
     }
 
     /**
-     * Formats a tool argument/result for the multi-line panel preview. Each input line maps to
-     * an output line (real {@code \n} separators) so the renderer can render rows that grow
-     * vertically. Each line is truncated to {@link #INLINE_PREVIEW_MAX_LINE_LEN} characters and
-     * the overall block is capped at {@link #INLINE_PREVIEW_MAX_LINES} lines with a "(N more
-     * lines)" hint; the full content remains available via tooltip and the double-click editor.
+     * Produces the bounded, single-line text stored in the Swing list model. The original content
+     * remains in {@link LogEntry#clipboardMessage()} and {@link LogEntry#fullContent()}.
+     * Processing stops as soon as the preview is full, so a multi-megabyte MCP response does not
+     * need to be copied merely to paint one row.
      */
-    static @NotNull String formatForRow(@NotNull String text) {
-        return formatForRow(text, INLINE_PREVIEW_MAX_LINE_LEN, INLINE_PREVIEW_MAX_LINES);
+    static @NotNull String formatForListRow(@NotNull String text) {
+        return formatForListRow(text, LIST_ROW_PREVIEW_MAX_LEN);
     }
 
-    static @NotNull String formatForRow(@NotNull String text, int maxLineLen, int maxLines) {
-        String[] lines = splitLines(text);
-        int total = effectiveLineCount(lines);
-        if (total == 0) return "";
+    static @NotNull String formatForListRow(@NotNull String text, int maxLen) {
+        if (text.isEmpty() || maxLen <= 0) return "";
 
-        int shown = Math.min(total, maxLines);
-        StringBuilder sb = new StringBuilder();
-        for (int i = 0; i < shown; i++) {
-            if (i > 0) sb.append('\n');
-            String line = lines[i];
-            if (line.length() > maxLineLen) {
-                sb.append(line, 0, maxLineLen).append('…');
+        StringBuilder preview = new StringBuilder(Math.min(text.length(), maxLen));
+        boolean pendingSpace = false;
+        boolean pendingLineBreak = false;
+        boolean truncated = false;
+        for (int i = 0; i < text.length(); i++) {
+            char c = text.charAt(i);
+            if (c == '\r' || c == '\n') {
+                if (c == '\r' && i + 1 < text.length() && text.charAt(i + 1) == '\n') i++;
+                pendingLineBreak = !preview.isEmpty();
+                pendingSpace = false;
+            } else if (Character.isWhitespace(c)) {
+                if (!preview.isEmpty() && !pendingLineBreak) pendingSpace = true;
             } else {
-                sb.append(line);
+                int separatorLength = pendingLineBreak ? 3 : pendingSpace ? 1 : 0;
+                if (preview.length() + separatorLength + 1 > maxLen) {
+                    truncated = true;
+                    break;
+                }
+                if (pendingLineBreak) preview.append(" ↵ ");
+                else if (pendingSpace) preview.append(' ');
+                preview.append(c);
+                pendingLineBreak = false;
+                pendingSpace = false;
             }
         }
-        if (total > shown) {
-            sb.append('\n').append("… (").append(total - shown).append(" more lines)");
+
+        if (truncated) {
+            if (preview.length() == maxLen) preview.setLength(maxLen - 1);
+            preview.append('…');
         }
-        return sb.toString();
+        return preview.toString();
+    }
+
+    static boolean isFollowingTail(boolean isShowing,
+                                   boolean isEmpty,
+                                   @NotNull BoundedRangeModel scrollModel) {
+        if (!isShowing) return false;
+        return isEmpty || scrollModel.getValue() + scrollModel.getExtent() >= scrollModel.getMaximum();
     }
 
     /**
@@ -788,22 +834,40 @@ public class AgentMcpLogPanel extends SimpleToolWindowPanel implements ActivityL
 
     private void pruneLogsToMaxSize() {
         ApplicationManager.getApplication().invokeLater(() -> {
-            while (fullLogs.size() > maxLogEntries) {
-                fullLogs.remove(0);
-            }
-            while (logListModel.size() > maxLogEntries) {
-                logListModel.remove(0);
-            }
+            int excess = fullLogs.size() - maxLogEntries;
+            int visibleEntriesToRemove = trimOldestAndCountMatching(
+                    fullLogs, excess, this::matchesFilter);
+            logListModel.removeFirst(visibleEntriesToRemove);
         });
     }
 
     @Override
     public void dispose() {
+        disposed = true;
+        pendingLogsTimer.stop();
         synchronized (pendingLogs) {
             pendingLogs.clear();
         }
         fullLogs.clear();
         logListModel.clear();
+    }
+
+    /** List model operations that emit at most one event per bulk removal or addition. */
+    static final class ActivityLogListModel<E> extends DefaultListModel<E> {
+        void appendAllAndRemoveFirst(@NotNull Collection<? extends E> entries, int removeFirstCount) {
+            removeFirst(removeFirstCount);
+            if (!entries.isEmpty()) addAll(entries);
+        }
+
+        void replaceAll(@NotNull Collection<? extends E> entries) {
+            if (!isEmpty()) removeRange(0, size() - 1);
+            if (!entries.isEmpty()) addAll(entries);
+        }
+
+        void removeFirst(int count) {
+            int actualCount = Math.min(Math.max(count, 0), size());
+            if (actualCount > 0) removeRange(0, actualCount - 1);
+        }
     }
 
     private class CombinedLogEntryRenderer extends DefaultListCellRenderer {
@@ -829,8 +893,10 @@ public class AgentMcpLogPanel extends SimpleToolWindowPanel implements ActivityL
                 };
                 String badge = currentFilter == LogFilter.ALL ? sourceTag : "";
                 String plain = entry.timestamp() + " " + badge + entry.message();
-                label.setText(toHtmlRow(plain));
-                label.setVerticalAlignment(SwingConstants.TOP);
+                // Plain text is intentional. Swing reparses JLabel HTML on both setText and
+                // setForeground; doing that for every retained row caused the TASK-260 freezes.
+                label.setText(plain);
+                label.setVerticalAlignment(SwingConstants.CENTER);
                 // No hover tooltip: large log entries produce a huge popup that flickers
                 // as the mouse moves. Double-click opens the full content in an editor.
                 label.setToolTipText(null);
@@ -840,15 +906,6 @@ public class AgentMcpLogPanel extends SimpleToolWindowPanel implements ActivityL
                 }
             }
             return label;
-        }
-
-        private @NotNull String toHtmlRow(@NotNull String text) {
-            String escaped = text
-                    .replace("&", "&amp;")
-                    .replace("<", "&lt;")
-                    .replace(">", "&gt;")
-                    .replace("\n", "<br>");
-            return "<html><pre style=\"font-family:monospace;margin:0;padding:0\">" + escaped + "</pre></html>";
         }
 
         private Color resolveEntryColor(LogEntry entry) {

--- a/src/test/java/com/devoxx/genie/ui/panel/log/AgentMcpLogPanelFormatTest.java
+++ b/src/test/java/com/devoxx/genie/ui/panel/log/AgentMcpLogPanelFormatTest.java
@@ -8,83 +8,15 @@ import org.junit.jupiter.api.Test;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
- * Unit tests for the row-preview, clipboard, and tooltip helpers used by {@link AgentMcpLogPanel}.
+ * Unit tests for the row-preview and clipboard helpers used by {@link AgentMcpLogPanel}.
  * These guard the contract that:
  * <ul>
- *   <li>panel rows render multi-line tool output across real lines (no {@code ⏎} markers),</li>
+ *   <li>panel rows flatten multi-line output into bounded single-line previews,</li>
  *   <li>copy-to-clipboard preserves the original newlines verbatim under the entry header,</li>
- *   <li>the hover tooltip surfaces the full multi-line content as HTML.</li>
+ *   <li>the detailed editor view retains the complete content.</li>
  * </ul>
  */
 class AgentMcpLogPanelFormatTest {
-
-    // --- formatForRow ---------------------------------------------------------------------
-
-    @Test
-    void formatForRow_singleLine_returnsAsIs() {
-        assertThat(AgentMcpLogPanel.formatForRow("hello")).isEqualTo("hello");
-    }
-
-    @Test
-    void formatForRow_emptyString_returnsEmpty() {
-        assertThat(AgentMcpLogPanel.formatForRow("")).isEmpty();
-    }
-
-    @Test
-    void formatForRow_trailingNewlineOnly_isTreatedAsSingleLine() {
-        // RunCommandToolExecutor appends a trailing '\n' to each line, so a single-line result
-        // ends with '\n'. That trailing empty segment must not be reported as a second line.
-        assertThat(AgentMcpLogPanel.formatForRow("output\n")).isEqualTo("output");
-    }
-
-    @Test
-    void formatForRow_multiLine_keepsRealNewlinesNoMarker() {
-        String input = "line1\nline2\nline3";
-        String preview = AgentMcpLogPanel.formatForRow(input);
-        assertThat(preview).isEqualTo("line1\nline2\nline3");
-        assertThat(preview).doesNotContain("⏎");
-    }
-
-    @Test
-    void formatForRow_realWorldRunCommandOutput_showsBothStderrAndStdout() {
-        // Reproduces the bug pattern from #1027 follow-up: the agent log row used to collapse
-        // both lines into one with a ⏎ marker. With multi-line rendering both lines appear on
-        // their own line in the panel.
-        String input = "/Users/x/.sdkman/path-helpers.sh: line 61: ${name^^}: bad substitution\n"
-                + "/Library/Java/jdk21\n";
-        String preview = AgentMcpLogPanel.formatForRow(input);
-        assertThat(preview.split("\n")).containsExactly(
-                "/Users/x/.sdkman/path-helpers.sh: line 61: ${name^^}: bad substitution",
-                "/Library/Java/jdk21"
-        );
-    }
-
-    @Test
-    void formatForRow_longSingleLine_isTruncatedWithEllipsis() {
-        String input = "x".repeat(800);
-        String preview = AgentMcpLogPanel.formatForRow(input, 100, 10);
-        assertThat(preview).hasSize(101); // 100 chars + ellipsis
-        assertThat(preview).endsWith("…");
-    }
-
-    @Test
-    void formatForRow_exceedingMaxLines_isCappedWithMoreLinesHint() {
-        StringBuilder sb = new StringBuilder();
-        for (int i = 0; i < 25; i++) sb.append("line").append(i).append('\n');
-        String preview = AgentMcpLogPanel.formatForRow(sb.toString(), 500, 10);
-        String[] lines = preview.split("\n");
-        assertThat(lines).hasSize(11); // 10 content lines + 1 hint line
-        assertThat(lines[0]).isEqualTo("line0");
-        assertThat(lines[9]).isEqualTo("line9");
-        assertThat(lines[10]).isEqualTo("… (15 more lines)");
-    }
-
-    @Test
-    void formatForRow_crlfLineEndings_areNormalised() {
-        String input = "first\r\nsecond\r\nthird";
-        String preview = AgentMcpLogPanel.formatForRow(input);
-        assertThat(preview).isEqualTo("first\nsecond\nthird");
-    }
 
     // --- formatForClipboard ---------------------------------------------------------------
 
@@ -128,24 +60,10 @@ class AgentMcpLogPanelFormatTest {
         assertThat(AgentMcpLogPanel.formatForClipboard(input)).isEqualTo("\n    first\n    second");
     }
 
-    @Test
-    void formatForRow_doubleTrailingNewline_countsAsOneLine() {
-        // "a\n\n" should collapse to a single-line result, not show a "(N more lines)" hint.
-        String preview = AgentMcpLogPanel.formatForRow("a\n\n");
-        assertThat(preview).isEqualTo("a");
-        assertThat(preview).doesNotContain("more lines");
-    }
-
-    @Test
-    void formatForRow_manyTrailingNewlines_countsAsOneLine() {
-        String preview = AgentMcpLogPanel.formatForRow("only-real-line\n\n\n\n");
-        assertThat(preview).isEqualTo("only-real-line");
-    }
-
     // --- formatAgentActivityMessage -------------------------------------------------------
 
     @Test
-    void formatAgentActivityMessage_toolErrorWithMultiLineResult_rendersAcrossLines() {
+    void formatAgentActivityRow_toolErrorWithMultiLineResult_isSingleLine() {
         ActivityMessage err = ActivityMessage.builder()
                 .source(ActivitySource.AGENT)
                 .agentType(AgentType.TOOL_ERROR)
@@ -154,18 +72,15 @@ class AgentMcpLogPanelFormatTest {
                 .callNumber(2)
                 .maxCalls(25)
                 .build();
-        String row = AgentMcpLogPanel.formatAgentActivityMessage(err, AgentMcpLogPanel::formatForRow);
-        assertThat(row).startsWith("[2/25] \u2716 run_command \u2192 ");
-        assertThat(row.split("\n")).containsExactly(
-                "[2/25] \u2716 run_command \u2192 Error: failed to spawn process",
-                "stacktrace line 1",
-                "stacktrace line 2"
-        );
-        assertThat(row).doesNotContain("\u23ce");
+        String row = AgentMcpLogPanel.formatAgentActivityRow(err);
+        assertThat(row).isEqualTo(
+                "[2/25] \u2716 run_command \u2192 Error: failed to spawn process"
+                        + " ↵ stacktrace line 1 ↵ stacktrace line 2");
+        assertThat(row).doesNotContain("\n");
     }
 
     @Test
-    void formatAgentActivityMessage_subAgentErrorWithMultiLineResult_rendersAcrossLines() {
+    void formatAgentActivityRow_subAgentErrorWithMultiLineResult_isSingleLine() {
         ActivityMessage err = ActivityMessage.builder()
                 .source(ActivitySource.AGENT)
                 .agentType(AgentType.SUB_AGENT_ERROR)
@@ -174,12 +89,10 @@ class AgentMcpLogPanelFormatTest {
                 .callNumber(1)
                 .maxCalls(25)
                 .build();
-        String row = AgentMcpLogPanel.formatAgentActivityMessage(err, AgentMcpLogPanel::formatForRow);
-        assertThat(row).contains("Sub-agent error: explorer-1");
-        assertThat(row.split("\n")).containsExactly(
-                "[1/25] [explorer-1] \u2716 Sub-agent error: explorer-1 \u2192 first error line",
-                "second error line"
-        );
+        String row = AgentMcpLogPanel.formatAgentActivityRow(err);
+        assertThat(row).isEqualTo(
+                "[1/25] [explorer-1] \u2716 Sub-agent error: explorer-1 \u2192 "
+                        + "first error line ↵ second error line");
     }
 
     @Test
@@ -201,21 +114,17 @@ class AgentMcpLogPanelFormatTest {
     }
 
     @Test
-    void formatAgentActivityMessage_systemPrompt_hasNoCallPrefixAndRendersBody() {
+    void formatAgentActivityRow_systemPrompt_hasNoCallPrefixAndRendersBody() {
         ActivityMessage prompt = ActivityMessage.builder()
                 .source(ActivitySource.AGENT)
                 .agentType(AgentType.SYSTEM_PROMPT)
                 .result("You are a helpful assistant.\n<ProjectContext>\nrules\n</ProjectContext>")
                 .build();
-        String row = AgentMcpLogPanel.formatAgentActivityMessage(prompt, AgentMcpLogPanel::formatForRow);
+        String row = AgentMcpLogPanel.formatAgentActivityRow(prompt);
         // No "[n/n]" call-count prefix for an informational system-prompt entry.
         assertThat(row).doesNotContain("[0/0]");
-        assertThat(row.split("\n")).containsExactly(
-                "\ud83d\udccb System prompt",
-                "You are a helpful assistant.",
-                "<ProjectContext>",
-                "rules",
-                "</ProjectContext>"
-        );
+        assertThat(row).isEqualTo(
+                "\ud83d\udccb System prompt ↵ You are a helpful assistant. ↵ "
+                        + "<ProjectContext> ↵ rules ↵ </ProjectContext>");
     }
 }

--- a/src/test/java/com/devoxx/genie/ui/panel/log/AgentMcpLogPanelPerformanceTest.java
+++ b/src/test/java/com/devoxx/genie/ui/panel/log/AgentMcpLogPanelPerformanceTest.java
@@ -1,0 +1,111 @@
+package com.devoxx.genie.ui.panel.log;
+
+import org.junit.jupiter.api.Test;
+
+import javax.swing.DefaultBoundedRangeModel;
+import javax.swing.event.ListDataEvent;
+import javax.swing.event.ListDataListener;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.IntStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Regression coverage for the bounded, bulk-updated Activity Log list (TASK-260). */
+class AgentMcpLogPanelPerformanceTest {
+
+    @Test
+    void listRowPreview_collapsesLinesAndKeepsWithinItsTotalLimit() {
+        String preview = AgentMcpLogPanel.formatForListRow("first\r\nsecond\nthird");
+
+        assertThat(preview).isEqualTo("first ↵ second ↵ third");
+        assertThat(preview).doesNotContain("\n", "\r");
+        assertThat(AgentMcpLogPanel.formatForListRow("output\n\n")).isEqualTo("output");
+    }
+
+    @Test
+    void listRowPreview_stopsAtBoundForVeryLargeMcpPayload() {
+        String preview = AgentMcpLogPanel.formatForListRow("x".repeat(1_000_000));
+
+        assertThat(preview).hasSize(500).endsWith("…");
+    }
+
+    @Test
+    void listModel_appendsAndPrunesUsingOneEventPerBulkOperation() {
+        AgentMcpLogPanel.ActivityLogListModel<String> model =
+                new AgentMcpLogPanel.ActivityLogListModel<>();
+        model.addAll(IntStream.range(0, 1_000).mapToObj(i -> "old-" + i).toList());
+        AtomicInteger additions = new AtomicInteger();
+        AtomicInteger removals = new AtomicInteger();
+        model.addListDataListener(countingListener(additions, removals));
+
+        List<String> incoming = IntStream.range(0, 20).mapToObj(i -> "new-" + i).toList();
+        model.appendAllAndRemoveFirst(incoming, 20);
+
+        assertThat(model.size()).isEqualTo(1_000);
+        assertThat(Collections.list(model.elements()))
+                .startsWith("old-20", "old-21")
+                .endsWith("new-18", "new-19");
+        assertThat(removals).hasValue(1);
+        assertThat(additions).hasValue(1);
+    }
+
+    @Test
+    void listModel_replacesFilteredContentsUsingBulkEvents() {
+        AgentMcpLogPanel.ActivityLogListModel<String> model =
+                new AgentMcpLogPanel.ActivityLogListModel<>();
+        model.addAll(List.of("mcp-1", "agent-1", "mcp-2"));
+        AtomicInteger additions = new AtomicInteger();
+        AtomicInteger removals = new AtomicInteger();
+        model.addListDataListener(countingListener(additions, removals));
+
+        model.replaceAll(List.of("mcp-1", "mcp-2"));
+
+        assertThat(Collections.list(model.elements())).containsExactly("mcp-1", "mcp-2");
+        assertThat(removals).hasValue(1);
+        assertThat(additions).hasValue(1);
+    }
+
+    @Test
+    void retention_countsOnlyRemovedEntriesVisibleUnderCurrentFilter() {
+        List<String> fullLogs = new ArrayList<>(List.of("mcp-1", "agent-1", "mcp-2", "agent-2"));
+
+        int visibleRemoved = AgentMcpLogPanel.trimOldestAndCountMatching(
+                fullLogs, 3, entry -> entry.startsWith("mcp"));
+
+        assertThat(visibleRemoved).isEqualTo(2);
+        assertThat(fullLogs).containsExactly("agent-2");
+    }
+
+    @Test
+    void tailFollowing_requiresVisibleListAtItsBottom() {
+        DefaultBoundedRangeModel atBottom = new DefaultBoundedRangeModel(90, 10, 0, 100);
+        DefaultBoundedRangeModel scrolledUp = new DefaultBoundedRangeModel(50, 10, 0, 100);
+
+        assertThat(AgentMcpLogPanel.isFollowingTail(true, false, atBottom)).isTrue();
+        assertThat(AgentMcpLogPanel.isFollowingTail(true, false, scrolledUp)).isFalse();
+        assertThat(AgentMcpLogPanel.isFollowingTail(false, false, atBottom)).isFalse();
+        assertThat(AgentMcpLogPanel.isFollowingTail(true, true, scrolledUp)).isTrue();
+    }
+
+    private static ListDataListener countingListener(AtomicInteger additions, AtomicInteger removals) {
+        return new ListDataListener() {
+            @Override
+            public void intervalAdded(ListDataEvent e) {
+                additions.incrementAndGet();
+            }
+
+            @Override
+            public void intervalRemoved(ListDataEvent e) {
+                removals.incrementAndGet();
+            }
+
+            @Override
+            public void contentsChanged(ListDataEvent e) {
+                // No-op: bulk add/remove should not degrade into per-row content changes.
+            }
+        };
+    }
+}


### PR DESCRIPTION
# Pull Request

## 📚 Documentation

Before submitting, please review our [Contributing Guide](https://genie.devoxx.com/docs/contributing).

## Description

Prevents the Activity Log from freezing IntelliJ after sustained MCP and agent traffic. The freeze path repeatedly measured variable-height list cells and reparsed Swing HTML on the EDT; this change uses bounded plain-text previews, fixed-height rows, bulk model updates, and tail-aware scrolling while preserving access to complete payloads.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [x] Performance improvement
- [x] Test addition/improvement

## Related Issue

Backlog: TASK-260

## Changes Made

- Replace variable-height Swing HTML cells with fixed-height plain-text rows.
- Bound list previews to 500 characters while preserving complete copy and double-click editor content.
- Coalesce retention and filtered-list changes into bulk model events and follow the tail only when the user is already at the bottom.
- Reduce default retention from 1,000 to 250 entries and add regression coverage for large payloads, pruning, filtering, and tail-follow decisions.

## Testing

**How has this been tested?**

- [x] Unit tests
- [x] Integration/platform tests included by the project test task
- [ ] Manual testing in IntelliJ IDEA
- [ ] Tested with local LLM (Ollama/LMStudio/GPT4All)
- [ ] Tested with cloud LLM (OpenAI/Anthropic/Gemini)
- [ ] Tested with MCP servers
- [ ] Tested with RAG enabled

Command: `./gradlew test -q` — passed.

**Test Configuration:**
- IntelliJ IDEA test platform: IU 2025.3.3
- JDK version: OpenJDK 25.0.2
- OS: macOS 26.5

## Documentation

- [x] No user documentation changes are required
- [x] Complex performance-sensitive behavior is documented in code

## Checklist

- [x] My code follows the existing code style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing tests pass locally with my changes
- [x] No dependent changes are required

## Screenshots/Videos (if applicable)

Not applicable; this is a responsiveness fix with intentionally compact single-line row previews.

## Additional Notes

Rows now display bounded single-line previews with ↵ markers. Complete multi-line payloads remain available through copy and double-click.

## Breaking Changes

None.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the project's license.
