### PR TITLE
fix(cli/acp): pass attached images to runners and survive history replay (#1280, #1282)

### DIFF
--- a/src/main/java/com/devoxx/genie/service/prompt/strategy/AbstractPromptExecutionStrategy.java
+++ b/src/main/java/com/devoxx/genie/service/prompt/strategy/AbstractPromptExecutionStrategy.java
@@ -2,6 +2,7 @@ package com.devoxx.genie.service.prompt.strategy;
 
 import com.devoxx.genie.model.request.ChatMessageContext;
 import com.devoxx.genie.model.request.SemanticFile;
+import com.devoxx.genie.service.FileListManager;
 import com.devoxx.genie.service.MessageCreationService;
 import com.devoxx.genie.service.prompt.error.ExecutionException;
 import com.devoxx.genie.service.prompt.error.PromptErrorHandler;
@@ -18,6 +19,7 @@ import com.devoxx.genie.ui.panel.PromptOutputPanel;
 import com.devoxx.genie.ui.topic.AppTopics;
 import com.devoxx.genie.ui.util.NotificationUtil;
 import com.intellij.openapi.project.Project;
+import com.intellij.openapi.vfs.VirtualFile;
 import dev.langchain4j.data.message.AiMessage;
 import dev.langchain4j.data.message.ChatMessage;
 import dev.langchain4j.data.message.SystemMessage;
@@ -270,7 +272,21 @@ public abstract class AbstractPromptExecutionStrategy implements PromptExecution
                       .append(filesContext)
                       .append("</attached_files>\n\n");
         }
-        
+
+        // Attached images never reach filesContext: MessageCreationService.addImages() puts them into
+        // ImageContent, which CLI/ACP runners cannot transport (they only receive plain text). The
+        // image files are already on disk, so hand the agent their paths and let it read them itself.
+        List<VirtualFile> imageFiles = FileListManager.getInstance().getImageFiles(project, context.getTabId());
+        if (!imageFiles.isEmpty()) {
+            fullPrompt.append("<attached_images>\n");
+            for (VirtualFile imageFile : imageFiles) {
+                fullPrompt.append(imageFile.getPath()).append("\n");
+            }
+            fullPrompt.append("</attached_images>\n")
+                      .append("The user attached the image file(s) listed above. ")
+                      .append("Read them with your file-reading tool before answering.\n\n");
+        }
+
         // Add the user prompt
         fullPrompt.append(context.getUserPrompt());
         

--- a/src/main/java/com/devoxx/genie/service/prompt/strategy/AbstractPromptExecutionStrategy.java
+++ b/src/main/java/com/devoxx/genie/service/prompt/strategy/AbstractPromptExecutionStrategy.java
@@ -22,7 +22,10 @@ import com.intellij.openapi.project.Project;
 import com.intellij.openapi.vfs.VirtualFile;
 import dev.langchain4j.data.message.AiMessage;
 import dev.langchain4j.data.message.ChatMessage;
+import dev.langchain4j.data.message.Content;
+import dev.langchain4j.data.message.ImageContent;
 import dev.langchain4j.data.message.SystemMessage;
+import dev.langchain4j.data.message.TextContent;
 import dev.langchain4j.data.message.UserMessage;
 import lombok.extern.slf4j.Slf4j;
 import org.jetbrains.annotations.NotNull;
@@ -249,7 +252,7 @@ public abstract class AbstractPromptExecutionStrategy implements PromptExecution
                 continue;
             }
             if (msg instanceof UserMessage userMsg) {
-                history.append("[user]: ").append(userMsg.singleText()).append("\n");
+                history.append("[user]: ").append(historyTextOf(userMsg)).append("\n");
             } else if (msg instanceof AiMessage aiMsg) {
                 history.append("[assistant]: ").append(aiMsg.text()).append("\n");
             }
@@ -291,6 +294,37 @@ public abstract class AbstractPromptExecutionStrategy implements PromptExecution
         fullPrompt.append(context.getUserPrompt());
         
         return fullPrompt.toString();
+    }
+
+    /**
+     * Plain-text rendering of a user message for history replay (issue #1282).
+     * <p>
+     * Image prompts are stored in memory as multimodal messages ({@code TextContent} +
+     * {@code ImageContent}); {@link UserMessage#singleText()} throws on those, which used to
+     * make every follow-up CLI/ACP prompt in the conversation fail. CLI/ACP runners only take
+     * text, so the text parts are joined and each image is replaced by a marker instead of
+     * leaking its base64 payload into the prompt.
+     */
+    static @NotNull String historyTextOf(@NotNull UserMessage userMsg) {
+        if (userMsg.hasSingleText()) {
+            return userMsg.singleText();
+        }
+        StringBuilder text = new StringBuilder();
+        int images = 0;
+        for (Content content : userMsg.contents()) {
+            if (content instanceof TextContent textContent) {
+                if (!text.isEmpty()) {
+                    text.append('\n');
+                }
+                text.append(textContent.text());
+            } else if (content instanceof ImageContent) {
+                images++;
+            }
+        }
+        for (int i = 0; i < images; i++) {
+            text.append(text.isEmpty() ? "" : " ").append("[image attached]");
+        }
+        return text.toString();
     }
 
     /**

--- a/src/test/java/com/devoxx/genie/service/CliAcpImageAttachmentIntegrationTest.java
+++ b/src/test/java/com/devoxx/genie/service/CliAcpImageAttachmentIntegrationTest.java
@@ -1,0 +1,342 @@
+package com.devoxx.genie.service;
+
+import com.devoxx.genie.model.LanguageModel;
+import com.devoxx.genie.model.enumarations.ModelProvider;
+import com.devoxx.genie.model.request.ChatMessageContext;
+import com.devoxx.genie.service.prompt.memory.ChatMemoryManager;
+import com.devoxx.genie.service.prompt.memory.ChatMemoryService;
+import com.devoxx.genie.service.prompt.result.PromptResult;
+import com.devoxx.genie.service.prompt.strategy.AbstractPromptExecutionStrategy;
+import com.devoxx.genie.service.prompt.threading.PromptTask;
+import com.devoxx.genie.service.prompt.threading.ThreadPoolManager;
+import com.devoxx.genie.ui.panel.PromptOutputPanel;
+import com.devoxx.genie.ui.settings.DevoxxGenieStateService;
+import com.intellij.openapi.application.Application;
+import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.vfs.VirtualFile;
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.data.message.ChatMessage;
+import dev.langchain4j.data.message.ImageContent;
+import dev.langchain4j.data.message.SystemMessage;
+import dev.langchain4j.data.message.UserMessage;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+import java.io.IOException;
+import java.util.Base64;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+/**
+ * Integration test for the CLI/ACP Runner image attachment flow, covering
+ * <a href="https://github.com/devoxx/DevoxxGenieIDEAPlugin/issues/1280">#1280</a>
+ * (attached images silently dropped) and
+ * <a href="https://github.com/devoxx/DevoxxGenieIDEAPlugin/issues/1282">#1282</a>
+ * (every follow-up prompt fails with "Expecting single text content" once an image was attached).
+ * <p>
+ * Unlike {@code AbstractPromptExecutionStrategyTest}, nothing in the prompt-assembly chain is
+ * stubbed here: the real {@link FileListManager}, {@link MessageCreationService},
+ * {@link ChatMemoryManager} and {@link ChatMemoryService} are wired together behind a mocked
+ * {@link ApplicationManager}, so the test exercises the same collaboration the runners use —
+ * image attach → multimodal {@link UserMessage} → chat memory → history replay on the next turn.
+ * Only the IDE {@link Project}/{@link VirtualFile} and the unused {@link ThreadPoolManager} are mocks.
+ * <p>
+ * Note: this deliberately does NOT extend {@code AbstractLightPlatformTestCase}. The build runs
+ * {@code useJUnitPlatform()} with only the Jupiter engine on the classpath, so JUnit 3/4 style
+ * platform test cases are never discovered (see {@code PromptMessageFlowIntegrationTest}, which
+ * silently does not execute).
+ */
+class CliAcpImageAttachmentIntegrationTest {
+
+    private static final String PROJECT_HASH = "project-hash-1280";
+    private static final String TAB_ID = "tab-1";
+    private static final String OTHER_TAB_ID = "tab-2";
+    private static final String IMAGE_PATH = "/Users/dev/Desktop/screenshot.png";
+
+    /** 1x1 transparent PNG — the bytes the runner would have to base64-encode for a vision model. */
+    private static final byte[] PNG_BYTES = Base64.getDecoder().decode(
+            "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==");
+    private static final String PNG_BASE64 = Base64.getEncoder().encodeToString(PNG_BYTES);
+
+    private MockedStatic<ApplicationManager> applicationManagerMock;
+
+    private Project project;
+    private FileListManager fileListManager;
+    private ChatMemoryService chatMemoryService;
+    private ChatMemoryManager chatMemoryManager;
+    private TestRunnerStrategy strategy;
+
+    @BeforeEach
+    void setUp() {
+        project = mock(Project.class);
+        when(project.getLocationHash()).thenReturn(PROJECT_HASH);
+        when(project.getName()).thenReturn("TestProject");
+
+        Application application = mock(Application.class);
+
+        applicationManagerMock = mockStatic(ApplicationManager.class);
+        applicationManagerMock.when(ApplicationManager::getApplication).thenReturn(application);
+
+        // Real collaborators — the whole point of this test
+        fileListManager = new FileListManager();
+        chatMemoryService = new ChatMemoryService();
+        MessageCreationService messageCreationService = new MessageCreationService();
+        DevoxxGenieStateService stateService = new DevoxxGenieStateService();
+
+        when(application.getService(FileListManager.class)).thenReturn(fileListManager);
+        when(application.getService(ChatMemoryService.class)).thenReturn(chatMemoryService);
+        when(application.getService(MessageCreationService.class)).thenReturn(messageCreationService);
+        when(application.getService(DevoxxGenieStateService.class)).thenReturn(stateService);
+
+        // ChatMemoryManager's constructor resolves ChatMemoryService, so build it after the stub
+        chatMemoryManager = new ChatMemoryManager();
+        when(application.getService(ChatMemoryManager.class)).thenReturn(chatMemoryManager);
+
+        strategy = new TestRunnerStrategy(project, chatMemoryManager,
+                mock(ThreadPoolManager.class), messageCreationService);
+
+        // Seed both tabs with a system message so prepareMemory() skips system-prompt assembly
+        // (skills/DEVOXXGENIE.md lookups), which is not what these issues are about.
+        seedMemory(PROJECT_HASH + "-" + TAB_ID);
+        seedMemory(PROJECT_HASH + "-" + OTHER_TAB_ID);
+    }
+
+    private void seedMemory(String memoryKey) {
+        chatMemoryService.initializeByKey(memoryKey, 50);
+        chatMemoryService.addMessageByKey(memoryKey, SystemMessage.from("You are a helpful coding assistant."));
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (applicationManagerMock != null) {
+            applicationManagerMock.close();
+        }
+    }
+
+    // ---------------------------------------------------------------------
+    // Issue #1280 — attached images must reach the agent
+    // ---------------------------------------------------------------------
+
+    @Test
+    @DisplayName("#1280: an image attached to the tab reaches the runner prompt as a readable file path")
+    void imageAttachedToTab_isHandedToTheRunnerAsAFilePath() throws IOException {
+        attachImage(TAB_ID, IMAGE_PATH);
+
+        String prompt = sendPrompt(TAB_ID, "what is this image ?");
+
+        assertThat(prompt)
+                .as("CLI/ACP runners only transport text, so the agent must be told where the image lives")
+                .contains("<attached_images>")
+                .contains(IMAGE_PATH)
+                .contains("</attached_images>");
+        assertThat(prompt.indexOf("</attached_images>"))
+                .as("the image block must precede the user prompt")
+                .isLessThan(prompt.indexOf("what is this image ?"));
+    }
+
+    @Test
+    @DisplayName("#1280: a prompt without attachments carries no image block")
+    void noImageAttached_promptHasNoImageBlock() {
+        String prompt = sendPrompt(TAB_ID, "hello");
+
+        assertThat(prompt).doesNotContain("<attached_images>").endsWith("hello");
+    }
+
+    @Test
+    @DisplayName("#1280: images are looked up per tab, not per project")
+    void imageAttachedInOneTab_doesNotLeakIntoAnotherTab() throws IOException {
+        attachImage(TAB_ID, IMAGE_PATH);
+
+        String otherTabPrompt = sendPrompt(OTHER_TAB_ID, "unrelated question");
+
+        assertThat(otherTabPrompt)
+                .as("FileListManager keys images by projectHash-tabId; the strategy must use the same key")
+                .doesNotContain("<attached_images>")
+                .doesNotContain(IMAGE_PATH);
+    }
+
+    // ---------------------------------------------------------------------
+    // Issue #1282 — follow-up prompts after an image turn must not fail
+    // ---------------------------------------------------------------------
+
+    @Test
+    @DisplayName("#1282: the image turn really is stored as a multimodal message (the crash precondition)")
+    void imageTurn_isStoredInMemoryAsMultimodalUserMessage() throws IOException {
+        attachImage(TAB_ID, IMAGE_PATH);
+
+        sendPrompt(TAB_ID, "what is this image ?");
+
+        UserMessage stored = lastUserMessage(PROJECT_HASH + "-" + TAB_ID);
+        assertThat(stored.hasSingleText())
+                .as("MessageCreationService.addImages() turns the prompt into TextContent + ImageContent")
+                .isFalse();
+        assertThat(stored.contents()).anyMatch(ImageContent.class::isInstance);
+        assertThatCode(stored::singleText)
+                .as("this is exactly the call that used to blow up on every follow-up prompt")
+                .isInstanceOf(RuntimeException.class);
+    }
+
+    @Test
+    @DisplayName("#1282: the follow-up prompt after an image turn is built without failing")
+    void followUpPromptAfterImageTurn_doesNotFail() throws IOException {
+        attachImage(TAB_ID, IMAGE_PATH);
+        ChatMessageContext imageTurn = newContext(TAB_ID, "what is this image ?");
+        strategy.buildPrompt(imageTurn);
+        agentReplies(imageTurn, "I don't see any image attached.");
+
+        ChatMessageContext followUp = newContext(TAB_ID, "what i asked you ?");
+
+        assertThatCode(() -> strategy.buildPrompt(followUp))
+                .as("used to throw IllegalStateException: Expecting single text content, but got: ...")
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("#1282: history replay keeps the text of the image turn and marks the image")
+    void followUpPromptAfterImageTurn_replaysTextAndMarksTheImage() throws IOException {
+        attachImage(TAB_ID, IMAGE_PATH);
+        ChatMessageContext imageTurn = newContext(TAB_ID, "what is this image ?");
+        strategy.buildPrompt(imageTurn);
+        agentReplies(imageTurn, "I don't see any image attached.");
+
+        String prompt = sendPrompt(TAB_ID, "what i asked you ?");
+
+        assertThat(prompt)
+                .contains("<conversation_history>")
+                .contains("what is this image ?")
+                .contains("[image attached]")
+                .contains("[assistant]: I don't see any image attached.")
+                .endsWith("what i asked you ?");
+    }
+
+    @Test
+    @DisplayName("#1282: history replay never inlines the base64 image payload")
+    void followUpPromptAfterImageTurn_doesNotLeakBase64Payload() throws IOException {
+        attachImage(TAB_ID, IMAGE_PATH);
+        ChatMessageContext imageTurn = newContext(TAB_ID, "what is this image ?");
+        strategy.buildPrompt(imageTurn);
+        agentReplies(imageTurn, "I don't see any image attached.");
+
+        String prompt = sendPrompt(TAB_ID, "what i asked you ?");
+
+        assertThat(prompt)
+                .as("dumping base64 into a CLI argument would blow up the prompt size for no benefit")
+                .doesNotContain(PNG_BASE64);
+    }
+
+    @Test
+    @DisplayName("#1282 + #1280: the image path stays available on later turns, so the agent can re-read it")
+    void followUpTurns_stillCarryTheImagePath() throws IOException {
+        attachImage(TAB_ID, IMAGE_PATH);
+        ChatMessageContext imageTurn = newContext(TAB_ID, "what is this image ?");
+        strategy.buildPrompt(imageTurn);
+        agentReplies(imageTurn, "I don't see any image attached.");
+
+        String prompt = sendPrompt(TAB_ID, "what i asked you ?");
+
+        // Attachments are only cleared when a new conversation starts (ConversationManager),
+        // so the follow-up prompt repeats the path. That is what compensates for the history
+        // marker itself not carrying the path (issue #1282 asked for "[image attached: /path]").
+        assertThat(prompt).contains("<attached_images>").contains(IMAGE_PATH);
+    }
+
+    @Test
+    @DisplayName("text-only conversations get no image marker in their history")
+    void textOnlyConversation_hasNoImageMarker() {
+        ChatMessageContext first = newContext(TAB_ID, "first question");
+        strategy.buildPrompt(first);
+        agentReplies(first, "first answer");
+
+        String prompt = sendPrompt(TAB_ID, "second question");
+
+        assertThat(prompt)
+                .contains("first question")
+                .contains("[assistant]: first answer")
+                .doesNotContain("[image attached]");
+    }
+
+    // ---------------------------------------------------------------------
+    // Helpers
+    // ---------------------------------------------------------------------
+
+    private void attachImage(String tabId, String path) throws IOException {
+        VirtualFile imageFile = mock(VirtualFile.class);
+        when(imageFile.getName()).thenReturn("screenshot.png");
+        when(imageFile.getPath()).thenReturn(path);
+        when(imageFile.contentsToByteArray()).thenReturn(PNG_BYTES);
+        fileListManager.addFile(project, tabId, imageFile);
+    }
+
+    private @org.jetbrains.annotations.NotNull ChatMessageContext newContext(String tabId, String userPrompt) {
+        return ChatMessageContext.builder()
+                .project(project)
+                .tabId(tabId)
+                .userPrompt(userPrompt)
+                .languageModel(LanguageModel.builder()
+                        .provider(ModelProvider.CLIRunners)
+                        .modelName("Claude")
+                        .displayName("Claude")
+                        .build())
+                .build();
+    }
+
+    private String sendPrompt(String tabId, String userPrompt) {
+        return strategy.buildPrompt(newContext(tabId, userPrompt));
+    }
+
+    private void agentReplies(ChatMessageContext context, String reply) {
+        context.setAiMessage(AiMessage.from(reply));
+        chatMemoryManager.addAiResponse(context);
+    }
+
+    private UserMessage lastUserMessage(String memoryKey) {
+        List<ChatMessage> messages = chatMemoryService.getMessagesByKey(memoryKey);
+        for (int i = messages.size() - 1; i >= 0; i--) {
+            if (messages.get(i) instanceof UserMessage userMessage) {
+                return userMessage;
+            }
+        }
+        throw new AssertionError("No UserMessage found in memory for key " + memoryKey);
+    }
+
+    /** Stand-in for {@code CliPromptStrategy}/{@code AcpPromptStrategy}: same prompt assembly, no process. */
+    private static class TestRunnerStrategy extends AbstractPromptExecutionStrategy {
+
+        TestRunnerStrategy(Project project,
+                           ChatMemoryManager chatMemoryManager,
+                           ThreadPoolManager threadPoolManager,
+                           MessageCreationService messageCreationService) {
+            super(project, chatMemoryManager, threadPoolManager, messageCreationService);
+        }
+
+        String buildPrompt(ChatMessageContext context) {
+            return buildPromptWithHistory(context);
+        }
+
+        @Override
+        protected void executeStrategySpecific(ChatMessageContext context,
+                                               PromptOutputPanel panel,
+                                               PromptTask<PromptResult> resultTask) {
+            // not exercised: this test stops at prompt assembly
+        }
+
+        @Override
+        protected String getStrategyName() {
+            return "Test Runner";
+        }
+
+        @Override
+        public void cancel() {
+            // no-op
+        }
+    }
+}

--- a/src/test/java/com/devoxx/genie/service/prompt/strategy/AbstractPromptExecutionStrategyTest.java
+++ b/src/test/java/com/devoxx/genie/service/prompt/strategy/AbstractPromptExecutionStrategyTest.java
@@ -12,6 +12,8 @@ import com.intellij.openapi.project.Project;
 import com.intellij.openapi.vfs.VirtualFile;
 import dev.langchain4j.data.message.AiMessage;
 import dev.langchain4j.data.message.ChatMessage;
+import dev.langchain4j.data.message.ImageContent;
+import dev.langchain4j.data.message.TextContent;
 import dev.langchain4j.data.message.UserMessage;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -337,5 +339,60 @@ class AbstractPromptExecutionStrategyTest {
         assertThat(result)
             .doesNotContain("<attached_images>")
             .contains(userPrompt);
+    }
+    @Test
+    void buildPromptWithHistory_WithImageInHistory_DoesNotThrowAndKeepsText() {
+        // Given: an earlier turn that carried an image (multimodal UserMessage in memory) — issue #1282
+        String base64 = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==";
+        List<ChatMessage> history = new ArrayList<>();
+        history.add(UserMessage.from(TextContent.from("what is this image ?"), ImageContent.from(base64, "image/png")));
+        history.add(AiMessage.from("I don't see any image attached."));
+        history.add(UserMessage.from("what i asked you ?")); // current prompt
+        when(mockChatMemoryManager.getMessagesByKey(any())).thenReturn(history);
+
+        ChatMessageContext realContext = ChatMessageContext.builder()
+            .project(mockProject)
+            .tabId("tab-1")
+            .userPrompt("what i asked you ?")
+            .languageModel(LanguageModel.builder()
+                .provider(ModelProvider.CLIRunners)
+                .modelName("Claude")
+                .displayName("Claude")
+                .build())
+            .build();
+
+        // When
+        String result = testStrategy.testBuildPromptWithHistory(realContext);
+
+        // Then: no crash, the text survives, the image is represented by a marker, and the base64 is not leaked
+        assertThat(result)
+            .contains("[user]: what is this image ?")
+            .contains("[image attached]")
+            .contains("[assistant]: I don't see any image attached.")
+            .doesNotContain(base64)
+            .endsWith("what i asked you ?");
+    }
+
+    @Test
+    void buildPromptWithHistory_WithTextOnlyHistory_HasNoImageMarker() {
+        List<ChatMessage> history = new ArrayList<>();
+        history.add(UserMessage.from("first question"));
+        history.add(AiMessage.from("first answer"));
+        history.add(UserMessage.from("second question"));
+        when(mockChatMemoryManager.getMessagesByKey(any())).thenReturn(history);
+
+        ChatMessageContext realContext = ChatMessageContext.builder()
+            .project(mockProject)
+            .tabId("tab-1")
+            .userPrompt("second question")
+            .languageModel(LanguageModel.builder()
+                .provider(ModelProvider.CLIRunners).modelName("Claude").displayName("Claude").build())
+            .build();
+
+        String result = testStrategy.testBuildPromptWithHistory(realContext);
+
+        assertThat(result)
+            .contains("[user]: first question")
+            .doesNotContain("[image attached]");
     }
 }

--- a/src/test/java/com/devoxx/genie/service/prompt/strategy/AbstractPromptExecutionStrategyTest.java
+++ b/src/test/java/com/devoxx/genie/service/prompt/strategy/AbstractPromptExecutionStrategyTest.java
@@ -3,14 +3,17 @@ package com.devoxx.genie.service.prompt.strategy;
 import com.devoxx.genie.model.LanguageModel;
 import com.devoxx.genie.model.enumarations.ModelProvider;
 import com.devoxx.genie.model.request.ChatMessageContext;
+import com.devoxx.genie.service.FileListManager;
 import com.devoxx.genie.service.MessageCreationService;
 import com.devoxx.genie.service.prompt.memory.ChatMemoryManager;
 import com.devoxx.genie.service.prompt.threading.ThreadPoolManager;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.project.Project;
+import com.intellij.openapi.vfs.VirtualFile;
 import dev.langchain4j.data.message.AiMessage;
 import dev.langchain4j.data.message.ChatMessage;
 import dev.langchain4j.data.message.UserMessage;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -22,6 +25,7 @@ import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -45,6 +49,11 @@ class AbstractPromptExecutionStrategyTest {
     
     @Mock
     private ChatMessageContext mockChatMessageContext;
+
+    @Mock
+    private FileListManager mockFileListManager;
+
+    private MockedStatic<FileListManager> fileListManagerStaticMock;
     
     private TestPromptExecutionStrategy testStrategy;
 
@@ -52,6 +61,12 @@ class AbstractPromptExecutionStrategyTest {
     void setUp() {
         MockitoAnnotations.openMocks(this);
         mockStaticDependencies();
+
+        // buildPromptWithHistory() looks up attached images via FileListManager; default to none
+        fileListManagerStaticMock = mockStatic(FileListManager.class);
+        fileListManagerStaticMock.when(FileListManager::getInstance).thenReturn(mockFileListManager);
+        when(mockFileListManager.getImageFiles(any(Project.class), any())).thenReturn(Collections.emptyList());
+        when(mockFileListManager.getImageFiles(any(Project.class))).thenReturn(Collections.emptyList());
         
         // Use the constructor that bypasses ApplicationManager.getApplication()
         testStrategy = new TestPromptExecutionStrategy(
@@ -62,6 +77,13 @@ class AbstractPromptExecutionStrategyTest {
         );
     }
     
+    @AfterEach
+    void tearDown() {
+        if (fileListManagerStaticMock != null) {
+            fileListManagerStaticMock.close();
+        }
+    }
+
     private void mockStaticDependencies() {
         // Mock ApplicationManager first
         try (MockedStatic<ApplicationManager> applicationManagerMockedStatic = mockStatic(ApplicationManager.class)) {
@@ -247,6 +269,73 @@ class AbstractPromptExecutionStrategyTest {
             .contains("<attached_files>")
             .contains(filesContext)
             .contains("</attached_files>")
+            .contains(userPrompt);
+    }
+    @Test
+    void buildPromptWithHistory_ShouldIncludeImagePaths_WhenImagesAreAttached() {
+        // Given: an image attached to the conversation tab (images never land in filesContext,
+        // they live in ImageContent which CLI/ACP runners cannot transport)
+        String userPrompt = "what is this image ?";
+        String imagePath = "/Users/dev/Desktop/screenshot.png";
+
+        VirtualFile imageFile = mock(VirtualFile.class);
+        when(imageFile.getPath()).thenReturn(imagePath);
+        when(mockFileListManager.getImageFiles(mockProject, "tab-1")).thenReturn(List.of(imageFile));
+
+        ChatMessageContext realContext = ChatMessageContext.builder()
+            .project(mockProject)
+            .tabId("tab-1")
+            .userPrompt(userPrompt)
+            .filesContext(null)
+            .languageModel(LanguageModel.builder()
+                .provider(ModelProvider.CLIRunners)
+                .modelName("Claude")
+                .displayName("Claude")
+                .build())
+            .build();
+
+        List<ChatMessage> messages = new ArrayList<>();
+        messages.add(UserMessage.from(userPrompt));
+        when(mockChatMemoryManager.getMessages(mockProject)).thenReturn(messages);
+
+        // When
+        String result = testStrategy.testBuildPromptWithHistory(realContext);
+
+        // Then: the runner is told where the image lives so it can read it from disk
+        assertThat(result)
+            .as("Prompt should reference attached image paths for CLI/ACP runners")
+            .contains("<attached_images>")
+            .contains(imagePath)
+            .contains("</attached_images>")
+            .contains(userPrompt);
+        assertThat(result.indexOf("</attached_images>"))
+            .as("Image block should precede the user prompt")
+            .isLessThan(result.indexOf(userPrompt));
+    }
+
+    @Test
+    void buildPromptWithHistory_ShouldNotIncludeAttachedImagesTags_WhenNoImagesAttached() {
+        String userPrompt = "Hello";
+
+        ChatMessageContext realContext = ChatMessageContext.builder()
+            .project(mockProject)
+            .tabId("tab-1")
+            .userPrompt(userPrompt)
+            .languageModel(LanguageModel.builder()
+                .provider(ModelProvider.CLIRunners)
+                .modelName("Claude")
+                .displayName("Claude")
+                .build())
+            .build();
+
+        List<ChatMessage> messages = new ArrayList<>();
+        messages.add(UserMessage.from(userPrompt));
+        when(mockChatMemoryManager.getMessages(mockProject)).thenReturn(messages);
+
+        String result = testStrategy.testBuildPromptWithHistory(realContext);
+
+        assertThat(result)
+            .doesNotContain("<attached_images>")
             .contains(userPrompt);
     }
 }


### PR DESCRIPTION
Fixes #1280. Fixes #1282. Both live in the CLI/ACP Runner prompt-assembly path.

## The bugs

**#1280 — attached images silently dropped.** `MessageCreationService.addImages()` puts attachments into `ImageContent`, which CLI/ACP runners cannot transport (they only receive plain text). The request succeeded, so nothing surfaced in the UI — the agent just answered that no image was provided.

**#1282 — every follow-up prompt failed afterwards.** History replay called `UserMessage.singleText()`, which throws on the multimodal messages an image turn leaves in memory. Once an image had been attached, every later prompt in that conversation failed before the agent process even started, with `Expecting single text content`. Only a new conversation cleared it.

## The fix

- `buildPromptWithHistory()` now appends an `<attached_images>` block listing the on-disk paths of the tab's attachments, and tells the agent to read them. CLI/ACP agents have file-reading tools, so a path is all they need.
- New `historyTextOf(UserMessage)` renders a user message as plain text for replay: it joins the `TextContent` parts and represents each image as an `[image attached]` marker, instead of throwing — and without leaking the base64 payload into the prompt.

## Verification

Nine integration tests (`CliAcpImageAttachmentIntegrationTest`) wire the real `FileListManager`, `MessageCreationService`, `ChatMemoryManager` and `ChatMemoryService` together behind a mocked `ApplicationManager`, exercising the actual attach → multimodal `UserMessage` → chat memory → history replay chain rather than stubbing `getMessagesByKey()`.

Checked against a revert of both fix commits: **5 of the 9 fail**, and #1282 reproduces the reported error verbatim —

```
java.lang.RuntimeException: Expecting single text content, but got: [TextContent {...}, ImageContent {...}]
  at dev.langchain4j.data.message.UserMessage.singleText(UserMessage.java:152)
  at ...AbstractPromptExecutionStrategy.buildPromptWithHistory(AbstractPromptExecutionStrategy.java:250)
```

Full suite green: 3629 tests, 0 failures.

**Live run against real agents.** The prompts produced by the production code were fed to both CLIs the way `CliPromptStrategy` does, with a test PNG living *outside* the project (as in the report's `~/Desktop/shot.png`) containing a code obtainable only by opening the file:

- Claude CLI (`claude -p`, stdin) — read the image and reported the code and shape.
- Codex CLI (`codex exec --sandbox read-only`, prompt as trailing argv) — same, confirming an absolute path outside the workdir is still readable under a sandbox.

The follow-up turn then correctly recalled both the earlier question and the image contents, with no error.

## Notes for reviewers

- #1282 asked for the marker to carry the path (`[image attached: /path/shot.png]`); it currently renders as a bare `[image attached]`. Attachments persist until a new conversation starts, so every follow-up prompt re-carries the full path in a fresh `<attached_images>` block — the agent can still re-open the file. Happy to add the path to the marker if preferred.
- The test is plain JUnit 5 on purpose: the build runs `useJUnitPlatform()` with only the Jupiter engine, so JUnit 3/4 `LightPlatformTestCase` tests are never discovered — `PromptMessageFlowIntegrationTest` silently does not run today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
